### PR TITLE
[ai-assisted] feat(react-auth): finalize LoginPage for #10

### DIFF
--- a/src/react/pages/LoginPage.tsx
+++ b/src/react/pages/LoginPage.tsx
@@ -25,6 +25,7 @@ import axios from "axios";
 import { API_BASE_URL } from "@/config/backend";
 import { resolveAxiosError } from "@/utils/helpers";
 import { useAuthStore } from "@/react/auth/store";
+import { useToast } from "@/react/feedback";
 
 const loginSchema = yup.object({
   username: yup.string().required("아이디를 입력하세요"),
@@ -49,13 +50,12 @@ export function LoginPage() {
   const navigate = useNavigate();
   const token = useAuthStore((state) => state.token);
   const login = useAuthStore((state) => state.login);
+  const toast = useToast();
   const [submitting, setSubmitting] = useState(false);
   const [loginError, setLoginError] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [resetOpen, setResetOpen] = useState(false);
   const [resetSubmitting, setResetSubmitting] = useState(false);
-  const [resetError, setResetError] = useState("");
-  const [resetMessage, setResetMessage] = useState("");
 
   const returnUrl = useMemo(() => {
     const params = new URLSearchParams(location.search);
@@ -98,18 +98,17 @@ export function LoginPage() {
 
   const submitReset = resetForm.handleSubmit(async (values: ResetFormValues) => {
     setResetSubmitting(true);
-    setResetError("");
-    setResetMessage("");
     try {
       await axios.post(
         `${API_BASE_URL}/api/auth/password-reset/request`,
         { email: values.email },
         { withCredentials: true }
       );
-      setResetMessage("비밀번호 재설정 메일이 발송되었습니다.");
+      toast.success("비밀번호 재설정 메일이 발송되었습니다.");
       resetForm.reset();
+      setResetOpen(false);
     } catch (error) {
-      setResetError(resolveAxiosError(error));
+      toast.error(resolveAxiosError(error));
     } finally {
       setResetSubmitting(false);
     }
@@ -127,16 +126,8 @@ export function LoginPage() {
     >
       <Container maxWidth="sm">
         <Paper elevation={10} sx={{ p: { xs: 3, sm: 5 }, borderRadius: 3 }}>
-          <Typography variant="h4" textAlign="center" gutterBottom>
+          <Typography variant="h4" textAlign="center" sx={{ mb: 4 }}>
             Studio One Platform
-          </Typography>
-          <Typography
-            variant="body2"
-            textAlign="center"
-            color="text.secondary"
-            sx={{ mb: 4 }}
-          >
-            React bootstrap gate 기준 로그인 화면
           </Typography>
 
           <Box component="form" onSubmit={submitLogin} noValidate>
@@ -165,14 +156,19 @@ export function LoginPage() {
                     type={showPassword ? "text" : "password"}
                     error={!!loginForm.formState.errors.password}
                     helperText={loginForm.formState.errors.password?.message}
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <IconButton onClick={() => setShowPassword((value) => !value)}>
-                            {showPassword ? <VisibilityOff /> : <Visibility />}
-                          </IconButton>
-                        </InputAdornment>
-                      ),
+                    slotProps={{
+                      input: {
+                        endAdornment: (
+                          <InputAdornment position="end">
+                            <IconButton
+                              onClick={() => setShowPassword((v) => !v)}
+                              edge="end"
+                            >
+                              {showPassword ? <VisibilityOff /> : <Visibility />}
+                            </IconButton>
+                          </InputAdornment>
+                        ),
+                      },
                     }}
                   />
                 )}
@@ -202,7 +198,7 @@ export function LoginPage() {
       <Dialog open={resetOpen} onClose={() => setResetOpen(false)} fullWidth maxWidth="xs">
         <DialogTitle>비밀번호 재설정</DialogTitle>
         <DialogContent>
-          <Alert severity="info" variant="outlined" sx={{ mb: 2 }}>
+          <Alert severity="info" variant="outlined" sx={{ mb: 2, mt: 1 }}>
             입력하신 이메일로 비밀번호 재설정 링크를 전송합니다.
           </Alert>
           <Box component="form" id="password-reset-form" onSubmit={submitReset}>
@@ -213,7 +209,6 @@ export function LoginPage() {
                 <TextField
                   {...field}
                   fullWidth
-                  margin="normal"
                   label="이메일"
                   type="email"
                   error={!!resetForm.formState.errors.email}
@@ -222,8 +217,6 @@ export function LoginPage() {
               )}
             />
           </Box>
-          {resetMessage ? <Alert severity="success">{resetMessage}</Alert> : null}
-          {resetError ? <Alert severity="error">{resetError}</Alert> : null}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setResetOpen(false)} disabled={resetSubmitting}>


### PR DESCRIPTION
## Summary

Issue #10 — auth 페이지 React 셸 이관 완료.

- **stub 문구 제거**: 개발 메모 삭제
- **useToast 연결**: 비밀번호 재설정 성공/실패 피드백을 Toast로 교체. Vue PasswordResetDialog 동작과 동일
- **로컬 상태 정리**: `resetMessage`, `resetError` state 제거
- **MUI v7 대응**: 비권장 `InputProps` → `slotProps.input` 교체

## Acceptance Criteria

- [x] 로그인 화면이 React 셸에서 동작한다
- [x] 폼 검증과 에러 표시가 정상 동작한다
- [x] 로그인 성공 후 라우팅 흐름이 기대대로 동작한다

## 범위

- `src/react/pages/LoginPage.tsx` 단일 파일 수정 (+20 / -27)
- 기존 Vue auth 파일 미수정
- Register 페이지: Vue 원본이 영문 boilerplate 상태(프로덕션 미사용)이므로 이번 이슈 범위에서 제외

## Test plan

- [ ] `npm run build` 통과 확인
- [ ] `npm run lint` 통과 확인
- [ ] 로그인 성공 후 `/` 리다이렉트 확인
- [ ] 로그인 실패 시 폼 하단 에러 메시지 확인
- [ ] 비밀번호 재설정 성공 시 toast 표시 + 다이얼로그 자동 닫힘 확인
- [ ] 비밀번호 재설정 실패 시 toast.error 표시 확인
- [ ] 비밀번호 표시/숨김 아이콘 동작 확인

## Validation

- npm run build: passed
- npm run lint: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)