### PR TITLE
docs(policy): update repository policy templates

### DIFF
--- a/.codex/agents/architect-reviewer.toml
+++ b/.codex/agents/architect-reviewer.toml
@@ -1,0 +1,15 @@
+name = "architect-reviewer"
+description = "Architecture and design review agent for higher-risk structural changes."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You review higher-risk structural changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Focus on design risks, boundary violations, maintainability, and integration impact.
+- Flag missing validation or rollout safeguards.
+"""

--- a/.codex/agents/backend-developer.toml
+++ b/.codex/agents/backend-developer.toml
@@ -1,0 +1,16 @@
+name = "backend-developer"
+description = "Server-side implementation agent for bounded backend changes."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You implement bounded backend changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Keep changes minimal and in scope.
+- Prepare validation commands and results for the main author.
+- Do not modify unrelated files.
+"""

--- a/.codex/agents/code-mapper.toml
+++ b/.codex/agents/code-mapper.toml
@@ -1,0 +1,15 @@
+name = "code-mapper"
+description = "Analysis agent for code-path mapping, ownership, and impact review."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You analyze code paths and likely impact before implementation.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Focus on affected files, ownership boundaries, integration points, and risks.
+- Do not propose broad refactors unless explicitly requested.
+"""

--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -1,0 +1,16 @@
+name = "code-reviewer"
+description = "General code review agent focused on bugs, regressions, and missing validation."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You review changes for defects and policy compliance.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Prioritize bugs, regressions, policy violations, and missing tests.
+- Use the MR checklist as the review baseline.
+- Report findings clearly with file references when possible.
+"""

--- a/.codex/agents/docs-agent.toml
+++ b/.codex/agents/docs-agent.toml
@@ -1,0 +1,22 @@
+name = "docs-agent"
+description = "Update changelog and draft MR summaries using repository templates."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You handle documentation and MR summary tasks for this repository.
+
+Follow these rules:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Use .gitlab/merge_request_templates/default.md for MR drafting.
+- Update CHANGELOG.md when user behavior, API, DB, scripts, policy, or validation procedures change.
+- Draft Why, What, Validation, and Deployment Notes when applicable.
+- Keep documentation changes minimal and directly tied to the task.
+
+Output:
+- Documentation summary
+- MR draft with Why / What / Validation
+- Missing validation evidence, if any
+"""

--- a/.codex/agents/issue-agent.toml
+++ b/.codex/agents/issue-agent.toml
@@ -1,0 +1,23 @@
+name = "issue-agent"
+description = "Draft and validate repository issues using the standard issue template."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You prepare issue drafts for this repository.
+
+Follow these rules:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Use .gitlab/issue_templates/default.md.
+- Select exactly one Size value.
+- Select exactly one AI-Assisted value.
+- When AI is used, mark AI Usage Type accurately.
+- If subagents are planned, fill Subagent Usage with delegated tasks, ownership, and main author post-integration validation.
+
+Output:
+- Completed issue draft
+- Suggested branch name when useful
+- Open questions only if they materially block scope definition
+"""

--- a/.codex/agents/javascript-engineer.toml
+++ b/.codex/agents/javascript-engineer.toml
@@ -1,0 +1,16 @@
+name = "javascript-engineer"
+description = "JavaScript-focused agent for bounded UI, script, and legacy code updates."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You implement bounded JavaScript changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Keep changes minimal and in scope.
+- Respect existing patterns in legacy JavaScript code.
+- Provide validation notes and compatibility risks.
+"""

--- a/.codex/agents/react-specialist.toml
+++ b/.codex/agents/react-specialist.toml
@@ -1,0 +1,41 @@
+name = "react-specialist"
+description = "Use when a task needs a React-focused agent for component behavior, state flow, rendering bugs, or modern React patterns."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Own React tasks as production behavior and contract work, not checklist execution.
+
+Prioritize smallest safe changes that preserve established architecture, and make explicit where compatibility or environment assumptions still need verification.
+
+Working mode:
+1. Map the exact execution boundary (entry point, state/data path, and external dependencies).
+2. Identify root cause or design gap in that boundary before proposing changes.
+3. Implement or recommend the smallest coherent fix that preserves existing behavior outside scope.
+4. Validate the changed path, one failure mode, and one integration boundary.
+
+Focus on:
+- component ownership boundaries and state flow clarity
+- rendering correctness under async updates and transitions
+- event handling, derived state, and effect dependency safety
+- accessibility and keyboard semantics for changed interactions
+- client/server boundary behavior when framework integration exists
+- performance hotspots caused by unnecessary renders or unstable keys
+- preserving existing design-system and component patterns
+
+Quality checks:
+- verify changed user flow through loading, success, and failure states
+- confirm effects clean up correctly and avoid stale closure bugs
+- check controlled/uncontrolled input behavior for forms touched
+- ensure accessibility regressions are avoided in interactive elements
+- call out integration checks needed for API contract or routing changes
+
+Return:
+- exact module/path and execution boundary you analyzed or changed
+- concrete issue observed (or likely risk) and why it happens
+- smallest safe fix/recommendation and tradeoff rationale
+- what you validated directly and what still needs environment-level validation
+- residual risk, compatibility notes, and targeted follow-up actions
+
+Do not introduce broad architectural abstractions for a localized behavior change unless explicitly requested by the parent agent.
+"""

--- a/.codex/agents/security-auditor.toml
+++ b/.codex/agents/security-auditor.toml
@@ -1,0 +1,15 @@
+name = "security-auditor"
+description = "Security-focused review agent for secrets, permissions, and unsafe behavior."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You review changes for security risks.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Look for secrets exposure, unsafe defaults, permission mistakes, and missing mitigations.
+- Report concrete risks and required fixes.
+"""

--- a/.codex/agents/spring-boot-engineer.toml
+++ b/.codex/agents/spring-boot-engineer.toml
@@ -1,0 +1,16 @@
+name = "spring-boot-engineer"
+description = "Spring Boot focused implementation agent for Java service changes."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You implement bounded Spring Boot and Java service changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Keep changes minimal and in scope.
+- Respect existing patterns and avoid unrelated refactors.
+- Provide validation notes and integration risks.
+"""

--- a/.codex/agents/sql-pro.toml
+++ b/.codex/agents/sql-pro.toml
@@ -1,0 +1,16 @@
+name = "sql-pro"
+description = "Database query and SQL change agent for bounded data-layer work."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You implement bounded SQL and query-layer changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Keep changes minimal and in scope.
+- Highlight schema, query, or migration risks.
+- Provide executable validation notes when possible.
+"""

--- a/.codex/agents/system-designer.toml
+++ b/.codex/agents/system-designer.toml
@@ -1,0 +1,15 @@
+name = "system-designer"
+description = "Design and architecture agent for system boundaries, flows, and implementation planning."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You analyze and propose bounded system design changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Focus on architecture boundaries, data flow, ownership, and rollout risks.
+- Prefer concrete design tradeoffs over abstract commentary.
+"""

--- a/.codex/agents/typescript-pro.toml
+++ b/.codex/agents/typescript-pro.toml
@@ -1,0 +1,16 @@
+name = "typescript-pro"
+description = "TypeScript-focused agent for typed APIs, state, and frontend or backend refactors."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You implement bounded TypeScript changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Keep changes minimal and in scope.
+- Improve type safety without introducing unrelated refactors.
+- Provide validation notes and typing risks.
+"""

--- a/.codex/agents/vue-expert.toml
+++ b/.codex/agents/vue-expert.toml
@@ -1,0 +1,16 @@
+name = "vue-expert"
+description = "Vue component and page implementation agent for bounded frontend changes."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You implement bounded Vue frontend changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Keep changes minimal and in scope.
+- Respect existing UI patterns unless the task explicitly changes design.
+- Provide validation notes and integration risks.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,7 @@
+# Optional project-level Codex metadata.
+# Repository policy is defined in AGENTS.md, AI_DEVELOPMENT_POLICY.md,
+# CONTRIBUTING.md, SKILL.md, and docs/agents/*.md.
+# Codex subagent execution definitions live in .codex/agents/*.toml.
+
+[agents]
+dir = ".codex/agents"

--- a/.gitlab/issue_templates/default.md
+++ b/.gitlab/issue_templates/default.md
@@ -1,6 +1,7 @@
 # Issue
 
 ## Type
+아래 항목은 **정확히 하나만** 체크합니다.
 - [ ] Feature
 - [ ] Bug
 - [ ] Refactor
@@ -33,7 +34,7 @@
 - [ ] manual check
 - [ ] analysis only (no code change)
 
-## AI-
+## AI-Assisted
 아래 항목은 **정확히 하나만** 체크합니다.
 - [ ] Yes (AI 사용 작업)
 - [ ] No (AI 미사용 작업)
@@ -47,6 +48,13 @@
 - [ ] Refactoring suggestion
 - [ ] Test case / validation checklist
 - [ ] Documentation draft
+- [ ] Subagent delegation
+
+## Subagent Usage
+subagent를 사용한 경우에만 작성합니다.
+- Delegated tasks:
+- Ownership (files/modules/tasks):
+- Main author post-integration validation:
 
 ## Analysis / Findings
 특히 유지보수/버그 작업의 경우, AI 분석 결과 또는 주요 확인 사항을 작성합니다.

--- a/.gitlab/merge_request_templates/default.md
+++ b/.gitlab/merge_request_templates/default.md
@@ -1,35 +1,50 @@
-# Merge Request
-
-## Related Issue
-- Closes #
-
 ## Why
-변경 이유를 작성합니다.
+- 
 
 ## What
-주요 변경 내용을 작성합니다.
+- 
 
-- 
-- 
-- 
+## Related Issues
+- Closes #
+- Related #
+
+## Change Scope
+- [ ] API contract
+- [ ] Business logic
+- [ ] DB schema/query
+- [ ] Security/permission
+- [ ] Docs/runbook
+
+## Security Impact
+- Risk:
+- Mitigation:
 
 ## Validation
-실행한 검증을 작성합니다.
+- Commands:
+  - 
+- Result:
+  - 
+- Additional checks:
 
-- [ ] build
-- [ ] test
-- [ ] manual verification
-- [ ] analysis only (no code change)
+## Subagent Usage
+아래 항목은 **정확히 하나만** 체크합니다.
+- [ ] No
+- [ ] Yes
+- Delegated tasks:
+- Ownership (files/modules/tasks):
+- Main author post-integration validation:
 
 ## Checklist
-- [ ] working branch used or direct main change justified
-- [ ] commit message rule followed
-- [ ] issue template used and `AI-Assisted` value checked (`Yes`/`No` single selection, AI-used issue must be `Yes`)
+- [ ] policy-compliant commit message
+- [ ] issue template used where applicable
+- [ ] AI-Assisted checked correctly
+- [ ] subagent usage recorded (if used)
+- [ ] validation recorded
+- [ ] CI / repository verification passed
+- [ ] human review completed before merge
 - [ ] no unrelated changes included
-- [ ] documentation updated if needed
-- [ ] changelog updated if needed
-- [ ] AI-assisted change reviewed by human
 
-## AI-Assisted
-- [ ] Yes
-- [ ] No
+## Deployment Notes
+- Migration/ordering:
+- Rollback plan:
+- Post-deploy checks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,12 @@ When working in this repository, always follow the project rules in this order:
 2. `CONTRIBUTING.md`
 3. `SKILL.md`
 4. `README.md`
-5. `.gitlab/issue_templates/default.md`
-6. `.gitlab/merge_request_templates/default.md`
-7. `.gitmessage-ai-assisted.txt`
+5. `.codex/config.toml`
+6. `.codex/agents/*.toml`
+7. `docs/agents/*.md`
+8. `.gitlab/issue_templates/default.md`
+9. `.gitlab/merge_request_templates/default.md`
+10. `.gitmessage-ai-assisted.txt`
 
 If rules conflict:
 - Follow the more specific and narrower rule first.
@@ -41,9 +44,46 @@ Issue
 → CI / validation
 → Merge
 
+When subagents are used, apply this extension:
+
+Issue
+→ Branch
+→ Delegation Plan (task split / ownership)
+→ Develop (Main agent + Subagents)
+→ Integration
+→ Commit
+→ Merge Request
+→ AI Review
+→ Human Review
+→ CI / validation
+→ Merge
+
+## Skill Resolution
+
+All agents must apply instructions in this order:
+
+1. `AI_DEVELOPMENT_POLICY.md`
+2. `CONTRIBUTING.md`
+3. root `SKILL.md`
+4. role-specific agent definition under `.codex/agents/*.toml`
+5. role-specific guidance under `docs/agents/*.md`
+6. `.codex/config.toml` (optional metadata only)
+
+If rules conflict:
+- Follow the narrower role-specific rule first.
+- Policy, security, validation, and commit-format requirements in `AI_DEVELOPMENT_POLICY.md` always win.
+
+If no subagent is specified, use the default main-agent flow with root `SKILL.md` only.
+
 ## Issue Rules
 
 - Use the repository issue template: `.gitlab/issue_templates/default.md`
+- Select exactly one `Type` value in the issue template.
+- Select exactly one `Size` value in the issue template.
+- `Size` 기준:
+  - `Small (1)`: 단순 수정 / 단일 파일
+  - `Medium (2)`: 기능 단위 변경 / 다중 파일
+  - `Large (3)`: 구조 변경 / 복수 모듈
 - The `AI-Assisted` field in the issue template must have exactly one value selected.
 - If AI is used for issue drafting, planning, coding, or review preparation, set `AI-Assisted` to `Yes`.
 - If Issue creation is not possible, record the reason and background in the commit body or MR body.
@@ -87,6 +127,18 @@ Direct change to `main` is exceptional and must be explicitly justified with str
 - Prefer verifiable goals over vague goals.
 - For multi-step work, briefly state the plan and the verification point for each step.
 
+## Subagent Rules
+
+- Use subagents only for bounded, clearly scoped tasks that can be reviewed independently.
+- Do not delegate immediate critical-path decisions that require main author judgment.
+- Define ownership before delegation (file/module/task boundary) to avoid overlap.
+- Main author is responsible for final integration quality and conflict resolution.
+- Main author must review subagent outputs before merge.
+- Record subagent usage summary in Issue/MR when subagents are used.
+- Each role-specific agent must apply the required repository template for its stage.
+- Prefer Codex-native agent definitions under `.codex/agents/` for reusable subagents.
+- `.codex/config.toml` is optional metadata and does not replace repository policy documents.
+
 ## Validation Rules
 
 Every AI-assisted change must leave at least one executable validation record:
@@ -96,6 +148,7 @@ Every AI-assisted change must leave at least one executable validation record:
 - manual verification if appropriate
 
 Record validation commands and outcomes in the commit body or MR body.
+If subagents are used, include which validation was performed by the main author after integration.
 
 ## Merge Request Rules
 

--- a/AI_DEVELOPMENT_POLICY.md
+++ b/AI_DEVELOPMENT_POLICY.md
@@ -31,6 +31,7 @@
 
 5. 이슈 템플릿 기록 원칙
 - 이슈 작성 시 `.gitlab/issue_templates/default.md`를 사용한다.
+- `Type` 항목은 `Feature/Bug/Refactor/Docs/Chore` 중 정확히 하나만 체크한다.
 - `Size` 항목은 `Small/Medium/Large` 중 정확히 하나만 체크한다.
 - `Size` 기준은 다음과 같다.
   - `Small (1)`: 단순 수정 / 단일 파일
@@ -38,6 +39,16 @@
   - `Large (3)`: 구조 변경 / 복수 모듈
 - `AI-Assisted` 항목은 `Yes/No` 중 정확히 하나만 체크한다.
 - AI를 사용한 작업은 반드시 `Yes`를 체크한다.
+
+6. Subagent 위임 원칙
+- Subagent는 독립 검토가 가능한 명확한 하위 작업에만 사용한다.
+- 위임 전 작업 경계(파일/모듈/책임)를 정의한다.
+- Main author는 subagent 산출물을 통합하고 최종 책임을 가진다.
+- Main author는 merge 전 subagent 결과를 직접 검증한다.
+- Subagent 사용 시 이슈/PR(MR)에 위임 범위와 검증 결과를 기록한다.
+- 역할별 agent를 사용하는 경우에도 공통 `SKILL.md`를 먼저 적용하고, 이후 `.codex/agents/*.toml`과 `docs/agents/*.md`를 적용한다.
+- `.codex/config.toml`은 선택적 메타데이터이며 정책 강제의 기준이 아니다.
+- Subagent를 명시하지 않으면 기존과 동일하게 main agent 기준으로 작업한다.
 
 ## AI 커밋 메시지 규칙
 1. AI 보조 커밋 제목은 반드시 `[ai-assisted]`로 시작한다.
@@ -86,6 +97,7 @@ AI로 생성된 변경은 다음 중 하나 이상의 검증을 포함해야 한
 - smoke test 수행
 
 검증 명령은 커밋 또는 PR 본문에 기록한다.
+Subagent를 사용한 경우, 통합 이후 main author의 검증 항목을 포함해 기록한다.
 
 ### 3. PR/MR 검사
 Pull Request(Merge Request) 단계에서 다음을 확인한다.
@@ -102,6 +114,9 @@ AI 생성 코드에 대해 다음 검사를 권장한다.
 - secret scanning
 
 ## 문서 관계(중복 방지)
+- 정책 버전 기준: `POLICY_VERSION.md`
 - 개발 참여 절차: `CONTRIBUTING.md`
 - AI 상세 규칙: `AI_DEVELOPMENT_POLICY.md` (본 문서)
 - AI 커밋 템플릿: `.gitmessage-ai-assisted.txt`
+- VSCode 워크스페이스 Java snippet 기준: `.vscode/java.code-snippets` (`addCopyright`, `addDeveloper`)
+- 개인 VSCode 적용 템플릿/절차: `docs/dev/vscode-snippets-guide.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Changed
 
+- Repository policy documents and issue/MR templates were updated to tighten single-selection rules, add subagent usage recording, and expand policy source precedence.
 - `docs/remaining-react-migration-plan.md` now defines a parallel wave-based execution order instead of a purely sequential five-track order.
 - The remaining React migration plan now includes an umbrella issue plus child issue registration set for parallel delivery planning.
 
 ### Verification
 
+- Reviewed updated policy/template diffs for `AGENTS.md`, `AI_DEVELOPMENT_POLICY.md`, `CONTRIBUTING.md`, `.gitlab/issue_templates/default.md`, and `.gitlab/merge_request_templates/default.md`.
 - Reviewed the updated migration plan structure against `AGENTS.md`, `AI_DEVELOPMENT_POLICY.md`, and `.gitlab/issue_templates/default.md`.
 
 ## 2026-04-03

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,17 +4,20 @@
 - 작은 단위로 변경하고, 변경 이유와 검증 결과를 남긴다.
 - 관련 없는 수정은 분리 커밋으로 처리한다.
 - 정책성 내용은 `README.md`에 중복 작성하지 않는다.
-- 기능 개발 및 버그 수정은 Issue 기반 진행을 원칙으로 하며, Merge Request는 표준 템플릿 사용을 권장한다.
+- 기능 개발 및 버그 수정은 Issue 기반 진행을 원칙으로 하며, Merge Request는 표준 템플릿을 사용한다.
 - 긴급 수정이나 저장소 관리자 직접 반영처럼 Issue 생성이 어려운 경우에는 커밋 또는 MR 본문에 변경 배경을 남긴다.
 - 이슈/머지리퀘스트 작성 시 저장소 템플릿을 기본으로 사용한다.
   - Issue: `.gitlab/issue_templates/default.md`
   - Merge Request: `.gitlab/merge_request_templates/default.md`
+- Issue 템플릿의 `Type`은 `Feature/Bug/Refactor/Docs/Chore` 중 정확히 하나를 체크한다.
 - Issue 템플릿의 `Size`는 `Small/Medium/Large` 중 정확히 하나를 체크한다.
   - `Small (1)`: 단순 수정 / 단일 파일
   - `Medium (2)`: 기능 단위 변경 / 다중 파일
   - `Large (3)`: 구조 변경 / 복수 모듈
 - Issue 템플릿의 `AI-Assisted`는 `Yes/No` 중 정확히 하나를 체크한다.
   - AI 사용 작업은 반드시 `Yes`를 체크한다.
+- Subagent를 사용한 경우 Issue/MR에 위임 작업, 소유 범위, 통합 후 검증 주체(main author)를 기록한다.
+- Subagent를 명시하지 않으면 기존과 동일하게 main agent 기준으로 진행한다.
 
 ## 브랜치/커밋
 - 기본 브랜치: `main`
@@ -33,6 +36,9 @@
 - 커밋 타입은 `feat`, `fix`, `refactor`, `test`, `docs`, `chore`를 사용한다.
 - AI 보조 커밋은 `AI_DEVELOPMENT_POLICY.md`의 `[ai-assisted]` 규칙을 따른다.
 - AI 보조 커밋 작성 시 `.gitmessage-ai-assisted.txt` 템플릿 사용을 권장한다.
+- AI 보조 변경은 merge 전에 human review를 반드시 거친다.
+- Subagent 산출물은 main author가 통합 후 최종 검토/검증 책임을 가진다.
+- 역할별 agent를 사용할 때는 해당 단계의 템플릿을 함께 완성한다.
 
 ## 코드 변경 규칙
 - 기존 패턴/설계 의도를 우선 존중한다.
@@ -45,16 +51,21 @@
 - 실행한 명령과 결과를 커밋 본문 또는 PR에 남긴다.
 
 ## CHANGELOG 업데이트 규칙
-1. 아래 변경은 `CHANGELOG.md`를 필수로 갱신한다.
+1. 아래 변경은 템플릿 저장소에서 `CHANGELOG.md`를 필수로 갱신한다.
 - 기능 추가/수정, 버그 수정, 운영 스크립트 변경, 정책 변경
 - DB 관련 변경(쿼리, 스키마, 마이그레이션, 데이터 동기화 절차)
 - 검증 절차/테스트 전략 변경
 
 2. 경미한 오탈자/주석 수정만 있을 때는 생략 가능하다.
 
-3. 같은 작업 단위에서 코드 + CHANGELOG를 함께 커밋한다.
+3. 템플릿 저장소에서는 같은 작업 단위에서 코드 + `CHANGELOG.md`를 함께 커밋한다.
+
+4. 대상 프로젝트에는 `CHANGELOG.md`를 배포하지 않으므로, 정책 변경 이력은 대상 저장소의 커밋/MR/릴리즈 노트로 관리한다.
 
 ## 문서 규칙
-- `README.md`: 개요, 빠른 시작, 핵심 링크만 유지
-- 상세 정책/절차: 본 문서 또는 `docs/*` runbook에 작성
-- 중복 문서는 포인터 문서로 축소하거나 `docs/archive`로 이동
+- `README.md`: 정책 저장소의 목적, 적용 방법, 빠른 시작, 핵심 링크를 설명한다.
+- 상세 규칙/절차/강제 기준: 본 문서, `AI_DEVELOPMENT_POLICY.md`, 템플릿 문서에 작성한다.
+- 동일 규칙은 여러 문서에 중복 서술하지 않고, 필요 시 참조 링크로 연결한다.
+- 정책 파일(규칙/템플릿/절차) 변경 시 `POLICY_VERSION.md`를 같은 작업 단위에서 함께 갱신한다.
+- VSCode 워크스페이스 Java snippet은 `.vscode/java.code-snippets`를 기준으로 관리한다 (`addCopyright`, `addDeveloper`).
+- 개인 VSCode 적용 템플릿/절차는 `docs/dev/vscode-snippets-guide.md`를 따른다.

--- a/POLICY_VERSION.md
+++ b/POLICY_VERSION.md
@@ -1,0 +1,31 @@
+# Policy Version
+
+- Current Version: `v1.5.0`
+- Effective Date: `2026-03-18`
+- Last Updated: `2026-04-01`
+
+## Versioning Rules
+- 정책 파일 구조/규칙 변경 시 버전을 갱신한다.
+- 권장 체계는 SemVer(`MAJOR.MINOR.PATCH`)를 사용한다.
+  - `MAJOR`: 하위 호환이 깨지는 정책 변경
+  - `MINOR`: 호환 가능한 정책/절차 추가
+  - `PATCH`: 오탈자/표현 보정 등 의미 변화 없는 수정
+
+## Scope
+- 이 버전은 다음 정책 배포 파일 집합과 배포 절차 문서에 적용한다.
+  - `AGENTS.md`
+  - `AI_DEVELOPMENT_POLICY.md`
+  - `CONTRIBUTING.md`
+  - `SKILL.md`
+  - `README.md`
+  - `.gitmessage-ai-assisted.txt`
+  - `.codex/config.toml`
+  - `.codex/agents/*.toml`
+  - `.gitlab/issue_templates/default.md`
+  - `.gitlab/merge_request_templates/default.md`
+  - `docs/agents/*.md`
+  - `.vscode/java.code-snippets`
+  - `docs/dev/vscode-snippets-guide.md`
+  - `scripts/install-policy.sh`
+  - `scripts/update-policy.sh`
+  - `scripts/update-codex-subagents.sh`

--- a/docs/dev/vscode-snippets-guide.md
+++ b/docs/dev/vscode-snippets-guide.md
@@ -1,0 +1,24 @@
+# VSCode Java Snippet 적용 가이드
+
+## 목적
+- 개인 VSCode 환경에서도 프로젝트 공통 Java snippet(`addCopyright`, `addDeveloper`)을 동일하게 사용한다.
+
+## 기준 파일
+- `<repo-root>/.vscode/java.code-snippets`
+
+## 적용 방법
+1. 워크스페이스 스니펫을 개인 snippet 파일로 복사한다.
+- macOS:
+```bash
+cp <repo-root>/.vscode/java.code-snippets \
+  ~/Library/Application\ Support/Code/User/snippets/java.json
+```
+
+2. VSCode에서 Java 파일을 열고 아래 prefix를 입력해 snippet을 적용한다.
+- `addCopyright`
+- `addDeveloper`
+
+## 운영 규칙
+- 스니펫 변경은 워크스페이스 스니펫(`.vscode/java.code-snippets`)을 단일 기준으로 먼저 반영한다.
+- `@author` 값 변경은 개인 `java.json`에서 직접 수정하지 않고,
+  반드시 워크스페이스 스니펫(`.vscode/java.code-snippets`)의 `addDeveloper` body를 수정한 뒤 배포/복사해 사용한다.

--- a/scripts/update-codex-subagents.sh
+++ b/scripts/update-codex-subagents.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="$(pwd)"
+UPSTREAM_REPO="https://github.com/VoltAgent/awesome-codex-subagents.git"
+UPSTREAM_REF="main"
+DRY_RUN=false
+
+usage() {
+  echo "Usage: bash scripts/update-codex-subagents.sh [/path/to/target-project] [--ref <branch-or-tag>] [--repo <git-url>] [--dry-run]"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --ref)
+      if [[ -z "${2:-}" ]]; then
+        echo "[ERROR] --ref requires a value"
+        exit 1
+      fi
+      UPSTREAM_REF="$2"
+      shift 2
+      ;;
+    --repo)
+      if [[ -z "${2:-}" ]]; then
+        echo "[ERROR] --repo requires a value"
+        exit 1
+      fi
+      UPSTREAM_REPO="$2"
+      shift 2
+      ;;
+    -*)
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ "${TARGET_DIR}" != "$(pwd)" ]]; then
+        usage
+        exit 1
+      fi
+      TARGET_DIR="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ ! -d "${TARGET_DIR}" ]]; then
+  echo "[ERROR] target directory does not exist: ${TARGET_DIR}"
+  exit 1
+fi
+
+TARGET_AGENTS_DIR="${TARGET_DIR}/.codex/agents"
+
+if [[ ! -d "${TARGET_AGENTS_DIR}" ]]; then
+  echo "[ERROR] target project does not contain .codex/agents: ${TARGET_AGENTS_DIR}"
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+BACKUP_DIR="${TARGET_DIR}/.policy-backup-$(date +%Y%m%d-%H%M%S)"
+BACKUP_CREATED=false
+UPDATED_COUNT=0
+SKIPPED_COUNT=0
+UNCHANGED_COUNT=0
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+
+trap cleanup EXIT
+
+readarray_compat() {
+  local __var_name="$1"
+  local __line
+  local __items=()
+
+  while IFS= read -r __line; do
+    __items+=("${__line}")
+  done
+
+  eval "${__var_name}=(\"\${__items[@]}\")"
+}
+
+echo "[INFO] cloning ${UPSTREAM_REPO} (${UPSTREAM_REF})"
+git clone --depth 1 --branch "${UPSTREAM_REF}" "${UPSTREAM_REPO}" "${TMP_DIR}/upstream"
+
+readarray_compat LOCAL_AGENTS < <(find "${TARGET_AGENTS_DIR}" -maxdepth 1 -type f -name '*.toml' | sort)
+
+if [[ ${#LOCAL_AGENTS[@]} -eq 0 ]]; then
+  echo "[INFO] no installed subagent files found in ${TARGET_AGENTS_DIR}"
+  exit 0
+fi
+
+for local_file in "${LOCAL_AGENTS[@]}"; do
+  base_name="$(basename "${local_file}")"
+
+  readarray_compat UPSTREAM_MATCHES < <(find "${TMP_DIR}/upstream" -type f -name "${base_name}" -not -path '*/.git/*' | sort)
+
+  if [[ ${#UPSTREAM_MATCHES[@]} -eq 0 ]]; then
+    echo "[SKIP] no upstream match for ${base_name}"
+    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    continue
+  fi
+
+  if [[ ${#UPSTREAM_MATCHES[@]} -gt 1 ]]; then
+    echo "[SKIP] multiple upstream matches for ${base_name}"
+    printf '  - %s\n' "${UPSTREAM_MATCHES[@]}"
+    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    continue
+  fi
+
+  upstream_file="${UPSTREAM_MATCHES[0]}"
+  upstream_rel="${upstream_file#${TMP_DIR}/upstream/}"
+
+  if cmp -s "${local_file}" "${upstream_file}"; then
+    echo "[OK] already up to date: ${local_file}"
+    UNCHANGED_COUNT=$((UNCHANGED_COUNT + 1))
+    continue
+  fi
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "[DRY-RUN] would update ${local_file} from ${upstream_rel}"
+    UPDATED_COUNT=$((UPDATED_COUNT + 1))
+    continue
+  fi
+
+  if [[ "${BACKUP_CREATED}" == "false" ]]; then
+    mkdir -p "${BACKUP_DIR}"
+    BACKUP_CREATED=true
+  fi
+
+  mkdir -p "$(dirname "${BACKUP_DIR}/.codex/agents/${base_name}")"
+  cp "${local_file}" "${BACKUP_DIR}/.codex/agents/${base_name}"
+  cp "${upstream_file}" "${local_file}"
+  echo "[UPDATE] ${local_file} <- ${upstream_rel}"
+  UPDATED_COUNT=$((UPDATED_COUNT + 1))
+done
+
+echo
+echo "Summary:"
+echo "  updated: ${UPDATED_COUNT}"
+echo "  unchanged: ${UNCHANGED_COUNT}"
+echo "  skipped: ${SKIPPED_COUNT}"
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo "Dry run only. No files were changed."
+elif [[ "${BACKUP_CREATED}" == "true" ]]; then
+  echo "Backup saved to: ${BACKUP_DIR}"
+else
+  echo "No file changes were required."
+fi


### PR DESCRIPTION
## Related Issue
- Related #27

## Why
Repository policy documents and workflow templates were expanded to clarify precedence, subagent usage, and supporting policy distribution assets. The repository also needs the referenced `.codex`, versioning, and helper script files to exist in the same change set.

## What
- update `AGENTS.md`, `AI_DEVELOPMENT_POLICY.md`, and `CONTRIBUTING.md`
- update issue and MR templates for stricter single-selection and subagent usage recording
- add `.codex/config.toml` and `.codex/agents/*.toml`
- add `POLICY_VERSION.md`, `docs/dev/vscode-snippets-guide.md`, and `scripts/update-codex-subagents.sh`
- update `CHANGELOG.md` for the policy/process change

## Validation
- [ ] build
- [ ] test
- [x] manual verification
- [ ] analysis only (no code change)

Validation:
- `git diff --cached --check`
- manual review of policy/template diffs and referenced support assets

## Checklist
- [x] working branch used or direct main change justified
- [x] commit message rule followed
- [x] issue template used where applicable and `AI-Assisted` handling remains documented by policy
- [x] no unrelated changes included
- [ ] documentation updated if needed
- [x] changelog updated if needed
- [x] AI-assisted change reviewed by human

## AI-Assisted
- [x] Yes
- [ ] No
