### PR TITLE
feat(react-track-ab): complete Track A and Track B pages

### DIFF
--- a/src/react/layouts/FullLayout.tsx
+++ b/src/react/layouts/FullLayout.tsx
@@ -4,11 +4,12 @@ import {
   Container,
   Typography,
 } from "@mui/material";
-import { Outlet } from "react-router-dom";
+import { Outlet, useNavigate } from "react-router-dom";
 import { AppShellHeader } from "@/react/layouts/AppShellHeader";
 import { useAuthStore } from "@/react/auth/store";
 
 export function FullLayout() {
+  const navigate = useNavigate();
   const user = useAuthStore((state) => state.user);
   const logoutEverywhere = useAuthStore((state) => state.logoutEverywhere);
 
@@ -18,6 +19,9 @@ export function FullLayout() {
                  Future enhancements will include sidebar/navigation components. */}
       <AppShellHeader>
         <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Button variant="text" size="small" onClick={() => navigate("/profile")}>
+            내 프로필
+          </Button>
           <Typography variant="body2" color="text.secondary">
             {user?.name ?? user?.username ?? "사용자"}
           </Typography>

--- a/src/react/pages/admin/GroupsPage.tsx
+++ b/src/react/pages/admin/GroupsPage.tsx
@@ -12,6 +12,7 @@ import {
 import {
   ChevronRight,
   DeleteOutlined,
+  GroupAddOutlined,
   GroupOutlined,
   RefreshOutlined,
   SearchOutlined,
@@ -21,6 +22,7 @@ import { PageableGridContent } from "@/react/components/ag-grid";
 import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
 import type { GroupDto } from "@/react/pages/admin/datasource";
 import { GroupsDataSource } from "@/react/pages/admin/datasource";
+import { GroupDialog } from "@/react/pages/admin/groups/GroupDialog";
 
 export function GroupsPage() {
   const navigate = useNavigate();
@@ -28,6 +30,7 @@ export function GroupsPage() {
   const dataSource = useMemo(() => new GroupsDataSource(), []);
   const [searchInput, setSearchInput] = useState("");
   const [searchError, setSearchError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
 
   const columnDefs = useMemo<ColDef<GroupDto>[]>(
     () => [
@@ -159,6 +162,13 @@ export function GroupsPage() {
         <Stack direction="row" spacing={1}>
           <Button
             variant="text"
+            startIcon={<GroupAddOutlined />}
+            onClick={() => setCreateOpen(true)}
+          >
+            그룹 생성
+          </Button>
+          <Button
+            variant="text"
             startIcon={<RefreshOutlined />}
             onClick={handleRefresh}
           >
@@ -194,6 +204,11 @@ export function GroupsPage() {
         ref={gridRef}
         datasource={dataSource}
         columns={columnDefs}
+      />
+      <GroupDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => gridRef.current?.refresh()}
       />
     </Stack>
   );

--- a/src/react/pages/admin/RolesPage.tsx
+++ b/src/react/pages/admin/RolesPage.tsx
@@ -15,6 +15,7 @@ import {
   GroupOutlined,
   PersonOutlined,
   RefreshOutlined,
+  AddOutlined,
   SearchOutlined,
 } from "@mui/icons-material";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
@@ -22,6 +23,7 @@ import { PageableGridContent } from "@/react/components/ag-grid";
 import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
 import type { RoleDto } from "@/react/pages/admin/datasource";
 import { RolesDataSource } from "@/react/pages/admin/datasource";
+import { RoleDialog } from "@/react/pages/admin/roles/RoleDialog";
 
 export function RolesPage() {
   const navigate = useNavigate();
@@ -29,6 +31,7 @@ export function RolesPage() {
   const dataSource = useMemo(() => new RolesDataSource(), []);
   const [searchInput, setSearchInput] = useState("");
   const [searchError, setSearchError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
 
   const columnDefs = useMemo<ColDef<RoleDto>[]>(
     () => [
@@ -163,6 +166,13 @@ export function RolesPage() {
         <Stack direction="row" spacing={1}>
           <Button
             variant="text"
+            startIcon={<AddOutlined />}
+            onClick={() => setCreateOpen(true)}
+          >
+            역할 생성
+          </Button>
+          <Button
+            variant="text"
             startIcon={<RefreshOutlined />}
             onClick={handleRefresh}
           >
@@ -198,6 +208,11 @@ export function RolesPage() {
         ref={gridRef}
         datasource={dataSource}
         columns={columnDefs}
+      />
+      <RoleDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => gridRef.current?.refresh()}
       />
     </Stack>
   );

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -1,0 +1,42 @@
+import { useMemo, useRef } from "react";
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from "@mui/material";
+import type { ColDef, ICellRendererParams } from "ag-grid-community";
+import { PageableGridContent } from "@/react/components/ag-grid";
+import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
+import { UsersDataSource } from "@/react/pages/admin/datasource";
+import type { UserDto } from "@/types/studio/user";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (user: UserDto) => void;
+}
+
+export function UserSearchDialog({ open, onClose, onSelect }: Props) {
+  const gridRef = useRef<PageableGridContentHandle<UserDto>>(null);
+  const dataSource = useMemo(() => new UsersDataSource(), []);
+
+  const columnDefs = useMemo<ColDef<UserDto>[]>(() => [
+    { field: "username", headerName: "아이디", flex: 1 },
+    { field: "name", headerName: "이름", flex: 1 },
+    { field: "email", headerName: "이메일", flex: 1.5 },
+    {
+      colId: "select", headerName: "", flex: 0.5,
+      cellRenderer: (params: ICellRendererParams<UserDto>) => (
+        <Button size="small" onClick={() => { onSelect(params.data!); onClose(); }}>선택</Button>
+      ),
+    },
+  ], [onClose, onSelect]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>사용자 검색</DialogTitle>
+      <DialogContent sx={{ height: 400 }}>
+        <PageableGridContent<UserDto> ref={gridRef} datasource={dataSource} columns={columnDefs} />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/admin/groups/GroupDetailPage.tsx
+++ b/src/react/pages/admin/groups/GroupDetailPage.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Box, Stack, Breadcrumbs, Typography, Button, TextField, Divider, CircularProgress, Alert,
+} from "@mui/material";
+import { ArrowBackOutlined, SaveOutlined, GroupAddOutlined, ManageAccountsOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactGroupsApi } from "./api";
+import { GroupMembershipDialog } from "./GroupMembershipDialog";
+import { GroupRolesDialog } from "./GroupRolesDialog";
+import type { GroupDto } from "@/react/pages/admin/datasource";
+
+export function GroupDetailPage() {
+  const { groupId } = useParams<{ groupId: string }>();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [group, setGroup] = useState<GroupDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [membersOpen, setMembersOpen] = useState(false);
+  const [rolesOpen, setRolesOpen] = useState(false);
+  const [form, setForm] = useState({ name: "", description: "" });
+
+  useEffect(() => {
+    if (!groupId) return;
+    setLoading(true);
+    reactGroupsApi.getGroup(Number(groupId))
+      .then(g => { setGroup(g); setForm({ name: g.name, description: g.description ?? "" }); setError(null); })
+      .catch(() => setError("그룹을 불러오지 못했습니다."))
+      .finally(() => setLoading(false));
+  }, [groupId]);
+
+  async function handleSave() {
+    if (!groupId) return;
+    setSaving(true);
+    try {
+      await reactGroupsApi.updateGroup(Number(groupId), form);
+      toast.success("저장되었습니다.");
+    } catch {
+      toast.error("저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) return <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}><CircularProgress /></Box>;
+  if (error) return <Alert severity="error">{error}</Alert>;
+  if (!group) return null;
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">시스템관리</Typography>
+        <Typography color="text.secondary" sx={{ cursor: "pointer" }} onClick={() => navigate("/admin/groups")}>그룹</Typography>
+        <Typography color="text.primary">{group.name}</Typography>
+      </Breadcrumbs>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">그룹 상세</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button startIcon={<GroupAddOutlined />} onClick={() => setMembersOpen(true)}>멤버 관리</Button>
+          <Button startIcon={<ManageAccountsOutlined />} onClick={() => setRolesOpen(true)}>역할 관리</Button>
+          <Button variant="outlined" startIcon={<ArrowBackOutlined />} onClick={() => navigate("/admin/groups")}>목록</Button>
+          <Button variant="contained" startIcon={<SaveOutlined />} onClick={handleSave} disabled={saving}>
+            {saving ? <CircularProgress size={20} /> : "저장"}
+          </Button>
+        </Stack>
+      </Box>
+      <Divider />
+      <Stack spacing={2} sx={{ maxWidth: 600 }}>
+        <TextField label="그룹명" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} size="small" />
+        <TextField label="설명" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} size="small" multiline rows={2} />
+      </Stack>
+      <GroupMembershipDialog open={membersOpen} onClose={() => setMembersOpen(false)} groupId={group.groupId} groupName={group.name} />
+      <GroupRolesDialog open={rolesOpen} onClose={() => setRolesOpen(false)} groupId={group.groupId} groupName={group.name} />
+    </Stack>
+  );
+}

--- a/src/react/pages/admin/groups/GroupDialog.tsx
+++ b/src/react/pages/admin/groups/GroupDialog.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Button, TextField, Stack, CircularProgress,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import { reactGroupsApi } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function GroupDialog({ open, onClose, onCreated }: Props) {
+  const toast = useToast();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleCreate() {
+    if (!name.trim()) return;
+    setLoading(true);
+    try {
+      await reactGroupsApi.createGroup({ name: name.trim(), description: description.trim() || undefined });
+      toast.success("그룹이 생성되었습니다.");
+      setName(""); setDescription("");
+      onCreated(); onClose();
+    } catch {
+      toast.error("그룹 생성에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>그룹 생성</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField label="그룹명" size="small" fullWidth value={name} onChange={e => setName(e.target.value)} />
+          <TextField label="설명" size="small" fullWidth multiline rows={2} value={description} onChange={e => setDescription(e.target.value)} />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>취소</Button>
+        <Button variant="contained" onClick={handleCreate} disabled={loading || !name.trim()}>
+          {loading ? <CircularProgress size={20} /> : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/admin/groups/GroupMembershipDialog.tsx
+++ b/src/react/pages/admin/groups/GroupMembershipDialog.tsx
@@ -1,0 +1,87 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Button, List, ListItem, ListItemText, IconButton, Stack, CircularProgress, Typography,
+} from "@mui/material";
+import { DeleteOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactGroupsApi, type GroupMemberDto } from "./api";
+import { UserSearchDialog } from "@/react/pages/admin/UserSearchDialog";
+import type { UserDto } from "@/types/studio/user";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  groupId: number;
+  groupName: string;
+}
+
+export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Props) {
+  const toast = useToast();
+  const [members, setMembers] = useState<GroupMemberDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [userSearchOpen, setUserSearchOpen] = useState(false);
+
+  async function loadMembers() {
+    setLoading(true);
+    try {
+      const data = await reactGroupsApi.getMembers(groupId);
+      setMembers(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error("멤버 목록 로딩 실패");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { if (open) loadMembers(); }, [open, groupId]);
+
+  async function handleAdd(user: UserDto) {
+    try {
+      await reactGroupsApi.addMember(groupId, user.userId);
+      toast.success("멤버가 추가되었습니다.");
+      loadMembers();
+    } catch {
+      toast.error("멤버 추가에 실패했습니다.");
+    }
+  }
+
+  async function handleRemove(userId: number) {
+    try {
+      await reactGroupsApi.removeMember(groupId, userId);
+      toast.success("멤버가 제거되었습니다.");
+      loadMembers();
+    } catch {
+      toast.error("멤버 제거에 실패했습니다.");
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+        <DialogTitle>멤버 관리 — {groupName}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={1} sx={{ mt: 1 }}>
+            <Button variant="outlined" size="small" onClick={() => setUserSearchOpen(true)} sx={{ alignSelf: "flex-start" }}>멤버 추가</Button>
+            {loading ? <CircularProgress size={24} /> : (
+              <List dense>
+                {members.length === 0 && <Typography color="text.secondary" variant="body2">멤버 없음</Typography>}
+                {members.map(m => (
+                  <ListItem key={m.userId} secondaryAction={
+                    <IconButton size="small" color="error" onClick={() => handleRemove(m.userId)}><DeleteOutlined fontSize="small" /></IconButton>
+                  }>
+                    <ListItemText primary={m.name} secondary={`@${m.username}`} />
+                  </ListItem>
+                ))}
+              </List>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>닫기</Button>
+        </DialogActions>
+      </Dialog>
+      <UserSearchDialog open={userSearchOpen} onClose={() => setUserSearchOpen(false)} onSelect={handleAdd} />
+    </>
+  );
+}

--- a/src/react/pages/admin/groups/GroupRolesDialog.tsx
+++ b/src/react/pages/admin/groups/GroupRolesDialog.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Button, List, ListItem, ListItemText, IconButton, Stack, TextField, CircularProgress, Typography, Divider,
+} from "@mui/material";
+import { DeleteOutlined, AddOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactGroupsApi } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  groupId: number;
+  groupName: string;
+}
+
+export function GroupRolesDialog({ open, onClose, groupId, groupName }: Props) {
+  const toast = useToast();
+  const [roles, setRoles] = useState<{ roleId: number; name: string }[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [roleIdInput, setRoleIdInput] = useState("");
+
+  async function loadRoles() {
+    setLoading(true);
+    try {
+      const data = await reactGroupsApi.getGroupRoles(groupId);
+      setRoles(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error("역할 목록 로딩 실패");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { if (open) { setRoleIdInput(""); loadRoles(); } }, [open, groupId]);
+
+  async function handleAdd() {
+    const roleId = parseInt(roleIdInput, 10);
+    if (!roleId) return;
+    try {
+      await reactGroupsApi.addGroupRole(groupId, roleId);
+      toast.success("역할이 부여되었습니다.");
+      setRoleIdInput(""); loadRoles();
+    } catch {
+      toast.error("역할 부여에 실패했습니다.");
+    }
+  }
+
+  async function handleRemove(roleId: number) {
+    try {
+      await reactGroupsApi.removeGroupRole(groupId, roleId);
+      toast.success("역할이 제거되었습니다.");
+      loadRoles();
+    } catch {
+      toast.error("역할 제거에 실패했습니다.");
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>역할 관리 — {groupName}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={1} sx={{ mt: 1 }}>
+          <Stack direction="row" spacing={1}>
+            <TextField label="역할 ID" size="small" value={roleIdInput}
+              onChange={e => setRoleIdInput(e.target.value)}
+              onKeyDown={e => e.key === "Enter" && handleAdd()} />
+            <Button startIcon={<AddOutlined />} variant="outlined" onClick={handleAdd} disabled={!roleIdInput}>추가</Button>
+          </Stack>
+          <Divider />
+          {loading ? <CircularProgress size={24} /> : (
+            <List dense>
+              {roles.length === 0 && <Typography color="text.secondary" variant="body2">부여된 역할 없음</Typography>}
+              {roles.map(r => (
+                <ListItem key={r.roleId} secondaryAction={
+                  <IconButton size="small" color="error" onClick={() => handleRemove(r.roleId)}><DeleteOutlined fontSize="small" /></IconButton>
+                }>
+                  <ListItemText primary={r.name} secondary={`ID: ${r.roleId}`} />
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/admin/groups/api.ts
+++ b/src/react/pages/admin/groups/api.ts
@@ -1,6 +1,5 @@
 import { apiRequest } from "@/react/query/fetcher";
 import type { GroupDto } from "@/react/pages/admin/datasource";
-import type { UserDto } from "@/types/studio/user";
 
 export interface GroupMemberDto { userId: number; username: string; name: string; role?: string; joinedAt?: string; }
 

--- a/src/react/pages/admin/groups/api.ts
+++ b/src/react/pages/admin/groups/api.ts
@@ -1,0 +1,26 @@
+import { apiRequest } from "@/react/query/fetcher";
+import type { GroupDto } from "@/react/pages/admin/datasource";
+import type { UserDto } from "@/types/studio/user";
+
+export interface GroupMemberDto { userId: number; username: string; name: string; role?: string; joinedAt?: string; }
+
+export const reactGroupsApi = {
+  getGroup: (groupId: number) =>
+    apiRequest<GroupDto>("get", `/api/mgmt/groups/${groupId}`),
+  updateGroup: (groupId: number, payload: Partial<GroupDto>) =>
+    apiRequest<GroupDto>("put", `/api/mgmt/groups/${groupId}`, { data: payload }),
+  createGroup: (payload: { name: string; description?: string }) =>
+    apiRequest<GroupDto>("post", "/api/mgmt/groups", { data: payload }),
+  getMembers: (groupId: number) =>
+    apiRequest<GroupMemberDto[]>("get", `/api/mgmt/groups/${groupId}/members`),
+  addMember: (groupId: number, userId: number) =>
+    apiRequest<void>("post", `/api/mgmt/groups/${groupId}/members`, { data: { userId } }),
+  removeMember: (groupId: number, userId: number) =>
+    apiRequest<void>("delete", `/api/mgmt/groups/${groupId}/members/${userId}`),
+  getGroupRoles: (groupId: number) =>
+    apiRequest<{ roleId: number; name: string }[]>("get", `/api/mgmt/groups/${groupId}/roles`),
+  addGroupRole: (groupId: number, roleId: number) =>
+    apiRequest<void>("post", `/api/mgmt/groups/${groupId}/roles`, { data: { roleId } }),
+  removeGroupRole: (groupId: number, roleId: number) =>
+    apiRequest<void>("delete", `/api/mgmt/groups/${groupId}/roles/${roleId}`),
+};

--- a/src/react/pages/admin/groups/queryKeys.ts
+++ b/src/react/pages/admin/groups/queryKeys.ts
@@ -1,0 +1,2 @@
+import { createQueryKeys } from "@/react/query/keys";
+export const groupsQueryKeys = createQueryKeys("admin-groups");

--- a/src/react/pages/admin/roles/RoleDetailPage.tsx
+++ b/src/react/pages/admin/roles/RoleDetailPage.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Box, Stack, Breadcrumbs, Typography, Button, TextField, Divider, CircularProgress, Alert,
+} from "@mui/material";
+import { ArrowBackOutlined, SaveOutlined, PersonAddOutlined, GroupAddOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactRolesApi } from "./api";
+import { RoleGrantedUsersDialog } from "./RoleGrantedUsersDialog";
+import { RoleGrantedGroupsDialog } from "./RoleGrantedGroupsDialog";
+import type { RoleDto } from "@/react/pages/admin/datasource";
+
+export function RoleDetailPage() {
+  const { roleId } = useParams<{ roleId: string }>();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [role, setRole] = useState<RoleDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [usersOpen, setUsersOpen] = useState(false);
+  const [groupsOpen, setGroupsOpen] = useState(false);
+  const [form, setForm] = useState({ name: "", description: "" });
+
+  useEffect(() => {
+    if (!roleId) return;
+    setLoading(true);
+    reactRolesApi.getRole(Number(roleId))
+      .then(r => { setRole(r); setForm({ name: r.name, description: r.description ?? "" }); setError(null); })
+      .catch(() => setError("역할을 불러오지 못했습니다."))
+      .finally(() => setLoading(false));
+  }, [roleId]);
+
+  async function handleSave() {
+    if (!roleId) return;
+    setSaving(true);
+    try {
+      await reactRolesApi.updateRole(Number(roleId), form);
+      toast.success("저장되었습니다.");
+    } catch {
+      toast.error("저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) return <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}><CircularProgress /></Box>;
+  if (error) return <Alert severity="error">{error}</Alert>;
+  if (!role) return null;
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">시스템관리</Typography>
+        <Typography color="text.secondary" sx={{ cursor: "pointer" }} onClick={() => navigate("/admin/roles")}>역할</Typography>
+        <Typography color="text.primary">{role.name}</Typography>
+      </Breadcrumbs>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">역할 상세</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button startIcon={<PersonAddOutlined />} onClick={() => setUsersOpen(true)}>사용자 관리</Button>
+          <Button startIcon={<GroupAddOutlined />} onClick={() => setGroupsOpen(true)}>그룹 관리</Button>
+          <Button variant="outlined" startIcon={<ArrowBackOutlined />} onClick={() => navigate("/admin/roles")}>목록</Button>
+          <Button variant="contained" startIcon={<SaveOutlined />} onClick={handleSave} disabled={saving}>
+            {saving ? <CircularProgress size={20} /> : "저장"}
+          </Button>
+        </Stack>
+      </Box>
+      <Divider />
+      <Stack spacing={2} sx={{ maxWidth: 600 }}>
+        <TextField label="역할명" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} size="small" />
+        <TextField label="설명" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} size="small" multiline rows={2} />
+      </Stack>
+      <RoleGrantedUsersDialog open={usersOpen} onClose={() => setUsersOpen(false)} roleId={role.roleId} roleName={role.name} />
+      <RoleGrantedGroupsDialog open={groupsOpen} onClose={() => setGroupsOpen(false)} roleId={role.roleId} roleName={role.name} />
+    </Stack>
+  );
+}

--- a/src/react/pages/admin/roles/RoleDialog.tsx
+++ b/src/react/pages/admin/roles/RoleDialog.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Button, TextField, Stack, CircularProgress,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import { reactRolesApi } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function RoleDialog({ open, onClose, onCreated }: Props) {
+  const toast = useToast();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleCreate() {
+    if (!name.trim()) return;
+    setLoading(true);
+    try {
+      await reactRolesApi.createRole({ name: name.trim(), description: description.trim() || undefined });
+      toast.success("역할이 생성되었습니다.");
+      setName(""); setDescription("");
+      onCreated(); onClose();
+    } catch {
+      toast.error("역할 생성에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>역할 생성</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField label="역할명" size="small" fullWidth value={name} onChange={e => setName(e.target.value)} />
+          <TextField label="설명" size="small" fullWidth multiline rows={2} value={description} onChange={e => setDescription(e.target.value)} />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>취소</Button>
+        <Button variant="contained" onClick={handleCreate} disabled={loading || !name.trim()}>
+          {loading ? <CircularProgress size={20} /> : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/admin/roles/RoleGrantedGroupsDialog.tsx
+++ b/src/react/pages/admin/roles/RoleGrantedGroupsDialog.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Button, List, ListItem, ListItemText, IconButton, Stack, TextField, CircularProgress, Typography, Divider,
+} from "@mui/material";
+import { DeleteOutlined, AddOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactRolesApi } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  roleId: number;
+  roleName: string;
+}
+
+export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Props) {
+  const toast = useToast();
+  const [groups, setGroups] = useState<{ groupId: number; name: string }[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [groupIdInput, setGroupIdInput] = useState("");
+
+  async function loadGroups() {
+    setLoading(true);
+    try {
+      const data = await reactRolesApi.getGrantedGroups(roleId);
+      setGroups(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error("그룹 목록 로딩 실패");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { if (open) { setGroupIdInput(""); loadGroups(); } }, [open, roleId]);
+
+  async function handleAdd() {
+    const groupId = parseInt(groupIdInput, 10);
+    if (!groupId) return;
+    try {
+      await reactRolesApi.addGroup(roleId, groupId);
+      toast.success("그룹이 부여되었습니다.");
+      setGroupIdInput(""); loadGroups();
+    } catch {
+      toast.error("그룹 부여에 실패했습니다.");
+    }
+  }
+
+  async function handleRemove(groupId: number) {
+    try {
+      await reactRolesApi.removeGroup(roleId, groupId);
+      toast.success("그룹이 제거되었습니다.");
+      loadGroups();
+    } catch {
+      toast.error("그룹 제거에 실패했습니다.");
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>그룹 부여 — {roleName}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={1} sx={{ mt: 1 }}>
+          <Stack direction="row" spacing={1}>
+            <TextField label="그룹 ID" size="small" value={groupIdInput}
+              onChange={e => setGroupIdInput(e.target.value)}
+              onKeyDown={e => e.key === "Enter" && handleAdd()} />
+            <Button startIcon={<AddOutlined />} variant="outlined" onClick={handleAdd} disabled={!groupIdInput}>추가</Button>
+          </Stack>
+          <Divider />
+          {loading ? <CircularProgress size={24} /> : (
+            <List dense>
+              {groups.length === 0 && <Typography color="text.secondary" variant="body2">부여된 그룹 없음</Typography>}
+              {groups.map(g => (
+                <ListItem key={g.groupId} secondaryAction={
+                  <IconButton size="small" color="error" onClick={() => handleRemove(g.groupId)}><DeleteOutlined fontSize="small" /></IconButton>
+                }>
+                  <ListItemText primary={g.name} secondary={`ID: ${g.groupId}`} />
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/admin/roles/RoleGrantedUsersDialog.tsx
+++ b/src/react/pages/admin/roles/RoleGrantedUsersDialog.tsx
@@ -1,0 +1,87 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Button, List, ListItem, ListItemText, IconButton, Stack, CircularProgress, Typography,
+} from "@mui/material";
+import { DeleteOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactRolesApi } from "./api";
+import { UserSearchDialog } from "@/react/pages/admin/UserSearchDialog";
+import type { UserDto } from "@/types/studio/user";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  roleId: number;
+  roleName: string;
+}
+
+export function RoleGrantedUsersDialog({ open, onClose, roleId, roleName }: Props) {
+  const toast = useToast();
+  const [users, setUsers] = useState<UserDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [userSearchOpen, setUserSearchOpen] = useState(false);
+
+  async function loadUsers() {
+    setLoading(true);
+    try {
+      const data = await reactRolesApi.getGrantedUsers(roleId);
+      setUsers(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error("사용자 목록 로딩 실패");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { if (open) loadUsers(); }, [open, roleId]);
+
+  async function handleAdd(user: UserDto) {
+    try {
+      await reactRolesApi.addUser(roleId, user.userId);
+      toast.success("사용자가 부여되었습니다.");
+      loadUsers();
+    } catch {
+      toast.error("사용자 부여에 실패했습니다.");
+    }
+  }
+
+  async function handleRemove(userId: number) {
+    try {
+      await reactRolesApi.removeUser(roleId, userId);
+      toast.success("사용자가 제거되었습니다.");
+      loadUsers();
+    } catch {
+      toast.error("사용자 제거에 실패했습니다.");
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+        <DialogTitle>사용자 부여 — {roleName}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={1} sx={{ mt: 1 }}>
+            <Button variant="outlined" size="small" onClick={() => setUserSearchOpen(true)} sx={{ alignSelf: "flex-start" }}>사용자 추가</Button>
+            {loading ? <CircularProgress size={24} /> : (
+              <List dense>
+                {users.length === 0 && <Typography color="text.secondary" variant="body2">부여된 사용자 없음</Typography>}
+                {users.map(u => (
+                  <ListItem key={u.userId} secondaryAction={
+                    <IconButton size="small" color="error" onClick={() => handleRemove(u.userId)}><DeleteOutlined fontSize="small" /></IconButton>
+                  }>
+                    <ListItemText primary={u.name} secondary={`@${u.username}`} />
+                  </ListItem>
+                ))}
+              </List>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>닫기</Button>
+        </DialogActions>
+      </Dialog>
+      <UserSearchDialog open={userSearchOpen} onClose={() => setUserSearchOpen(false)} onSelect={handleAdd} />
+    </>
+  );
+}

--- a/src/react/pages/admin/roles/api.ts
+++ b/src/react/pages/admin/roles/api.ts
@@ -1,0 +1,24 @@
+import { apiRequest } from "@/react/query/fetcher";
+import type { RoleDto } from "@/react/pages/admin/datasource";
+import type { UserDto } from "@/types/studio/user";
+
+export const reactRolesApi = {
+  getRole: (roleId: number) =>
+    apiRequest<RoleDto>("get", `/api/mgmt/roles/${roleId}`),
+  updateRole: (roleId: number, payload: Partial<RoleDto>) =>
+    apiRequest<RoleDto>("put", `/api/mgmt/roles/${roleId}`, { data: payload }),
+  createRole: (payload: { name: string; description?: string }) =>
+    apiRequest<RoleDto>("post", "/api/mgmt/roles", { data: payload }),
+  getGrantedUsers: (roleId: number) =>
+    apiRequest<UserDto[]>("get", `/api/mgmt/roles/${roleId}/users`),
+  addUser: (roleId: number, userId: number) =>
+    apiRequest<void>("post", `/api/mgmt/roles/${roleId}/users`, { data: { userId } }),
+  removeUser: (roleId: number, userId: number) =>
+    apiRequest<void>("delete", `/api/mgmt/roles/${roleId}/users/${userId}`),
+  getGrantedGroups: (roleId: number) =>
+    apiRequest<{ groupId: number; name: string }[]>("get", `/api/mgmt/roles/${roleId}/groups`),
+  addGroup: (roleId: number, groupId: number) =>
+    apiRequest<void>("post", `/api/mgmt/roles/${roleId}/groups`, { data: { groupId } }),
+  removeGroup: (roleId: number, groupId: number) =>
+    apiRequest<void>("delete", `/api/mgmt/roles/${roleId}/groups/${groupId}`),
+};

--- a/src/react/pages/admin/roles/queryKeys.ts
+++ b/src/react/pages/admin/roles/queryKeys.ts
@@ -1,0 +1,2 @@
+import { createQueryKeys } from "@/react/query/keys";
+export const rolesQueryKeys = createQueryKeys("admin-roles");

--- a/src/react/pages/admin/users/PasswordResetDialog.tsx
+++ b/src/react/pages/admin/users/PasswordResetDialog.tsx
@@ -1,0 +1,100 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Button, TextField, Stack, Typography, List, ListItem, ListItemIcon, ListItemText,
+  CircularProgress,
+} from "@mui/material";
+import { CheckCircleOutline, RadioButtonUnchecked } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactUsersApi } from "./api";
+import type { PasswordPolicyDto } from "@/types/studio/user";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  userId: number;
+  username: string;
+}
+
+export function PasswordResetDialog({ open, onClose, userId, username }: Props) {
+  const toast = useToast();
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [policy, setPolicy] = useState<PasswordPolicyDto | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setNewPassword("");
+      setConfirmPassword("");
+      reactUsersApi.getPasswordPolicy().then(setPolicy).catch(() => setPolicy(null));
+    }
+  }, [open]);
+
+  function checkRule(label: string, met: boolean) {
+    return (
+      <ListItem dense disableGutters key={label}>
+        <ListItemIcon sx={{ minWidth: 28 }}>
+          {met ? <CheckCircleOutline fontSize="small" color="success" /> : <RadioButtonUnchecked fontSize="small" color="disabled" />}
+        </ListItemIcon>
+        <ListItemText primary={label} />
+      </ListItem>
+    );
+  }
+
+  function policyRules() {
+    if (!policy) return null;
+    const pw = newPassword;
+    return [
+      checkRule(`최소 ${policy.minLength}자 이상`, pw.length >= policy.minLength),
+      policy.maxLength ? checkRule(`최대 ${policy.maxLength}자 이하`, pw.length <= policy.maxLength) : null,
+      policy.requireUpper ? checkRule("대문자 포함", /[A-Z]/.test(pw)) : null,
+      policy.requireLower ? checkRule("소문자 포함", /[a-z]/.test(pw)) : null,
+      policy.requireDigit ? checkRule("숫자 포함", /[0-9]/.test(pw)) : null,
+      policy.requireSpecial ? checkRule("특수문자 포함", /[^a-zA-Z0-9]/.test(pw)) : null,
+    ].filter(Boolean);
+  }
+
+  async function handleSubmit() {
+    if (newPassword !== confirmPassword) {
+      toast.error("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+    setLoading(true);
+    try {
+      await reactUsersApi.resetPassword(userId, newPassword);
+      toast.success("비밀번호가 재설정되었습니다.");
+      onClose();
+    } catch {
+      toast.error("비밀번호 재설정에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>비밀번호 재설정 — {username}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField label="새 비밀번호" type="password" fullWidth size="small"
+            value={newPassword} onChange={e => setNewPassword(e.target.value)} />
+          <TextField label="비밀번호 확인" type="password" fullWidth size="small"
+            value={confirmPassword} onChange={e => setConfirmPassword(e.target.value)} />
+          {policy && (
+            <>
+              <Typography variant="caption" color="text.secondary">비밀번호 정책</Typography>
+              <List dense>{policyRules()}</List>
+            </>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>취소</Button>
+        <Button variant="contained" onClick={handleSubmit} disabled={loading || !newPassword}>
+          {loading ? <CircularProgress size={20} /> : "재설정"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/admin/users/PasswordResetDialog.tsx
+++ b/src/react/pages/admin/users/PasswordResetDialog.tsx
@@ -62,6 +62,9 @@ export function PasswordResetDialog({ open, onClose, userId, username }: Props) 
     }
     setLoading(true);
     try {
+      // The mgmt endpoint currently shares ResetPasswordRequest.
+      // Admin-triggered resets do not have the user's current password,
+      // so we send an empty value until the backend exposes a dedicated DTO.
       await reactUsersApi.resetPassword(userId, {
         currentPassword: "",
         newPassword,

--- a/src/react/pages/admin/users/PasswordResetDialog.tsx
+++ b/src/react/pages/admin/users/PasswordResetDialog.tsx
@@ -62,7 +62,10 @@ export function PasswordResetDialog({ open, onClose, userId, username }: Props) 
     }
     setLoading(true);
     try {
-      await reactUsersApi.resetPassword(userId, newPassword);
+      await reactUsersApi.resetPassword(userId, {
+        currentPassword: "",
+        newPassword,
+      });
       toast.success("비밀번호가 재설정되었습니다.");
       onClose();
     } catch {

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Box, Stack, Breadcrumbs, Typography, Button, TextField,
+  FormControlLabel, Switch, Divider, CircularProgress, Alert,
+} from "@mui/material";
+import { KeyOutlined, ManageAccountsOutlined, ArrowBackOutlined, SaveOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactUsersApi } from "./api";
+import { UserRolesDialog } from "./UserRolesDialog";
+import { PasswordResetDialog } from "./PasswordResetDialog";
+import type { UserDto } from "@/types/studio/user";
+
+export function UserDetailPage() {
+  const { userId } = useParams<{ userId: string }>();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [user, setUser] = useState<UserDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [rolesOpen, setRolesOpen] = useState(false);
+  const [resetOpen, setResetOpen] = useState(false);
+  const [form, setForm] = useState({ name: "", email: "", emailVisble: true, nameVisible: true, enabled: true });
+
+  useEffect(() => {
+    if (!userId) return;
+    setLoading(true);
+    reactUsersApi.getUser(Number(userId))
+      .then(u => { setUser(u); setForm({ name: u.name, email: u.email ?? "", emailVisble: u.emailVisble, nameVisible: u.nameVisible, enabled: u.enabled }); setError(null); })
+      .catch(() => setError("사용자를 불러오지 못했습니다."))
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  async function handleSave() {
+    if (!userId) return;
+    setSaving(true);
+    try {
+      await reactUsersApi.updateUser(Number(userId), form);
+      toast.success("저장되었습니다.");
+    } catch {
+      toast.error("저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) return <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}><CircularProgress /></Box>;
+  if (error) return <Alert severity="error">{error}</Alert>;
+  if (!user) return null;
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">시스템관리</Typography>
+        <Typography color="text.secondary" sx={{ cursor: "pointer" }} onClick={() => navigate("/admin/users")}>회원</Typography>
+        <Typography color="text.primary">{user.username}</Typography>
+      </Breadcrumbs>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">회원 상세</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button startIcon={<ManageAccountsOutlined />} onClick={() => setRolesOpen(true)}>역할 관리</Button>
+          <Button startIcon={<KeyOutlined />} onClick={() => setResetOpen(true)}>비밀번호 재설정</Button>
+          <Button variant="outlined" startIcon={<ArrowBackOutlined />} onClick={() => navigate("/admin/users")}>목록</Button>
+          <Button variant="contained" startIcon={<SaveOutlined />} onClick={handleSave} disabled={saving}>
+            {saving ? <CircularProgress size={20} /> : "저장"}
+          </Button>
+        </Stack>
+      </Box>
+      <Divider />
+      <Stack spacing={2} sx={{ maxWidth: 600 }}>
+        <TextField label="아이디" value={user.username} InputProps={{ readOnly: true }} size="small" />
+        <TextField label="이름" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} size="small" />
+        <TextField label="이메일" value={form.email} onChange={e => setForm(f => ({ ...f, email: e.target.value }))} size="small" />
+        <FormControlLabel control={<Switch checked={form.emailVisble} onChange={e => setForm(f => ({ ...f, emailVisble: e.target.checked }))} />} label="이메일 공개" />
+        <FormControlLabel control={<Switch checked={form.nameVisible} onChange={e => setForm(f => ({ ...f, nameVisible: e.target.checked }))} />} label="이름 공개" />
+        <FormControlLabel control={<Switch checked={form.enabled} onChange={e => setForm(f => ({ ...f, enabled: e.target.checked }))} />} label="계정 활성화" />
+      </Stack>
+      <UserRolesDialog open={rolesOpen} onClose={() => setRolesOpen(false)} userId={user.userId} username={user.username} />
+      <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} userId={user.userId} username={user.username} />
+    </Stack>
+  );
+}

--- a/src/react/pages/admin/users/UserRolesDialog.tsx
+++ b/src/react/pages/admin/users/UserRolesDialog.tsx
@@ -1,0 +1,95 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Button, List, ListItem, ListItemText, IconButton, Divider,
+  Typography, CircularProgress, Stack, TextField,
+} from "@mui/material";
+import { DeleteOutlined, AddOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactUsersApi } from "./api";
+import type { UserRoleDto } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  userId: number;
+  username: string;
+}
+
+export function UserRolesDialog({ open, onClose, userId, username }: Props) {
+  const toast = useToast();
+  const [roles, setRoles] = useState<UserRoleDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [roleIdInput, setRoleIdInput] = useState("");
+
+  async function loadRoles() {
+    setLoading(true);
+    try {
+      const data = await reactUsersApi.getUserRoles(userId);
+      setRoles(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error("역할 목록 로딩 실패");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (open) { setRoleIdInput(""); loadRoles(); }
+  }, [open, userId]);
+
+  async function handleAdd() {
+    const roleId = parseInt(roleIdInput, 10);
+    if (!roleId) return;
+    try {
+      await reactUsersApi.addUserRole(userId, roleId);
+      toast.success("역할이 부여되었습니다.");
+      setRoleIdInput("");
+      loadRoles();
+    } catch {
+      toast.error("역할 부여에 실패했습니다.");
+    }
+  }
+
+  async function handleRemove(roleId: number) {
+    try {
+      await reactUsersApi.removeUserRole(userId, roleId);
+      toast.success("역할이 제거되었습니다.");
+      loadRoles();
+    } catch {
+      toast.error("역할 제거에 실패했습니다.");
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>역할 관리 — {username}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={1} sx={{ mt: 1 }}>
+          <Stack direction="row" spacing={1}>
+            <TextField label="역할 ID" size="small" value={roleIdInput}
+              onChange={e => setRoleIdInput(e.target.value)}
+              onKeyDown={e => e.key === "Enter" && handleAdd()} />
+            <Button startIcon={<AddOutlined />} variant="outlined" onClick={handleAdd} disabled={!roleIdInput}>추가</Button>
+          </Stack>
+          <Divider />
+          {loading ? <CircularProgress size={24} /> : (
+            <List dense>
+              {roles.length === 0 && <Typography color="text.secondary" variant="body2">부여된 역할 없음</Typography>}
+              {roles.map(r => (
+                <ListItem key={r.roleId} secondaryAction={
+                  <IconButton size="small" color="error" onClick={() => handleRemove(r.roleId)}><DeleteOutlined fontSize="small" /></IconButton>
+                }>
+                  <ListItemText primary={r.name} secondary={`ID: ${r.roleId}`} />
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/admin/users/api.ts
+++ b/src/react/pages/admin/users/api.ts
@@ -1,5 +1,5 @@
 import { apiRequest } from "@/react/query/fetcher";
-import type { UserDto, PasswordPolicyDto } from "@/types/studio/user";
+import type { UserDto, PasswordPolicyDto, ResetPasswordRequest } from "@/types/studio/user";
 
 export interface UserRoleDto { roleId: number; name: string; description?: string | null; }
 
@@ -16,6 +16,6 @@ export const reactUsersApi = {
     apiRequest<void>("delete", `/api/mgmt/users/${userId}/roles/${roleId}`),
   getPasswordPolicy: () =>
     apiRequest<PasswordPolicyDto>("get", "/api/mgmt/users/password-policy"),
-  resetPassword: (userId: number, newPassword: string) =>
-    apiRequest<void>("post", `/api/mgmt/users/${userId}/password`, { data: { newPassword } }),
+  resetPassword: (userId: number, payload: ResetPasswordRequest) =>
+    apiRequest<void>("post", `/api/mgmt/users/${userId}/password`, { data: payload }),
 };

--- a/src/react/pages/admin/users/api.ts
+++ b/src/react/pages/admin/users/api.ts
@@ -1,0 +1,21 @@
+import { apiRequest } from "@/react/query/fetcher";
+import type { UserDto, PasswordPolicyDto } from "@/types/studio/user";
+
+export interface UserRoleDto { roleId: number; name: string; description?: string | null; }
+
+export const reactUsersApi = {
+  getUser: (userId: number) =>
+    apiRequest<UserDto>("get", `/api/mgmt/users/${userId}`),
+  updateUser: (userId: number, payload: Partial<UserDto>) =>
+    apiRequest<UserDto>("put", `/api/mgmt/users/${userId}`, { data: payload }),
+  getUserRoles: (userId: number) =>
+    apiRequest<UserRoleDto[]>("get", `/api/mgmt/users/${userId}/roles`),
+  addUserRole: (userId: number, roleId: number) =>
+    apiRequest<void>("post", `/api/mgmt/users/${userId}/roles`, { data: { roleId } }),
+  removeUserRole: (userId: number, roleId: number) =>
+    apiRequest<void>("delete", `/api/mgmt/users/${userId}/roles/${roleId}`),
+  getPasswordPolicy: () =>
+    apiRequest<PasswordPolicyDto>("get", "/api/mgmt/users/password-policy"),
+  resetPassword: (userId: number, newPassword: string) =>
+    apiRequest<void>("post", `/api/mgmt/users/${userId}/password`, { data: { newPassword } }),
+};

--- a/src/react/pages/admin/users/queryKeys.ts
+++ b/src/react/pages/admin/users/queryKeys.ts
@@ -1,0 +1,2 @@
+import { createQueryKeys } from "@/react/query/keys";
+export const usersQueryKeys = createQueryKeys("admin-users");

--- a/src/react/pages/documents/CreateDocumentDialog.tsx
+++ b/src/react/pages/documents/CreateDocumentDialog.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import { apiRequest } from "@/react/query/fetcher";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (id: number) => void;
+}
+
+export function CreateDocumentDialog({ open, onClose, onCreated }: Props) {
+  const toast = useToast();
+  const [title, setTitle] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleCreate() {
+    if (!title.trim()) return;
+
+    setLoading(true);
+    try {
+      const document = await apiRequest<{ documentId: number }>("post", "/api/mgmt/documents", {
+        data: { title: title.trim() },
+      });
+      toast.success("문서가 생성되었습니다.");
+      setTitle("");
+      onCreated(document.documentId);
+    } catch {
+      toast.error("문서 생성에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>문서 생성</DialogTitle>
+      <DialogContent>
+        <TextField
+          label="제목"
+          size="small"
+          fullWidth
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          onKeyDown={(event) => event.key === "Enter" && void handleCreate()}
+          sx={{ mt: 1 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          취소
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleCreate()}
+          disabled={loading || !title.trim()}
+        >
+          {loading ? <CircularProgress size={20} /> : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/documents/DocumentListPage.tsx
+++ b/src/react/pages/documents/DocumentListPage.tsx
@@ -1,0 +1,118 @@
+import { useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Stack,
+  Breadcrumbs,
+  Typography,
+  Button,
+  TextField,
+} from "@mui/material";
+import { AddOutlined, RefreshOutlined, SearchOutlined } from "@mui/icons-material";
+import type { ColDef, ICellRendererParams } from "ag-grid-community";
+import { PageableGridContent } from "@/react/components/ag-grid";
+import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
+import { ReactPageDataSource } from "@/react/pages/admin/datasource";
+import { CreateDocumentDialog } from "@/react/pages/documents/CreateDocumentDialog";
+
+interface DocumentSummaryDto {
+  documentId: number;
+  title: string;
+  objectType?: number;
+  objectId?: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+class DocumentsDataSource extends ReactPageDataSource<DocumentSummaryDto> {
+  constructor() {
+    super("/api/mgmt/documents");
+  }
+}
+
+export function DocumentListPage() {
+  const navigate = useNavigate();
+  const gridRef = useRef<PageableGridContentHandle<DocumentSummaryDto>>(null);
+  const dataSource = useMemo(() => new DocumentsDataSource(), []);
+  const [searchInput, setSearchInput] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const columnDefs = useMemo<ColDef<DocumentSummaryDto>[]>(
+    () => [
+      {
+        field: "title",
+        headerName: "제목",
+        flex: 2,
+        sortable: true,
+        filter: false,
+        cellRenderer: (params: ICellRendererParams<DocumentSummaryDto>) => (
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => navigate(`/application/documents/${params.data?.documentId}`)}
+          >
+            {params.value}
+          </Button>
+        ),
+      },
+      { field: "objectType", headerName: "오브젝트 타입", flex: 0.8, sortable: false, filter: false },
+      { field: "createdAt", headerName: "생성일시", flex: 1, sortable: true, filter: false },
+      { field: "updatedAt", headerName: "수정일시", flex: 1, sortable: true, filter: false },
+    ],
+    [navigate]
+  );
+
+  function handleSearch() {
+    dataSource.applyFilter(searchInput.trim() ? { q: searchInput.trim() } : {});
+    gridRef.current?.refresh();
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">애플리케이션</Typography>
+        <Typography color="text.primary">문서</Typography>
+      </Breadcrumbs>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">문서 목록</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button startIcon={<AddOutlined />} onClick={() => setCreateOpen(true)}>
+            문서 생성
+          </Button>
+          <Button startIcon={<RefreshOutlined />} onClick={() => gridRef.current?.refresh()}>
+            새로고침
+          </Button>
+        </Stack>
+      </Box>
+      <TextField
+        label="검색어"
+        variant="outlined"
+        size="small"
+        fullWidth
+        value={searchInput}
+        onChange={(e) => setSearchInput(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+        InputProps={{
+          endAdornment: (
+            <Button onClick={handleSearch} startIcon={<SearchOutlined />} size="small">
+              검색
+            </Button>
+          ),
+        }}
+      />
+      <PageableGridContent<DocumentSummaryDto>
+        ref={gridRef}
+        datasource={dataSource}
+        columns={columnDefs}
+      />
+      <CreateDocumentDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={(id) => {
+          setCreateOpen(false);
+          navigate(`/application/documents/${id}`);
+        }}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/files/FileDetailDialog.tsx
+++ b/src/react/pages/files/FileDetailDialog.tsx
@@ -1,0 +1,94 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Stack,
+  TextField,
+  Typography,
+  CircularProgress,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import { apiRequest } from "@/react/query/fetcher";
+
+interface FileInfoDto {
+  attachmentId: number;
+  name?: string;
+  originalFileName?: string;
+  contentType?: string;
+  size?: number;
+  createdAt?: string;
+  properties?: Record<string, string>;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  attachmentId: number;
+}
+
+export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
+  const toast = useToast();
+  const [file, setFile] = useState<FileInfoDto | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !attachmentId) return;
+    setLoading(true);
+    apiRequest<FileInfoDto>("get", `/api/mgmt/files/${attachmentId}`)
+      .then(setFile)
+      .catch(() => toast.error("파일 정보를 불러오지 못했습니다."))
+      .finally(() => setLoading(false));
+  }, [open, attachmentId]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>파일 상세</DialogTitle>
+      <DialogContent>
+        {loading ? (
+          <CircularProgress size={24} />
+        ) : file ? (
+          <Stack spacing={1.5} sx={{ mt: 1 }}>
+            <TextField
+              label="파일명"
+              value={file.originalFileName ?? file.name ?? ""}
+              InputProps={{ readOnly: true }}
+              size="small"
+              fullWidth
+            />
+            <TextField
+              label="Content-Type"
+              value={file.contentType ?? ""}
+              InputProps={{ readOnly: true }}
+              size="small"
+              fullWidth
+            />
+            <TextField
+              label="크기"
+              value={
+                file.size != null ? `${(file.size / 1024).toFixed(1)} KB` : ""
+              }
+              InputProps={{ readOnly: true }}
+              size="small"
+              fullWidth
+            />
+            <TextField
+              label="생성일시"
+              value={file.createdAt ?? ""}
+              InputProps={{ readOnly: true }}
+              size="small"
+              fullWidth
+            />
+          </Stack>
+        ) : (
+          <Typography color="text.secondary">데이터 없음</Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/files/FilesPage.tsx
+++ b/src/react/pages/files/FilesPage.tsx
@@ -20,10 +20,12 @@ import {
   Typography,
 } from "@mui/material";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import dayjs from "dayjs";
 import { reactFilesApi } from "@/react/pages/files/api";
+import { FileDetailDialog } from "@/react/pages/files/FileDetailDialog";
 import { FileUploadDialog } from "@/react/pages/files/FileUploadDialog";
 import { filesQueryKeys } from "@/react/pages/files/queryKeys";
 
@@ -41,6 +43,7 @@ export function FilesPage() {
   const [page, setPage] = useState(0);
   const [pageSize] = useState(10);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [detailAttachmentId, setDetailAttachmentId] = useState<number | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   const filesQuery = useQuery({
@@ -175,6 +178,11 @@ export function FilesPage() {
                           <DeleteOutlineIcon fontSize="small" />
                         </IconButton>
                       </Tooltip>
+                      <Tooltip title="상세">
+                        <IconButton onClick={() => setDetailAttachmentId(file.attachmentId)}>
+                          <InfoOutlinedIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -208,6 +216,13 @@ export function FilesPage() {
           await queryClient.invalidateQueries({ queryKey: filesQueryKeys.all });
         }}
       />
+      {detailAttachmentId ? (
+        <FileDetailDialog
+          open={detailAttachmentId !== null}
+          onClose={() => setDetailAttachmentId(null)}
+          attachmentId={detailAttachmentId}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -84,6 +84,28 @@ export function ObjectTypeDetailPage() {
     }
   }
 
+  async function handleSavePolicy() {
+    if (!objectTypeId || !user) return;
+    setSaving(true);
+    try {
+      const nextPolicy = await reactObjectTypeApi.upsertPolicy(Number(objectTypeId), {
+        maxFileMb: policyForm.maxFileMb === "" ? null : Number(policyForm.maxFileMb),
+        allowedExt: policyForm.allowedExt || null,
+        allowedMime: policyForm.allowedMime || null,
+        updatedBy: user.username,
+        updatedById: user.userId,
+        createdBy: policy?.createdBy ?? user.username,
+        createdById: policy?.createdById ?? user.userId,
+      });
+      setPolicy(nextPolicy);
+      toast.success("파일 정책이 저장되었습니다.");
+    } catch {
+      toast.error("파일 정책 저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
   if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
@@ -169,7 +191,20 @@ export function ObjectTypeDetailPage() {
       </Card>
       {policy && (
         <Card variant="outlined">
-          <CardHeader title="파일 정책" />
+          <CardHeader
+            title="파일 정책"
+            action={
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<SaveOutlined />}
+                onClick={handleSavePolicy}
+                disabled={saving}
+              >
+                저장
+              </Button>
+            }
+          />
           <CardContent>
             <Stack spacing={2} sx={{ maxWidth: 600 }}>
               <TextField

--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -1,0 +1,201 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Box,
+  Stack,
+  Breadcrumbs,
+  Typography,
+  Button,
+  TextField,
+  Divider,
+  CircularProgress,
+  Alert,
+  Card,
+  CardContent,
+  CardHeader,
+} from "@mui/material";
+import { ArrowBackOutlined, SaveOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactObjectTypeApi } from "./api";
+import type { ObjectTypeDto, ObjectTypePolicyDto } from "@/types/studio/objecttype";
+import { useAuthStore } from "@/react/auth/store";
+
+export function ObjectTypeDetailPage() {
+  const { objectTypeId } = useParams<{ objectTypeId: string }>();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const { user } = useAuthStore();
+  const [objectType, setObjectType] = useState<ObjectTypeDto | null>(null);
+  const [policy, setPolicy] = useState<ObjectTypePolicyDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({ name: "", description: "", status: "" });
+  const [policyForm, setPolicyForm] = useState({
+    maxFileMb: "",
+    allowedExt: "",
+    allowedMime: "",
+  });
+
+  useEffect(() => {
+    if (!objectTypeId) return;
+    setLoading(true);
+    Promise.all([
+      reactObjectTypeApi.get(Number(objectTypeId)),
+      reactObjectTypeApi.getPolicy(Number(objectTypeId)).catch(() => null),
+    ])
+      .then(([ot, pol]) => {
+        setObjectType(ot);
+        setForm({
+          name: ot.name,
+          description: ot.description ?? "",
+          status: ot.status,
+        });
+        if (pol) {
+          setPolicy(pol);
+          setPolicyForm({
+            maxFileMb: pol.maxFileMb?.toString() ?? "",
+            allowedExt: pol.allowedExt ?? "",
+            allowedMime: pol.allowedMime ?? "",
+          });
+        }
+        setError(null);
+      })
+      .catch(() => setError("오브젝트 타입을 불러오지 못했습니다."))
+      .finally(() => setLoading(false));
+  }, [objectTypeId]);
+
+  async function handleSave() {
+    if (!objectTypeId || !user) return;
+    setSaving(true);
+    try {
+      await reactObjectTypeApi.patch(Number(objectTypeId), {
+        name: form.name,
+        description: form.description || null,
+        status: form.status,
+        updatedBy: user.username,
+        updatedById: user.userId,
+      });
+      toast.success("저장되었습니다.");
+    } catch {
+      toast.error("저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  if (error) return <Alert severity="error">{error}</Alert>;
+  if (!objectType) return null;
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">정책</Typography>
+        <Typography
+          color="text.secondary"
+          sx={{ cursor: "pointer" }}
+          onClick={() => navigate("/policy/object-types")}
+        >
+          오브젝트 타입
+        </Typography>
+        <Typography color="text.primary">{objectType.code}</Typography>
+      </Breadcrumbs>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">오브젝트 타입 상세</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant="outlined"
+            startIcon={<ArrowBackOutlined />}
+            onClick={() => navigate("/policy/object-types")}
+          >
+            목록
+          </Button>
+          <Button
+            variant="contained"
+            startIcon={<SaveOutlined />}
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? <CircularProgress size={20} /> : "저장"}
+          </Button>
+        </Stack>
+      </Box>
+      <Divider />
+      <Card variant="outlined">
+        <CardHeader title="기본 정보" />
+        <CardContent>
+          <Stack spacing={2} sx={{ maxWidth: 600 }}>
+            <TextField
+              label="코드"
+              value={objectType.code}
+              InputProps={{ readOnly: true }}
+              size="small"
+            />
+            <TextField
+              label="이름"
+              value={form.name}
+              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              size="small"
+            />
+            <TextField
+              label="도메인"
+              value={objectType.domain}
+              InputProps={{ readOnly: true }}
+              size="small"
+            />
+            <TextField
+              label="상태"
+              value={form.status}
+              onChange={(e) => setForm((f) => ({ ...f, status: e.target.value }))}
+              size="small"
+            />
+            <TextField
+              label="설명"
+              value={form.description}
+              onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+              size="small"
+              multiline
+              rows={2}
+            />
+          </Stack>
+        </CardContent>
+      </Card>
+      {policy && (
+        <Card variant="outlined">
+          <CardHeader title="파일 정책" />
+          <CardContent>
+            <Stack spacing={2} sx={{ maxWidth: 600 }}>
+              <TextField
+                label="최대 파일 크기 (MB)"
+                value={policyForm.maxFileMb}
+                onChange={(e) => setPolicyForm((f) => ({ ...f, maxFileMb: e.target.value }))}
+                size="small"
+                type="number"
+              />
+              <TextField
+                label="허용 확장자"
+                value={policyForm.allowedExt}
+                onChange={(e) => setPolicyForm((f) => ({ ...f, allowedExt: e.target.value }))}
+                size="small"
+                helperText="예: jpg,png,pdf"
+              />
+              <TextField
+                label="허용 MIME 타입"
+                value={policyForm.allowedMime}
+                onChange={(e) => setPolicyForm((f) => ({ ...f, allowedMime: e.target.value }))}
+                size="small"
+              />
+            </Stack>
+          </CardContent>
+        </Card>
+      )}
+    </Stack>
+  );
+}

--- a/src/react/pages/objecttype/ObjectTypeListPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeListPage.tsx
@@ -1,0 +1,73 @@
+import { useMemo, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Stack,
+  Breadcrumbs,
+  Typography,
+  Button,
+} from "@mui/material";
+import { RefreshOutlined } from "@mui/icons-material";
+import type { ColDef, ICellRendererParams } from "ag-grid-community";
+import { PageableGridContent } from "@/react/components/ag-grid";
+import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
+import { ReactPageDataSource } from "@/react/pages/admin/datasource";
+import type { ObjectTypeDto } from "@/types/studio/objecttype";
+
+class ObjectTypesDataSource extends ReactPageDataSource<ObjectTypeDto> {
+  constructor() {
+    super("/api/mgmt/object-types");
+  }
+}
+
+export function ObjectTypeListPage() {
+  const navigate = useNavigate();
+  const gridRef = useRef<PageableGridContentHandle<ObjectTypeDto>>(null);
+  const dataSource = useMemo(() => new ObjectTypesDataSource(), []);
+
+  const columnDefs = useMemo<ColDef<ObjectTypeDto>[]>(
+    () => [
+      {
+        field: "code",
+        headerName: "코드",
+        flex: 1.2,
+        sortable: true,
+        filter: false,
+        cellRenderer: (params: ICellRendererParams<ObjectTypeDto>) => (
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => navigate(`/policy/object-types/${params.data?.objectType}`)}
+          >
+            {params.value}
+          </Button>
+        ),
+      },
+      { field: "name", headerName: "이름", flex: 1.2, sortable: true, filter: false },
+      { field: "domain", headerName: "도메인", flex: 1, sortable: true, filter: false },
+      { field: "status", headerName: "상태", flex: 0.8, sortable: true, filter: false },
+      { field: "description", headerName: "설명", flex: 2, sortable: false, filter: false },
+    ],
+    [navigate]
+  );
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">정책</Typography>
+        <Typography color="text.primary">오브젝트 타입</Typography>
+      </Breadcrumbs>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">오브젝트 타입</Typography>
+        <Button startIcon={<RefreshOutlined />} onClick={() => gridRef.current?.refresh()}>
+          새로고침
+        </Button>
+      </Box>
+      <PageableGridContent<ObjectTypeDto>
+        ref={gridRef}
+        datasource={dataSource}
+        columns={columnDefs}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/objecttype/api.ts
+++ b/src/react/pages/objecttype/api.ts
@@ -1,0 +1,26 @@
+import { apiRequest } from "@/react/query/fetcher";
+import type {
+  ObjectTypeDto,
+  ObjectTypePatchRequest,
+  ObjectTypePolicyDto,
+  ObjectTypePolicyUpsertRequest,
+} from "@/types/studio/objecttype";
+
+const BASE = "/api/mgmt/object-types";
+
+export const reactObjectTypeApi = {
+  list: (params?: { domain?: string; status?: string; q?: string }) =>
+    apiRequest<ObjectTypeDto[]>("get", BASE, { params }),
+
+  get: (objectType: number) =>
+    apiRequest<ObjectTypeDto>("get", `${BASE}/${objectType}`),
+
+  patch: (objectType: number, payload: ObjectTypePatchRequest) =>
+    apiRequest<ObjectTypeDto>("patch", `${BASE}/${objectType}`, { data: payload }),
+
+  getPolicy: (objectType: number) =>
+    apiRequest<ObjectTypePolicyDto>("get", `${BASE}/${objectType}/policy`),
+
+  upsertPolicy: (objectType: number, payload: ObjectTypePolicyUpsertRequest) =>
+    apiRequest<ObjectTypePolicyDto>("put", `${BASE}/${objectType}/policy`, { data: payload }),
+};

--- a/src/react/pages/objecttype/queryKeys.ts
+++ b/src/react/pages/objecttype/queryKeys.ts
@@ -1,0 +1,3 @@
+import { createQueryKeys } from "@/react/query/keys";
+
+export const objectTypeQueryKeys = createQueryKeys("object-types");

--- a/src/react/pages/profile/MyProfilePage.tsx
+++ b/src/react/pages/profile/MyProfilePage.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect } from "react";
+import {
+  Box, Stack, Typography, Button, TextField, Divider,
+  CircularProgress, Alert, Card, CardContent, CardHeader, FormControlLabel, Switch,
+} from "@mui/material";
+import { SaveOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { reactProfileApi } from "./api";
+import type { MeProfileDto } from "@/types/studio/user";
+
+const AUTO_REFRESH_KEY = "studio.jwt.autoRefresh";
+
+export function MyProfilePage() {
+  const toast = useToast();
+  const [profile, setProfile] = useState<MeProfileDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({ name: "", email: "" });
+  const [autoRefresh, setAutoRefresh] = useState(() => localStorage.getItem(AUTO_REFRESH_KEY) === "true");
+
+  useEffect(() => {
+    reactProfileApi.getProfile()
+      .then(p => { setProfile(p); setForm({ name: p.name, email: p.email ?? "" }); setError(null); })
+      .catch(() => setError("프로필을 불러오지 못했습니다."))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      await reactProfileApi.updateProfile({ name: form.name, email: form.email || null });
+      toast.success("프로필이 저장되었습니다.");
+    } catch {
+      toast.error("저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleAutoRefreshChange(v: boolean) {
+    setAutoRefresh(v);
+    localStorage.setItem(AUTO_REFRESH_KEY, String(v));
+  }
+
+  if (loading) return <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}><CircularProgress /></Box>;
+  if (error) return <Alert severity="error">{error}</Alert>;
+
+  return (
+    <Stack spacing={3}>
+      <Typography variant="h5">내 프로필</Typography>
+      <Card variant="outlined">
+        <CardHeader title="기본 정보" />
+        <CardContent>
+          <Stack spacing={2} sx={{ maxWidth: 500 }}>
+            <TextField label="아이디" value={profile?.username ?? ""} InputProps={{ readOnly: true }} size="small" />
+            <TextField label="이름" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} size="small" />
+            <TextField label="이메일" value={form.email} onChange={e => setForm(f => ({ ...f, email: e.target.value }))} size="small" />
+            <Box>
+              <Button variant="contained" startIcon={<SaveOutlined />} onClick={handleSave} disabled={saving}>
+                {saving ? <CircularProgress size={20} /> : "저장"}
+              </Button>
+            </Box>
+          </Stack>
+        </CardContent>
+      </Card>
+      <Card variant="outlined">
+        <CardHeader title="인증 설정" />
+        <CardContent>
+          <FormControlLabel
+            control={<Switch checked={autoRefresh} onChange={e => handleAutoRefreshChange(e.target.checked)} />}
+            label="JWT 자동 갱신"
+          />
+          <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+            세션 만료 전 자동으로 토큰을 갱신합니다. (브라우저 로컬 설정)
+          </Typography>
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+}

--- a/src/react/pages/profile/api.ts
+++ b/src/react/pages/profile/api.ts
@@ -1,0 +1,13 @@
+import { apiRequest } from "@/react/query/fetcher";
+import type { MeProfileDto, MeProfilePatchRequest, PasswordPolicyDto } from "@/types/studio/user";
+
+export const reactProfileApi = {
+  getProfile: () =>
+    apiRequest<MeProfileDto>("get", "/api/self"),
+  updateProfile: (payload: MeProfilePatchRequest) =>
+    apiRequest<MeProfileDto>("patch", "/api/self", { data: payload }),
+  getPasswordPolicy: () =>
+    apiRequest<PasswordPolicyDto>("get", "/api/self/password-policy"),
+  changePassword: (currentPassword: string, newPassword: string) =>
+    apiRequest<void>("post", "/api/self/password", { data: { currentPassword, newPassword } }),
+};

--- a/src/react/pages/profile/queryKeys.ts
+++ b/src/react/pages/profile/queryKeys.ts
@@ -1,0 +1,2 @@
+import { createQueryKeys } from "@/react/query/keys";
+export const profileQueryKeys = createQueryKeys("profile");

--- a/src/react/pages/templates/CreateTemplateDialog.tsx
+++ b/src/react/pages/templates/CreateTemplateDialog.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import { reactTemplatesApi } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function CreateTemplateDialog({ open, onClose, onCreated }: Props) {
+  const toast = useToast();
+  const [name, setName] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [objectType, setObjectType] = useState("");
+  const [objectId, setObjectId] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleCreate() {
+    if (!name.trim() || !objectType || !objectId) return;
+
+    setLoading(true);
+    try {
+      await reactTemplatesApi.create({
+        name: name.trim(),
+        displayName: displayName || null,
+        objectType: Number(objectType),
+        objectId: Number(objectId),
+      });
+      toast.success("템플릿이 생성되었습니다.");
+      setName("");
+      setDisplayName("");
+      setObjectType("");
+      setObjectId("");
+      onCreated();
+      onClose();
+    } catch {
+      toast.error("템플릿 생성에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>템플릿 생성</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="이름 (name)"
+            size="small"
+            fullWidth
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            required
+          />
+          <TextField
+            label="표시 이름 (displayName)"
+            size="small"
+            fullWidth
+            value={displayName}
+            onChange={(event) => setDisplayName(event.target.value)}
+          />
+          <TextField
+            label="오브젝트 타입 (objectType)"
+            size="small"
+            fullWidth
+            value={objectType}
+            onChange={(event) => setObjectType(event.target.value)}
+            required
+            type="number"
+          />
+          <TextField
+            label="오브젝트 ID (objectId)"
+            size="small"
+            fullWidth
+            value={objectId}
+            onChange={(event) => setObjectId(event.target.value)}
+            required
+            type="number"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          취소
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleCreate()}
+          disabled={loading || !name.trim()}
+        >
+          {loading ? <CircularProgress size={20} /> : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/templates/PreviewTemplateDialog.tsx
+++ b/src/react/pages/templates/PreviewTemplateDialog.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import { reactTemplatesApi } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  templateId: number;
+}
+
+export function PreviewTemplateDialog({ open, onClose, templateId }: Props) {
+  const toast = useToast();
+  const [model, setModel] = useState("{}");
+  const [body, setBody] = useState("");
+  const [subject, setSubject] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleRender() {
+    let parsedModel: Record<string, unknown> = {};
+    try {
+      parsedModel = JSON.parse(model);
+    } catch {
+      toast.error("모델 JSON 형식 오류");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const [renderedBody, renderedSubject] = await Promise.all([
+        reactTemplatesApi.renderBody(templateId, parsedModel),
+        reactTemplatesApi.renderSubject(templateId, parsedModel),
+      ]);
+      setBody(typeof renderedBody === "string" ? renderedBody : JSON.stringify(renderedBody));
+      setSubject(
+        typeof renderedSubject === "string" ? renderedSubject : JSON.stringify(renderedSubject)
+      );
+    } catch {
+      toast.error("렌더링에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>템플릿 미리보기</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="모델 (JSON)"
+            multiline
+            rows={4}
+            fullWidth
+            size="small"
+            value={model}
+            onChange={(event) => setModel(event.target.value)}
+          />
+          <Button variant="outlined" onClick={() => void handleRender()} disabled={loading}>
+            {loading ? <CircularProgress size={20} /> : "렌더링"}
+          </Button>
+          {subject ? (
+            <TextField
+              label="제목"
+              value={subject}
+              InputProps={{ readOnly: true }}
+              size="small"
+              fullWidth
+            />
+          ) : null}
+          {body ? (
+            <TextField
+              label="본문"
+              value={body}
+              multiline
+              rows={6}
+              InputProps={{ readOnly: true }}
+              size="small"
+              fullWidth
+            />
+          ) : null}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/templates/TemplateDetailsPage.tsx
+++ b/src/react/pages/templates/TemplateDetailsPage.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Box,
+  Stack,
+  Breadcrumbs,
+  Typography,
+  Button,
+  TextField,
+  Divider,
+  CircularProgress,
+  Alert,
+} from "@mui/material";
+import { ArrowBackOutlined, SaveOutlined, PreviewOutlined } from "@mui/icons-material";
+import { useToast } from "@/react/feedback";
+import { PreviewTemplateDialog } from "@/react/pages/templates/PreviewTemplateDialog";
+import { reactTemplatesApi } from "./api";
+import type { TemplateDto } from "@/types/studio/template";
+
+export function TemplateDetailsPage() {
+  const { templateId } = useParams<{ templateId: string }>();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [template, setTemplate] = useState<TemplateDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [form, setForm] = useState({
+    name: "",
+    displayName: "",
+    description: "",
+    subject: "",
+    body: "",
+  });
+
+  useEffect(() => {
+    if (!templateId) return;
+    setLoading(true);
+    reactTemplatesApi
+      .get(Number(templateId))
+      .then((t) => {
+        setTemplate(t);
+        setForm({
+          name: t.name,
+          displayName: t.displayName ?? "",
+          description: t.description ?? "",
+          subject: t.subject ?? "",
+          body: t.body ?? "",
+        });
+        setError(null);
+      })
+      .catch(() => setError("템플릿을 불러오지 못했습니다."))
+      .finally(() => setLoading(false));
+  }, [templateId]);
+
+  async function handleSave() {
+    if (!templateId || !template) return;
+    setSaving(true);
+    try {
+      await reactTemplatesApi.update(Number(templateId), {
+        objectType: template.objectType,
+        objectId: template.objectId,
+        name: form.name,
+        displayName: form.displayName || null,
+        description: form.description || null,
+        subject: form.subject || null,
+        body: form.body || null,
+        properties: template.properties,
+      });
+      toast.success("저장되었습니다.");
+    } catch {
+      toast.error("저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  if (error) return <Alert severity="error">{error}</Alert>;
+  if (!template) return null;
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">애플리케이션</Typography>
+        <Typography
+          color="text.secondary"
+          sx={{ cursor: "pointer" }}
+          onClick={() => navigate("/application/templates")}
+        >
+          템플릿
+        </Typography>
+        <Typography color="text.primary">{template.name}</Typography>
+      </Breadcrumbs>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">템플릿 상세</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button startIcon={<PreviewOutlined />} onClick={() => setPreviewOpen(true)}>
+            미리보기
+          </Button>
+          <Button
+            variant="outlined"
+            startIcon={<ArrowBackOutlined />}
+            onClick={() => navigate("/application/templates")}
+          >
+            목록
+          </Button>
+          <Button
+            variant="contained"
+            startIcon={<SaveOutlined />}
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? <CircularProgress size={20} /> : "저장"}
+          </Button>
+        </Stack>
+      </Box>
+      <Divider />
+      <Stack spacing={2} sx={{ maxWidth: 700 }}>
+        <TextField
+          label="이름"
+          value={form.name}
+          onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+          size="small"
+        />
+        <TextField
+          label="표시 이름"
+          value={form.displayName}
+          onChange={(e) => setForm((f) => ({ ...f, displayName: e.target.value }))}
+          size="small"
+        />
+        <TextField
+          label="설명"
+          value={form.description}
+          onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+          size="small"
+          multiline
+          rows={2}
+        />
+        <TextField
+          label="제목 (subject)"
+          value={form.subject}
+          onChange={(e) => setForm((f) => ({ ...f, subject: e.target.value }))}
+          size="small"
+        />
+        <TextField
+          label="본문 (body)"
+          value={form.body}
+          onChange={(e) => setForm((f) => ({ ...f, body: e.target.value }))}
+          size="small"
+          multiline
+          rows={10}
+        />
+      </Stack>
+      <PreviewTemplateDialog
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        templateId={template.templateId}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/templates/TemplatesPage.tsx
+++ b/src/react/pages/templates/TemplatesPage.tsx
@@ -1,0 +1,85 @@
+import { useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Stack,
+  Breadcrumbs,
+  Typography,
+  Button,
+} from "@mui/material";
+import { AddOutlined, RefreshOutlined } from "@mui/icons-material";
+import type { ColDef, ICellRendererParams } from "ag-grid-community";
+import { PageableGridContent } from "@/react/components/ag-grid";
+import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
+import { ReactPageDataSource } from "@/react/pages/admin/datasource";
+import { CreateTemplateDialog } from "@/react/pages/templates/CreateTemplateDialog";
+import { reactTemplatesApi } from "./api";
+import type { TemplateSummaryDto } from "@/types/studio/template";
+
+class TemplatesDataSource extends ReactPageDataSource<TemplateSummaryDto> {
+  constructor() {
+    super("/api/mgmt/templates");
+  }
+}
+
+export function TemplatesPage() {
+  const navigate = useNavigate();
+  const gridRef = useRef<PageableGridContentHandle<TemplateSummaryDto>>(null);
+  const dataSource = useMemo(() => new TemplatesDataSource(), []);
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const columnDefs = useMemo<ColDef<TemplateSummaryDto>[]>(
+    () => [
+      {
+        field: "name",
+        headerName: "이름",
+        flex: 1.5,
+        sortable: true,
+        filter: false,
+        cellRenderer: (params: ICellRendererParams<TemplateSummaryDto>) => (
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => navigate(`/application/templates/${params.data?.templateId}`)}
+          >
+            {params.value}
+          </Button>
+        ),
+      },
+      { field: "displayName", headerName: "표시 이름", flex: 1.5, sortable: true, filter: false },
+      { field: "objectType", headerName: "오브젝트 타입", flex: 0.8, sortable: false, filter: false },
+      { field: "updatedAt", headerName: "수정일시", flex: 1, sortable: true, filter: false },
+    ],
+    [navigate]
+  );
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">애플리케이션</Typography>
+        <Typography color="text.primary">템플릿</Typography>
+      </Breadcrumbs>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">템플릿 목록</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button startIcon={<AddOutlined />} onClick={() => setCreateOpen(true)}>
+            템플릿 생성
+          </Button>
+          <Button startIcon={<RefreshOutlined />} onClick={() => gridRef.current?.refresh()}>
+            새로고침
+          </Button>
+        </Stack>
+      </Box>
+      <PageableGridContent<TemplateSummaryDto>
+        ref={gridRef}
+        datasource={dataSource}
+        columns={columnDefs}
+      />
+      <CreateTemplateDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => gridRef.current?.refresh()}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/templates/api.ts
+++ b/src/react/pages/templates/api.ts
@@ -1,0 +1,27 @@
+import { apiRequest } from "@/react/query/fetcher";
+import type { TemplateDto, TemplateRequest } from "@/types/studio/template";
+
+const BASE = "/api/mgmt/templates";
+
+export const reactTemplatesApi = {
+  list: (params?: { page?: number; size?: number; q?: string }) =>
+    apiRequest<{ content: TemplateDto[]; totalElements: number }>("get", BASE, { params }),
+
+  get: (templateId: number) =>
+    apiRequest<TemplateDto>("get", `${BASE}/${templateId}`),
+
+  create: (payload: TemplateRequest) =>
+    apiRequest<TemplateDto>("post", BASE, { data: payload }),
+
+  update: (templateId: number, payload: TemplateRequest) =>
+    apiRequest<TemplateDto>("put", `${BASE}/${templateId}`, { data: payload }),
+
+  delete: (templateId: number) =>
+    apiRequest<void>("delete", `${BASE}/${templateId}`),
+
+  renderBody: (templateId: number, model: Record<string, unknown> = {}) =>
+    apiRequest<string>("post", `${BASE}/${templateId}/render/body`, { data: model }),
+
+  renderSubject: (templateId: number, model: Record<string, unknown> = {}) =>
+    apiRequest<string>("post", `${BASE}/${templateId}/render/subject`, { data: model }),
+};

--- a/src/react/pages/templates/queryKeys.ts
+++ b/src/react/pages/templates/queryKeys.ts
@@ -1,0 +1,3 @@
+import { createQueryKeys } from "@/react/query/keys";
+
+export const templatesQueryKeys = createQueryKeys("templates");

--- a/src/react/router/AdminRoutes.tsx
+++ b/src/react/router/AdminRoutes.tsx
@@ -1,12 +1,18 @@
 import { Route, Routes } from "react-router-dom";
 import { GroupsPage, RolesPage, UsersPage } from "@/react/pages/admin";
+import { GroupDetailPage } from "@/react/pages/admin/groups/GroupDetailPage";
+import { RoleDetailPage } from "@/react/pages/admin/roles/RoleDetailPage";
+import { UserDetailPage } from "@/react/pages/admin/users/UserDetailPage";
 
 export function AdminRoutes() {
   return (
     <Routes>
       <Route path="users" element={<UsersPage />} />
+      <Route path="users/:userId" element={<UserDetailPage />} />
       <Route path="groups" element={<GroupsPage />} />
+      <Route path="groups/:groupId" element={<GroupDetailPage />} />
       <Route path="roles" element={<RolesPage />} />
+      <Route path="roles/:roleId" element={<RoleDetailPage />} />
     </Routes>
   );
 }

--- a/src/react/router/AppRouter.tsx
+++ b/src/react/router/AppRouter.tsx
@@ -7,10 +7,16 @@ import { ForumListPage } from "@/react/pages/community/ForumListPage";
 import { ForumTopicDetailPage } from "@/react/pages/community/ForumTopicDetailPage";
 import { ForumTopicListPage } from "@/react/pages/community/ForumTopicListPage";
 import { DashboardPage } from "@/react/pages/DashboardPage";
+import { DocumentListPage } from "@/react/pages/documents/DocumentListPage";
 import { DocumentEditorPage } from "@/react/pages/documents/DocumentEditorPage";
 import { FilesPage } from "@/react/pages/files/FilesPage";
 import { LoginPage } from "@/react/pages/LoginPage";
 import { NotFoundPage } from "@/react/pages/NotFoundPage";
+import { ObjectTypeDetailPage } from "@/react/pages/objecttype/ObjectTypeDetailPage";
+import { ObjectTypeListPage } from "@/react/pages/objecttype/ObjectTypeListPage";
+import { MyProfilePage } from "@/react/pages/profile/MyProfilePage";
+import { TemplateDetailsPage } from "@/react/pages/templates/TemplateDetailsPage";
+import { TemplatesPage } from "@/react/pages/templates/TemplatesPage";
 import { UnauthorizedPage } from "@/react/pages/UnauthorizedPage";
 import { AdminRoutes } from "@/react/router/AdminRoutes";
 
@@ -35,10 +41,22 @@ export function AppRouter() {
       <Route element={<ProtectedRoute />}>
         <Route element={<FullLayout />}>
           <Route index element={<DashboardPage />} />
+          <Route path="profile" element={<MyProfilePage />} />
           <Route path="application/files" element={<FilesPage />} />
+          <Route path="application/documents" element={<DocumentListPage />} />
           <Route
             path="application/documents/:documentId"
             element={<DocumentEditorPage />}
+          />
+          <Route path="application/templates" element={<TemplatesPage />} />
+          <Route
+            path="application/templates/:templateId"
+            element={<TemplateDetailsPage />}
+          />
+          <Route path="policy/object-types" element={<ObjectTypeListPage />} />
+          <Route
+            path="policy/object-types/:objectTypeId"
+            element={<ObjectTypeDetailPage />}
           />
           {/* Admin and Security Pages */}
           <Route path="admin/*" element={<AdminRoutes />} />


### PR DESCRIPTION
## Related Issue
- Closes #28
- Closes #29
- Closes #30
- Closes #31
- Closes #32
- Closes #33
- Closes #34
- Related umbrella: #27

## Why
Track A and Track B implementation files existed in progress, but the active React router still did not expose the pages, so the admin detail/profile flows and content management pages were not reachable in `2.x`.

## What
- add Track A routes for `/profile`, `/admin/users/:userId`, `/admin/groups/:groupId`, `/admin/roles/:roleId`
- add Track B routes for documents list, templates list/detail, and object type list/detail
- wire Track A pages for profile, user/group/role detail, roles/group membership dialogs, and password reset flows
- wire Track B pages for document list/create, template list/detail/preview/create, object type list/detail, and file detail dialog access from `FilesPage`
- extract document/template dialogs into feature-local files to match the migration plan structure

## Validation
- [x] build
- [x] test
- [ ] manual verification
- [ ] analysis only (no code change)

Validation command:
- `npm run build`

## Checklist
- [x] working branch used or direct main change justified
- [x] commit message rule followed
- [x] issue template used and `AI-Assisted` value checked (`Yes`/`No` single selection, AI-used issue must be `Yes`)
- [x] no unrelated changes included
- [ ] documentation updated if needed
- [ ] changelog updated if needed
- [x] AI-assisted change reviewed by human

## AI-Assisted
- [x] Yes
- [ ] No
