### PR TITLE
feat(audit-pages): implement issue #36

### DIFF
--- a/src/react/pages/audit/LoginFailureLogPage.tsx
+++ b/src/react/pages/audit/LoginFailureLogPage.tsx
@@ -1,0 +1,55 @@
+import { useMemo, useRef } from "react";
+import {
+  Box,
+  Breadcrumbs,
+  Stack,
+  Typography,
+} from "@mui/material";
+import type { ColDef } from "ag-grid-community";
+import { PageableGridContent } from "@/react/components/ag-grid";
+import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
+import { LoginFailuresDataSource } from "@/react/pages/audit/LoginFailuresDataSource";
+import type { LoginFailureEvent } from "@/react/pages/audit/loginFailuresApi";
+
+export function LoginFailureLogPage() {
+  const gridRef = useRef<PageableGridContentHandle<LoginFailureEvent>>(null);
+  const dataSource = useMemo(() => new LoginFailuresDataSource(), []);
+
+  const columnDefs = useMemo<ColDef<LoginFailureEvent>[]>(
+    () => [
+      { field: "id", headerName: "ID", sortable: true, flex: 0.5 },
+      { field: "username", headerName: "사용자명", sortable: true, flex: 1 },
+      { field: "ipAddress", headerName: "IP 주소", sortable: true, flex: 1 },
+      { field: "reason", headerName: "실패 사유", sortable: true, flex: 2 },
+      {
+        field: "timestamp",
+        headerName: "시각",
+        sortable: true,
+        flex: 1.5,
+        valueFormatter: (params) =>
+          params.value ? new Date(params.value).toLocaleString() : "",
+      },
+    ],
+    []
+  );
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">시스템관리</Typography>
+        <Typography color="text.secondary">감사</Typography>
+        <Typography color="text.primary">로그인 실패</Typography>
+      </Breadcrumbs>
+
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">로그인 실패 로그</Typography>
+      </Box>
+
+      <PageableGridContent<LoginFailureEvent>
+        ref={gridRef}
+        datasource={dataSource}
+        columns={columnDefs}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/audit/LoginFailureLogPage.tsx
+++ b/src/react/pages/audit/LoginFailureLogPage.tsx
@@ -2,9 +2,13 @@ import { useMemo, useRef } from "react";
 import {
   Box,
   Breadcrumbs,
+  Button,
   Stack,
   Typography,
 } from "@mui/material";
+import {
+  RefreshOutlined,
+} from "@mui/icons-material";
 import type { ColDef } from "ag-grid-community";
 import { PageableGridContent } from "@/react/components/ag-grid";
 import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
@@ -33,6 +37,10 @@ export function LoginFailureLogPage() {
     []
   );
 
+  const handleRefresh = () => {
+    gridRef.current?.refresh();
+  };
+
   return (
     <Stack spacing={2}>
       <Breadcrumbs separator="›">
@@ -43,6 +51,15 @@ export function LoginFailureLogPage() {
 
       <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <Typography variant="h5">로그인 실패 로그</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant="text"
+            startIcon={<RefreshOutlined />}
+            onClick={handleRefresh}
+          >
+            새로고침
+          </Button>
+        </Stack>
       </Box>
 
       <PageableGridContent<LoginFailureEvent>

--- a/src/react/pages/audit/LoginFailuresDataSource.ts
+++ b/src/react/pages/audit/LoginFailuresDataSource.ts
@@ -1,0 +1,8 @@
+import { ReactPageDataSource } from "@/react/pages/admin/datasource";
+import type { LoginFailureEvent } from "@/react/pages/audit/loginFailuresApi";
+
+export class LoginFailuresDataSource extends ReactPageDataSource<LoginFailureEvent> {
+  constructor() {
+    super("/api/mgmt/audit/login-failures");
+  }
+}

--- a/src/react/pages/audit/loginFailuresApi.ts
+++ b/src/react/pages/audit/loginFailuresApi.ts
@@ -1,0 +1,16 @@
+import { apiQuery } from "@/react/query/fetcher";
+import type { PageResponse } from "@/types/studio/api-common";
+
+export interface LoginFailureEvent {
+  id: string;
+  timestamp: string;
+  username: string;
+  ipAddress: string;
+  reason: string;
+}
+
+export const loginFailuresApi = {
+  getLoginFailureEvents: (page: number, size: number) => {
+    return apiQuery<PageResponse<LoginFailureEvent>>(`/api/mgmt/audit/login-failures?page=${page}&size=${size}`);
+  },
+};

--- a/src/react/pages/audit/loginFailuresApi.ts
+++ b/src/react/pages/audit/loginFailuresApi.ts
@@ -1,4 +1,3 @@
-import { apiQuery } from "@/react/query/fetcher";
 import type { PageResponse } from "@/types/studio/api-common";
 
 export interface LoginFailureEvent {
@@ -8,9 +7,3 @@ export interface LoginFailureEvent {
   ipAddress: string;
   reason: string;
 }
-
-export const loginFailuresApi = {
-  getLoginFailureEvents: (page: number, size: number) => {
-    return apiQuery<PageResponse<LoginFailureEvent>>(`/api/mgmt/audit/login-failures?page=${page}&size=${size}`);
-  },
-};

--- a/src/react/pages/audit/loginFailuresKeys.ts
+++ b/src/react/pages/audit/loginFailuresKeys.ts
@@ -1,0 +1,3 @@
+import { createQueryKeys } from "@/react/query/keys";
+
+export const loginFailuresQueryKeys = createQueryKeys("loginFailuresAudit");

--- a/src/react/pages/forums/admin/ForumAuditDataSource.ts
+++ b/src/react/pages/forums/admin/ForumAuditDataSource.ts
@@ -1,0 +1,8 @@
+import { ReactPageDataSource } from "@/react/pages/admin/datasource";
+import type { ForumAuditEvent } from "@/react/pages/forums/admin/auditApi";
+
+export class ForumAuditDataSource extends ReactPageDataSource<ForumAuditEvent> {
+  constructor(forumSlug: string) {
+    super(`/api/mgmt/forums/${encodeURIComponent(forumSlug)}/audit`);
+  }
+}

--- a/src/react/pages/forums/admin/ForumAuditLogPage.tsx
+++ b/src/react/pages/forums/admin/ForumAuditLogPage.tsx
@@ -1,0 +1,92 @@
+import { useMemo, useRef } from "react";
+import { useParams } from "react-router-dom";
+import {
+  Alert,
+  Box,
+  Breadcrumbs,
+  Stack,
+  Typography,
+} from "@mui/material";
+import type { ColDef } from "ag-grid-community";
+import { PageableGridContent } from "@/react/components/ag-grid";
+import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
+import { ForumAuditDataSource } from "@/react/pages/forums/admin/ForumAuditDataSource";
+import type { ForumAuditEvent } from "@/react/pages/forums/admin/auditApi";
+
+export function ForumAuditLogPage() {
+  const { forumSlug } = useParams<{ forumSlug: string }>();
+
+  const gridRef = useRef<PageableGridContentHandle<ForumAuditEvent>>(null);
+  const dataSource = useMemo(() => {
+    if (!forumSlug) {
+      return null;
+    }
+    return new ForumAuditDataSource(forumSlug);
+  }, [forumSlug]);
+
+  const columnDefs = useMemo<ColDef<ForumAuditEvent>[]>(
+    () => [
+      { field: "id", headerName: "ID", sortable: true, flex: 0.5 },
+      { field: "actor", headerName: "행위자", sortable: true, flex: 1 },
+      { field: "action", headerName: "액션", sortable: true, flex: 1.5 },
+      {
+        field: "details",
+        headerName: "세부 정보",
+        flex: 2,
+        cellRenderer: (params) => (
+          <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+            {JSON.stringify(params.value)}
+          </Typography>
+        ),
+      },
+      {
+        field: "timestamp",
+        headerName: "시각",
+        sortable: true,
+        flex: 1.5,
+        valueFormatter: (params) =>
+          params.value ? new Date(params.value).toLocaleString() : "",
+      },
+    ],
+    []
+  );
+
+  if (!forumSlug) {
+    return (
+      <Stack spacing={2}>
+        <Alert severity="error">
+          URL에서 포럼 슬러그를 찾을 수 없습니다.
+        </Alert>
+      </Stack>
+    );
+  }
+
+  // Handle case where dataSource might be null initially
+  if (!dataSource) {
+    return (
+      <Stack spacing={2}>
+        <Typography>데이터 소스 초기화 중...</Typography>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">어드민</Typography>
+        <Typography color="text.secondary">포럼</Typography>
+        <Typography color="text.primary">{forumSlug} 감사 로그</Typography>
+      </Breadcrumbs>
+
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">{forumSlug} 포럼 감사 로그</Typography>
+      </Box>
+
+      <PageableGridContent<ForumAuditEvent>
+        ref={gridRef}
+        datasource={dataSource}
+        columns={columnDefs}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/forums/admin/auditApi.ts
+++ b/src/react/pages/forums/admin/auditApi.ts
@@ -1,4 +1,3 @@
-import { apiQuery } from "@/react/query/fetcher";
 import type { PageResponse } from "@/types/studio/api-common";
 
 export interface ForumAuditEvent {
@@ -9,10 +8,3 @@ export interface ForumAuditEvent {
   details: Record<string, unknown>;
   forumSlug: string;
 }
-
-export const forumAuditApi = {
-  getForumAuditEvents: (forumSlug: string, page: number, size: number) => {
-    const encodedForumSlug = encodeURIComponent(forumSlug);
-    return apiQuery<PageResponse<ForumAuditEvent>>(`/api/mgmt/forums/${encodedForumSlug}/audit?page=${page}&size=${size}`);
-  },
-};

--- a/src/react/pages/forums/admin/auditApi.ts
+++ b/src/react/pages/forums/admin/auditApi.ts
@@ -1,0 +1,18 @@
+import { apiQuery } from "@/react/query/fetcher";
+import type { PageResponse } from "@/types/studio/api-common";
+
+export interface ForumAuditEvent {
+  id: string;
+  timestamp: string;
+  actor: string;
+  action: string;
+  details: Record<string, unknown>;
+  forumSlug: string;
+}
+
+export const forumAuditApi = {
+  getForumAuditEvents: (forumSlug: string, page: number, size: number) => {
+    const encodedForumSlug = encodeURIComponent(forumSlug);
+    return apiQuery<PageResponse<ForumAuditEvent>>(`/api/mgmt/forums/${encodedForumSlug}/audit?page=${page}&size=${size}`);
+  },
+};

--- a/src/react/pages/forums/admin/auditKeys.ts
+++ b/src/react/pages/forums/admin/auditKeys.ts
@@ -1,0 +1,3 @@
+import { createQueryKeys } from "@/react/query/keys";
+
+export const forumAuditQueryKeys = createQueryKeys("forumAudit");

--- a/src/react/router/AdminRoutes.tsx
+++ b/src/react/router/AdminRoutes.tsx
@@ -3,6 +3,8 @@ import { GroupsPage, RolesPage, UsersPage } from "@/react/pages/admin";
 import { GroupDetailPage } from "@/react/pages/admin/groups/GroupDetailPage";
 import { RoleDetailPage } from "@/react/pages/admin/roles/RoleDetailPage";
 import { UserDetailPage } from "@/react/pages/admin/users/UserDetailPage";
+import { LoginFailureLogPage } from "@/react/pages/audit/LoginFailureLogPage";
+import { ForumAuditLogPage } from "@/react/pages/forums/admin/ForumAuditLogPage";
 
 export function AdminRoutes() {
   return (
@@ -13,6 +15,8 @@ export function AdminRoutes() {
       <Route path="groups/:groupId" element={<GroupDetailPage />} />
       <Route path="roles" element={<RolesPage />} />
       <Route path="roles/:roleId" element={<RoleDetailPage />} />
+      <Route path="audit/login-failures" element={<LoginFailureLogPage />} />
+      <Route path="forums/:forumSlug/audit" element={<ForumAuditLogPage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Related Issue
- Closes #36
- Related umbrella: #27

## Why
Track C audit pages were still missing after Track A and B were merged. The React runtime needed working admin audit routes for login failure logs and forum audit logs.

## What
- add `LoginFailureLogPage` for `/admin/audit/login-failures`
- add `ForumAuditLogPage` for `/admin/forums/:forumSlug/audit`
- add feature-local audit API/query-key files for login failures and forum audit logs
- register the audit routes in `AdminRoutes.tsx`

## Validation
- [x] build
- [ ] test
- [ ] manual verification
- [ ] analysis only (no code change)

Validation command:
- `npm run build`

## Checklist
- [x] working branch used or direct main change justified
- [x] commit message rule followed
- [x] issue template used and `AI-Assisted` value checked (`Yes`/`No` single selection, AI-used issue must be `Yes`)
- [x] no unrelated changes included
- [ ] documentation updated if needed
- [ ] changelog updated if needed
- [ ] AI-assisted change reviewed by human

## AI-Assisted
- [x] Yes
- [ ] No
