### PR TITLE
feat(acl): implement issue #35

### DIFF
--- a/src/react/pages/acl/AclPage.tsx
+++ b/src/react/pages/acl/AclPage.tsx
@@ -1,0 +1,492 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Breadcrumbs,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  IconButton,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { AddOutlined, DeleteOutlined, RefreshOutlined } from "@mui/icons-material";
+import { useConfirm, useToast } from "@/react/feedback";
+import type {
+  AclClassDto,
+  AclEntryDto,
+  AclObjectIdentityDto,
+  AclSidDto,
+} from "@/types/studio/acl";
+import type { AclActionMaskDto } from "@/types/studio/ai";
+import { reactAclApi } from "./api";
+import { CreateClassDialog } from "./CreateClassDialog";
+import { CreateSidDialog } from "./CreateSidDialog";
+import { CreateObjectDialog } from "./CreateObjectDialog";
+import { CreateEntryDialog } from "./CreateEntryDialog";
+
+function SectionHeader({
+  title,
+  onAdd,
+  onRefresh,
+}: {
+  title: string;
+  onAdd: () => void;
+  onRefresh: () => void;
+}) {
+  return (
+    <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <Typography variant="h6">{title}</Typography>
+      <Stack direction="row" spacing={1}>
+        <Button size="small" startIcon={<AddOutlined />} onClick={onAdd}>
+          추가
+        </Button>
+        <Button size="small" startIcon={<RefreshOutlined />} onClick={onRefresh}>
+          새로고침
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+
+export function AclPage() {
+  const toast = useToast();
+  const confirm = useConfirm();
+
+  const [classes, setClasses] = useState<AclClassDto[]>([]);
+  const [sids, setSids] = useState<AclSidDto[]>([]);
+  const [objects, setObjects] = useState<AclObjectIdentityDto[]>([]);
+  const [entries, setEntries] = useState<AclEntryDto[]>([]);
+  const [actions, setActions] = useState<AclActionMaskDto[]>([]);
+
+  const [loadingClasses, setLoadingClasses] = useState(false);
+  const [loadingSids, setLoadingSids] = useState(false);
+  const [loadingObjects, setLoadingObjects] = useState(false);
+  const [loadingEntries, setLoadingEntries] = useState(false);
+  const [pageError, setPageError] = useState<string | null>(null);
+
+  const [createClassOpen, setCreateClassOpen] = useState(false);
+  const [createSidOpen, setCreateSidOpen] = useState(false);
+  const [createObjectOpen, setCreateObjectOpen] = useState(false);
+  const [createEntryOpen, setCreateEntryOpen] = useState(false);
+
+  const objectById = useMemo(
+    () => Object.fromEntries(objects.map((objectIdentity) => [objectIdentity.id, objectIdentity])),
+    [objects]
+  );
+  const actionByMask = useMemo(
+    () => Object.fromEntries(actions.map((action) => [action.mask, action.action])),
+    [actions]
+  );
+  const sidById = useMemo(
+    () => Object.fromEntries(sids.map((sid) => [sid.id, sid])),
+    [sids]
+  );
+
+  const loadClasses = useCallback(async () => {
+    setLoadingClasses(true);
+    try {
+      setClasses(await reactAclApi.listClasses());
+      setPageError(null);
+    } catch {
+      setPageError("ACL 클래스를 불러오지 못했습니다.");
+      toast.error("ACL 클래스를 불러오지 못했습니다.");
+    } finally {
+      setLoadingClasses(false);
+    }
+  }, [toast]);
+
+  const loadSids = useCallback(async () => {
+    setLoadingSids(true);
+    try {
+      setSids(await reactAclApi.listSids());
+      setPageError(null);
+    } catch {
+      setPageError("ACL SID를 불러오지 못했습니다.");
+      toast.error("ACL SID를 불러오지 못했습니다.");
+    } finally {
+      setLoadingSids(false);
+    }
+  }, [toast]);
+
+  const loadObjects = useCallback(async () => {
+    setLoadingObjects(true);
+    try {
+      setObjects(await reactAclApi.listObjects());
+      setPageError(null);
+    } catch {
+      setPageError("ACL 오브젝트를 불러오지 못했습니다.");
+      toast.error("ACL 오브젝트를 불러오지 못했습니다.");
+    } finally {
+      setLoadingObjects(false);
+    }
+  }, [toast]);
+
+  const loadEntries = useCallback(async () => {
+    setLoadingEntries(true);
+    try {
+      setEntries(await reactAclApi.listEntries());
+      setPageError(null);
+    } catch {
+      setPageError("ACL 엔트리를 불러오지 못했습니다.");
+      toast.error("ACL 엔트리를 불러오지 못했습니다.");
+    } finally {
+      setLoadingEntries(false);
+    }
+  }, [toast]);
+
+  const loadActions = useCallback(async () => {
+    try {
+      setActions(await reactAclApi.listActions());
+    } catch {
+      toast.error("ACL 액션 정의를 불러오지 못했습니다.");
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    void loadClasses();
+    void loadSids();
+    void loadObjects();
+    void loadEntries();
+    void loadActions();
+  }, [loadActions, loadClasses, loadEntries, loadObjects, loadSids]);
+
+  async function handleDeleteClass(id: number) {
+    const ok = await confirm({ title: "ACL 클래스 삭제", message: "이 클래스를 삭제하시겠습니까?" });
+    if (!ok) return;
+
+    try {
+      await reactAclApi.deleteClass(id);
+      toast.success("ACL 클래스가 삭제되었습니다.");
+      await loadClasses();
+    } catch {
+      toast.error("ACL 클래스 삭제에 실패했습니다.");
+    }
+  }
+
+  async function handleDeleteSid(id: number) {
+    const ok = await confirm({ title: "ACL SID 삭제", message: "이 SID를 삭제하시겠습니까?" });
+    if (!ok) return;
+
+    try {
+      await reactAclApi.deleteSid(id);
+      toast.success("ACL SID가 삭제되었습니다.");
+      await loadSids();
+    } catch {
+      toast.error("ACL SID 삭제에 실패했습니다.");
+    }
+  }
+
+  async function handleDeleteObject(id: number) {
+    const ok = await confirm({
+      title: "ACL 오브젝트 삭제",
+      message: "이 오브젝트 아이덴티티를 삭제하시겠습니까?",
+    });
+    if (!ok) return;
+
+    try {
+      await reactAclApi.deleteObject(id);
+      toast.success("ACL 오브젝트가 삭제되었습니다.");
+      await loadObjects();
+    } catch {
+      toast.error("ACL 오브젝트 삭제에 실패했습니다.");
+    }
+  }
+
+  async function handleDeleteEntry(id: number) {
+    const ok = await confirm({ title: "ACL 엔트리 삭제", message: "이 ACL 엔트리를 삭제하시겠습니까?" });
+    if (!ok) return;
+
+    try {
+      await reactAclApi.deleteEntry(id);
+      toast.success("ACL 엔트리가 삭제되었습니다.");
+      await loadEntries();
+    } catch {
+      toast.error("ACL 엔트리 삭제에 실패했습니다.");
+    }
+  }
+
+  return (
+    <Stack spacing={3}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">시스템관리</Typography>
+        <Typography color="text.secondary">보안관리</Typography>
+        <Typography color="text.primary">ACL 관리</Typography>
+      </Breadcrumbs>
+
+      <Box>
+        <Typography variant="h5">ACL 관리</Typography>
+        <Typography variant="body2" color="text.secondary">
+          클래스, SID, 오브젝트 아이덴티티, 엔트리를 한 화면에서 관리합니다.
+        </Typography>
+      </Box>
+
+      {pageError ? <Alert severity="error">{pageError}</Alert> : null}
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          <SectionHeader
+            title="ACL 클래스"
+            onAdd={() => setCreateClassOpen(true)}
+            onRefresh={() => void loadClasses()}
+          />
+          {loadingClasses ? (
+            <CircularProgress size={24} />
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>ID</TableCell>
+                    <TableCell>클래스명</TableCell>
+                    <TableCell>ID 타입</TableCell>
+                    <TableCell align="right">동작</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {classes.map((aclClass) => (
+                    <TableRow key={aclClass.id}>
+                      <TableCell>{aclClass.id}</TableCell>
+                      <TableCell>{aclClass.className}</TableCell>
+                      <TableCell>{aclClass.classIdType ?? "-"}</TableCell>
+                      <TableCell align="right">
+                        <IconButton color="error" size="small" onClick={() => void handleDeleteClass(aclClass.id)}>
+                          <DeleteOutlined fontSize="small" />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {classes.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={4}>
+                        <Typography color="text.secondary">등록된 ACL 클래스가 없습니다.</Typography>
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          <SectionHeader title="ACL SID" onAdd={() => setCreateSidOpen(true)} onRefresh={() => void loadSids()} />
+          {loadingSids ? (
+            <CircularProgress size={24} />
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>ID</TableCell>
+                    <TableCell>SID</TableCell>
+                    <TableCell>유형</TableCell>
+                    <TableCell align="right">동작</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {sids.map((sid) => (
+                    <TableRow key={sid.id}>
+                      <TableCell>{sid.id}</TableCell>
+                      <TableCell>{sid.sid}</TableCell>
+                      <TableCell>
+                        <Chip size="small" label={sid.principal ? "Principal" : "Authority"} />
+                      </TableCell>
+                      <TableCell align="right">
+                        <IconButton color="error" size="small" onClick={() => void handleDeleteSid(sid.id)}>
+                          <DeleteOutlined fontSize="small" />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {sids.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={4}>
+                        <Typography color="text.secondary">등록된 SID가 없습니다.</Typography>
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          <SectionHeader
+            title="오브젝트 아이덴티티"
+            onAdd={() => setCreateObjectOpen(true)}
+            onRefresh={() => void loadObjects()}
+          />
+          {loadingObjects ? (
+            <CircularProgress size={24} />
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>ID</TableCell>
+                    <TableCell>클래스</TableCell>
+                    <TableCell>오브젝트 ID</TableCell>
+                    <TableCell>Owner SID</TableCell>
+                    <TableCell>상속</TableCell>
+                    <TableCell align="right">동작</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {objects.map((objectIdentity) => (
+                    <TableRow key={objectIdentity.id}>
+                      <TableCell>{objectIdentity.id}</TableCell>
+                      <TableCell>{objectIdentity.className}</TableCell>
+                      <TableCell>
+                        {String(objectIdentity.objectIdIdentity) === "__root__"
+                          ? "__root__"
+                          : String(objectIdentity.objectIdIdentity)}
+                      </TableCell>
+                      <TableCell>{objectIdentity.ownerSidId ? sidById[objectIdentity.ownerSidId]?.sid ?? objectIdentity.ownerSidId : "-"}</TableCell>
+                      <TableCell>
+                        <Chip size="small" label={objectIdentity.entriesInheriting ? "상속" : "비상속"} />
+                      </TableCell>
+                      <TableCell align="right">
+                        <IconButton color="error" size="small" onClick={() => void handleDeleteObject(objectIdentity.id)}>
+                          <DeleteOutlined fontSize="small" />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {objects.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={6}>
+                        <Typography color="text.secondary">등록된 오브젝트 아이덴티티가 없습니다.</Typography>
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          <SectionHeader
+            title="ACL 엔트리"
+            onAdd={() => setCreateEntryOpen(true)}
+            onRefresh={() => void loadEntries()}
+          />
+          {loadingEntries ? (
+            <CircularProgress size={24} />
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>ID</TableCell>
+                    <TableCell>오브젝트</TableCell>
+                    <TableCell>SID</TableCell>
+                    <TableCell>액션</TableCell>
+                    <TableCell>순서</TableCell>
+                    <TableCell>허용 여부</TableCell>
+                    <TableCell>감사</TableCell>
+                    <TableCell align="right">동작</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {entries.map((entry) => {
+                    const objectIdentity = objectById[entry.aclObjectIdentity];
+                    const sid = sidById[entry.sid];
+                    const action = actionByMask[entry.mask] ?? entry.mask;
+
+                    return (
+                      <TableRow key={entry.id}>
+                        <TableCell>{entry.id}</TableCell>
+                        <TableCell>
+                          {objectIdentity
+                            ? `${objectIdentity.className}#${String(objectIdentity.objectIdIdentity)}`
+                            : entry.aclObjectIdentity}
+                        </TableCell>
+                        <TableCell>{sid?.sid ?? entry.sid}</TableCell>
+                        <TableCell>{String(action)}</TableCell>
+                        <TableCell>{entry.aceOrder}</TableCell>
+                        <TableCell>
+                          <Chip
+                            size="small"
+                            color={entry.granting ? "success" : "error"}
+                            label={entry.granting ? "허용" : "거부"}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Stack direction="row" spacing={0.5}>
+                            {entry.auditSuccess ? <Chip size="small" label="성공" /> : null}
+                            {entry.auditFailure ? <Chip size="small" label="실패" /> : null}
+                            {!entry.auditSuccess && !entry.auditFailure ? (
+                              <Typography color="text.secondary">-</Typography>
+                            ) : null}
+                          </Stack>
+                        </TableCell>
+                        <TableCell align="right">
+                          <IconButton color="error" size="small" onClick={() => void handleDeleteEntry(entry.id)}>
+                            <DeleteOutlined fontSize="small" />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                  {entries.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={8}>
+                        <Typography color="text.secondary">등록된 ACL 엔트리가 없습니다.</Typography>
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </Stack>
+      </Paper>
+
+      <Divider />
+
+      <CreateClassDialog
+        open={createClassOpen}
+        onClose={() => setCreateClassOpen(false)}
+        onCreated={() => void loadClasses()}
+      />
+      <CreateSidDialog
+        open={createSidOpen}
+        onClose={() => setCreateSidOpen(false)}
+        onCreated={() => void loadSids()}
+      />
+      <CreateObjectDialog
+        open={createObjectOpen}
+        onClose={() => setCreateObjectOpen(false)}
+        classes={classes}
+        sids={sids}
+        onCreated={() => void loadObjects()}
+      />
+      <CreateEntryDialog
+        open={createEntryOpen}
+        onClose={() => setCreateEntryOpen(false)}
+        classes={classes}
+        sids={sids}
+        objects={objects}
+        actions={actions}
+        onCreated={() => void loadEntries()}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/acl/AclPage.tsx
+++ b/src/react/pages/acl/AclPage.tsx
@@ -1,24 +1,21 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   Alert,
   Box,
   Breadcrumbs,
   Button,
   Chip,
-  CircularProgress,
   Divider,
   IconButton,
   Paper,
   Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   Typography,
 } from "@mui/material";
 import { AddOutlined, DeleteOutlined, RefreshOutlined } from "@mui/icons-material";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ColDef } from "ag-grid-community";
+import { PageableGridContent } from "@/react/components/ag-grid";
+import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
 import { useConfirm, useToast } from "@/react/feedback";
 import type {
   AclClassDto,
@@ -27,7 +24,14 @@ import type {
   AclSidDto,
 } from "@/types/studio/acl";
 import type { AclActionMaskDto } from "@/types/studio/ai";
+import { aclQueryKeys } from "./queryKeys";
 import { reactAclApi } from "./api";
+import {
+  AclClassesDataSource,
+  AclEntriesDataSource,
+  AclObjectsDataSource,
+  AclSidsDataSource,
+} from "./datasource";
 import { CreateClassDialog } from "./CreateClassDialog";
 import { CreateSidDialog } from "./CreateSidDialog";
 import { CreateObjectDialog } from "./CreateObjectDialog";
@@ -60,23 +64,44 @@ function SectionHeader({
 export function AclPage() {
   const toast = useToast();
   const confirm = useConfirm();
-
-  const [classes, setClasses] = useState<AclClassDto[]>([]);
-  const [sids, setSids] = useState<AclSidDto[]>([]);
-  const [objects, setObjects] = useState<AclObjectIdentityDto[]>([]);
-  const [entries, setEntries] = useState<AclEntryDto[]>([]);
-  const [actions, setActions] = useState<AclActionMaskDto[]>([]);
-
-  const [loadingClasses, setLoadingClasses] = useState(false);
-  const [loadingSids, setLoadingSids] = useState(false);
-  const [loadingObjects, setLoadingObjects] = useState(false);
-  const [loadingEntries, setLoadingEntries] = useState(false);
+  const queryClient = useQueryClient();
+  const classesGridRef = useRef<PageableGridContentHandle<AclClassDto>>(null);
+  const sidsGridRef = useRef<PageableGridContentHandle<AclSidDto>>(null);
+  const objectsGridRef = useRef<PageableGridContentHandle<AclObjectIdentityDto>>(null);
+  const entriesGridRef = useRef<PageableGridContentHandle<AclEntryDto>>(null);
   const [pageError, setPageError] = useState<string | null>(null);
 
   const [createClassOpen, setCreateClassOpen] = useState(false);
   const [createSidOpen, setCreateSidOpen] = useState(false);
   const [createObjectOpen, setCreateObjectOpen] = useState(false);
   const [createEntryOpen, setCreateEntryOpen] = useState(false);
+
+  const classesDataSource = useMemo(() => new AclClassesDataSource(), []);
+  const sidsDataSource = useMemo(() => new AclSidsDataSource(), []);
+  const objectsDataSource = useMemo(() => new AclObjectsDataSource(), []);
+  const entriesDataSource = useMemo(() => new AclEntriesDataSource(), []);
+
+  const classesQuery = useQuery({
+    queryKey: aclQueryKeys.custom("classes"),
+    queryFn: reactAclApi.listClasses,
+  });
+  const sidsQuery = useQuery({
+    queryKey: aclQueryKeys.custom("sids"),
+    queryFn: reactAclApi.listSids,
+  });
+  const objectsQuery = useQuery({
+    queryKey: aclQueryKeys.custom("objects"),
+    queryFn: reactAclApi.listObjects,
+  });
+  const actionsQuery = useQuery({
+    queryKey: aclQueryKeys.custom("actions"),
+    queryFn: reactAclApi.listActions,
+  });
+
+  const classes = classesQuery.data ?? [];
+  const sids = sidsQuery.data ?? [];
+  const objects = objectsQuery.data ?? [];
+  const actions = actionsQuery.data ?? [];
 
   const objectById = useMemo(
     () => Object.fromEntries(objects.map((objectIdentity) => [objectIdentity.id, objectIdentity])),
@@ -91,73 +116,210 @@ export function AclPage() {
     [sids]
   );
 
-  const loadClasses = useCallback(async () => {
-    setLoadingClasses(true);
+  const refreshLookups = useCallback(async () => {
     try {
-      setClasses(await reactAclApi.listClasses());
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: aclQueryKeys.custom("classes") }),
+        queryClient.invalidateQueries({ queryKey: aclQueryKeys.custom("sids") }),
+        queryClient.invalidateQueries({ queryKey: aclQueryKeys.custom("objects") }),
+        queryClient.invalidateQueries({ queryKey: aclQueryKeys.custom("actions") }),
+      ]);
       setPageError(null);
     } catch {
-      setPageError("ACL 클래스를 불러오지 못했습니다.");
-      toast.error("ACL 클래스를 불러오지 못했습니다.");
-    } finally {
-      setLoadingClasses(false);
+      setPageError("ACL lookup 데이터를 새로고침하지 못했습니다.");
+      toast.error("ACL lookup 데이터를 새로고침하지 못했습니다.");
     }
-  }, [toast]);
+  }, [queryClient, toast]);
 
-  const loadSids = useCallback(async () => {
-    setLoadingSids(true);
-    try {
-      setSids(await reactAclApi.listSids());
-      setPageError(null);
-    } catch {
-      setPageError("ACL SID를 불러오지 못했습니다.");
-      toast.error("ACL SID를 불러오지 못했습니다.");
-    } finally {
-      setLoadingSids(false);
-    }
-  }, [toast]);
+  const refreshAllGrids = useCallback(async () => {
+    classesGridRef.current?.refresh();
+    sidsGridRef.current?.refresh();
+    objectsGridRef.current?.refresh();
+    entriesGridRef.current?.refresh();
+    await refreshLookups();
+  }, [refreshLookups]);
 
-  const loadObjects = useCallback(async () => {
-    setLoadingObjects(true);
-    try {
-      setObjects(await reactAclApi.listObjects());
-      setPageError(null);
-    } catch {
-      setPageError("ACL 오브젝트를 불러오지 못했습니다.");
-      toast.error("ACL 오브젝트를 불러오지 못했습니다.");
-    } finally {
-      setLoadingObjects(false);
-    }
-  }, [toast]);
+  const classesColumnDefs = useMemo<ColDef<AclClassDto>[]>(
+    () => [
+      { field: "id", headerName: "ID", sortable: true, flex: 0.5, filter: false },
+      { field: "className", headerName: "클래스명", sortable: true, flex: 1.5, filter: false },
+      { field: "classIdType", headerName: "ID 타입", sortable: true, flex: 1, filter: false },
+      {
+        colId: "actions",
+        headerName: "",
+        sortable: false,
+        filter: false,
+        flex: 0.5,
+        cellRenderer: (params: { data?: AclClassDto }) => (
+          <IconButton color="error" size="small" onClick={() => params.data && void handleDeleteClass(params.data.id)}>
+            <DeleteOutlined fontSize="small" />
+          </IconButton>
+        ),
+      },
+    ],
+    []
+  );
 
-  const loadEntries = useCallback(async () => {
-    setLoadingEntries(true);
-    try {
-      setEntries(await reactAclApi.listEntries());
-      setPageError(null);
-    } catch {
-      setPageError("ACL 엔트리를 불러오지 못했습니다.");
-      toast.error("ACL 엔트리를 불러오지 못했습니다.");
-    } finally {
-      setLoadingEntries(false);
-    }
-  }, [toast]);
+  const sidsColumnDefs = useMemo<ColDef<AclSidDto>[]>(
+    () => [
+      { field: "id", headerName: "ID", sortable: true, flex: 0.5, filter: false },
+      { field: "sid", headerName: "SID", sortable: true, flex: 1.5, filter: false },
+      {
+        colId: "principal",
+        headerName: "유형",
+        sortable: true,
+        flex: 1,
+        filter: false,
+        cellRenderer: (params: { data?: AclSidDto }) => (
+          <Chip size="small" label={params.data?.principal ? "Principal" : "Authority"} />
+        ),
+      },
+      {
+        colId: "actions",
+        headerName: "",
+        sortable: false,
+        filter: false,
+        flex: 0.5,
+        cellRenderer: (params: { data?: AclSidDto }) => (
+          <IconButton color="error" size="small" onClick={() => params.data && void handleDeleteSid(params.data.id)}>
+            <DeleteOutlined fontSize="small" />
+          </IconButton>
+        ),
+      },
+    ],
+    []
+  );
 
-  const loadActions = useCallback(async () => {
-    try {
-      setActions(await reactAclApi.listActions());
-    } catch {
-      toast.error("ACL 액션 정의를 불러오지 못했습니다.");
-    }
-  }, [toast]);
+  const objectsColumnDefs = useMemo<ColDef<AclObjectIdentityDto>[]>(
+    () => [
+      { field: "id", headerName: "ID", sortable: true, flex: 0.5, filter: false },
+      { field: "className", headerName: "클래스", sortable: true, flex: 1, filter: false },
+      {
+        colId: "objectIdIdentity",
+        headerName: "오브젝트 ID",
+        sortable: true,
+        flex: 1,
+        filter: false,
+        valueGetter: (params) =>
+          String(params.data?.objectIdIdentity) === "__root__"
+            ? "__root__"
+            : String(params.data?.objectIdIdentity ?? ""),
+      },
+      {
+        colId: "ownerSidId",
+        headerName: "Owner SID",
+        sortable: false,
+        flex: 1,
+        filter: false,
+        valueGetter: (params) => {
+          const ownerSidId = params.data?.ownerSidId;
+          return ownerSidId ? sidById[ownerSidId]?.sid ?? ownerSidId : "-";
+        },
+      },
+      {
+        colId: "entriesInheriting",
+        headerName: "상속",
+        sortable: true,
+        flex: 0.7,
+        filter: false,
+        cellRenderer: (params: { data?: AclObjectIdentityDto }) => (
+          <Chip size="small" label={params.data?.entriesInheriting ? "상속" : "비상속"} />
+        ),
+      },
+      {
+        colId: "actions",
+        headerName: "",
+        sortable: false,
+        filter: false,
+        flex: 0.5,
+        cellRenderer: (params: { data?: AclObjectIdentityDto }) => (
+          <IconButton color="error" size="small" onClick={() => params.data && void handleDeleteObject(params.data.id)}>
+            <DeleteOutlined fontSize="small" />
+          </IconButton>
+        ),
+      },
+    ],
+    [sidById]
+  );
 
-  useEffect(() => {
-    void loadClasses();
-    void loadSids();
-    void loadObjects();
-    void loadEntries();
-    void loadActions();
-  }, [loadActions, loadClasses, loadEntries, loadObjects, loadSids]);
+  const entriesColumnDefs = useMemo<ColDef<AclEntryDto>[]>(
+    () => [
+      { field: "id", headerName: "ID", sortable: true, flex: 0.5, filter: false },
+      {
+        colId: "object",
+        headerName: "오브젝트",
+        sortable: false,
+        flex: 1.5,
+        filter: false,
+        valueGetter: (params) => {
+          const objectIdentity = objectById[params.data?.aclObjectIdentity ?? -1];
+          return objectIdentity
+            ? `${objectIdentity.className}#${String(objectIdentity.objectIdIdentity)}`
+            : params.data?.aclObjectIdentity;
+        },
+      },
+      {
+        colId: "sid",
+        headerName: "SID",
+        sortable: false,
+        flex: 1,
+        filter: false,
+        valueGetter: (params) => sidById[params.data?.sid ?? -1]?.sid ?? params.data?.sid,
+      },
+      {
+        colId: "mask",
+        headerName: "액션",
+        sortable: false,
+        flex: 1,
+        filter: false,
+        valueGetter: (params) => actionByMask[params.data?.mask ?? -1] ?? params.data?.mask,
+      },
+      { field: "aceOrder", headerName: "순서", sortable: true, flex: 0.6, filter: false },
+      {
+        colId: "granting",
+        headerName: "허용 여부",
+        sortable: true,
+        flex: 0.8,
+        filter: false,
+        cellRenderer: (params: { data?: AclEntryDto }) => (
+          <Chip
+            size="small"
+            color={params.data?.granting ? "success" : "error"}
+            label={params.data?.granting ? "허용" : "거부"}
+          />
+        ),
+      },
+      {
+        colId: "audit",
+        headerName: "감사",
+        sortable: false,
+        flex: 1,
+        filter: false,
+        cellRenderer: (params: { data?: AclEntryDto }) => (
+          <Stack direction="row" spacing={0.5}>
+            {params.data?.auditSuccess ? <Chip size="small" label="성공" /> : null}
+            {params.data?.auditFailure ? <Chip size="small" label="실패" /> : null}
+            {!params.data?.auditSuccess && !params.data?.auditFailure ? (
+              <Typography color="text.secondary">-</Typography>
+            ) : null}
+          </Stack>
+        ),
+      },
+      {
+        colId: "actions",
+        headerName: "",
+        sortable: false,
+        filter: false,
+        flex: 0.5,
+        cellRenderer: (params: { data?: AclEntryDto }) => (
+          <IconButton color="error" size="small" onClick={() => params.data && void handleDeleteEntry(params.data.id)}>
+            <DeleteOutlined fontSize="small" />
+          </IconButton>
+        ),
+      },
+    ],
+    [actionByMask, objectById, sidById]
+  );
 
   async function handleDeleteClass(id: number) {
     const ok = await confirm({ title: "ACL 클래스 삭제", message: "이 클래스를 삭제하시겠습니까?" });
@@ -166,7 +328,8 @@ export function AclPage() {
     try {
       await reactAclApi.deleteClass(id);
       toast.success("ACL 클래스가 삭제되었습니다.");
-      await loadClasses();
+      classesGridRef.current?.refresh();
+      await refreshLookups();
     } catch {
       toast.error("ACL 클래스 삭제에 실패했습니다.");
     }
@@ -179,7 +342,10 @@ export function AclPage() {
     try {
       await reactAclApi.deleteSid(id);
       toast.success("ACL SID가 삭제되었습니다.");
-      await loadSids();
+      sidsGridRef.current?.refresh();
+      objectsGridRef.current?.refresh();
+      entriesGridRef.current?.refresh();
+      await refreshLookups();
     } catch {
       toast.error("ACL SID 삭제에 실패했습니다.");
     }
@@ -195,7 +361,9 @@ export function AclPage() {
     try {
       await reactAclApi.deleteObject(id);
       toast.success("ACL 오브젝트가 삭제되었습니다.");
-      await loadObjects();
+      objectsGridRef.current?.refresh();
+      entriesGridRef.current?.refresh();
+      await refreshLookups();
     } catch {
       toast.error("ACL 오브젝트 삭제에 실패했습니다.");
     }
@@ -208,7 +376,7 @@ export function AclPage() {
     try {
       await reactAclApi.deleteEntry(id);
       toast.success("ACL 엔트리가 삭제되었습니다.");
-      await loadEntries();
+      entriesGridRef.current?.refresh();
     } catch {
       toast.error("ACL 엔트리 삭제에 실패했습니다.");
     }
@@ -236,90 +404,36 @@ export function AclPage() {
           <SectionHeader
             title="ACL 클래스"
             onAdd={() => setCreateClassOpen(true)}
-            onRefresh={() => void loadClasses()}
+            onRefresh={() => {
+              classesGridRef.current?.refresh();
+              void refreshLookups();
+            }}
           />
-          {loadingClasses ? (
-            <CircularProgress size={24} />
-          ) : (
-            <TableContainer>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>ID</TableCell>
-                    <TableCell>클래스명</TableCell>
-                    <TableCell>ID 타입</TableCell>
-                    <TableCell align="right">동작</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {classes.map((aclClass) => (
-                    <TableRow key={aclClass.id}>
-                      <TableCell>{aclClass.id}</TableCell>
-                      <TableCell>{aclClass.className}</TableCell>
-                      <TableCell>{aclClass.classIdType ?? "-"}</TableCell>
-                      <TableCell align="right">
-                        <IconButton color="error" size="small" onClick={() => void handleDeleteClass(aclClass.id)}>
-                          <DeleteOutlined fontSize="small" />
-                        </IconButton>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                  {classes.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={4}>
-                        <Typography color="text.secondary">등록된 ACL 클래스가 없습니다.</Typography>
-                      </TableCell>
-                    </TableRow>
-                  ) : null}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
+          <PageableGridContent<AclClassDto>
+            ref={classesGridRef}
+            datasource={classesDataSource}
+            columns={classesColumnDefs}
+            height={260}
+          />
         </Stack>
       </Paper>
 
       <Paper variant="outlined" sx={{ p: 2 }}>
         <Stack spacing={2}>
-          <SectionHeader title="ACL SID" onAdd={() => setCreateSidOpen(true)} onRefresh={() => void loadSids()} />
-          {loadingSids ? (
-            <CircularProgress size={24} />
-          ) : (
-            <TableContainer>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>ID</TableCell>
-                    <TableCell>SID</TableCell>
-                    <TableCell>유형</TableCell>
-                    <TableCell align="right">동작</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {sids.map((sid) => (
-                    <TableRow key={sid.id}>
-                      <TableCell>{sid.id}</TableCell>
-                      <TableCell>{sid.sid}</TableCell>
-                      <TableCell>
-                        <Chip size="small" label={sid.principal ? "Principal" : "Authority"} />
-                      </TableCell>
-                      <TableCell align="right">
-                        <IconButton color="error" size="small" onClick={() => void handleDeleteSid(sid.id)}>
-                          <DeleteOutlined fontSize="small" />
-                        </IconButton>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                  {sids.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={4}>
-                        <Typography color="text.secondary">등록된 SID가 없습니다.</Typography>
-                      </TableCell>
-                    </TableRow>
-                  ) : null}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
+          <SectionHeader
+            title="ACL SID"
+            onAdd={() => setCreateSidOpen(true)}
+            onRefresh={() => {
+              sidsGridRef.current?.refresh();
+              void refreshLookups();
+            }}
+          />
+          <PageableGridContent<AclSidDto>
+            ref={sidsGridRef}
+            datasource={sidsDataSource}
+            columns={sidsColumnDefs}
+            height={260}
+          />
         </Stack>
       </Paper>
 
@@ -328,55 +442,17 @@ export function AclPage() {
           <SectionHeader
             title="오브젝트 아이덴티티"
             onAdd={() => setCreateObjectOpen(true)}
-            onRefresh={() => void loadObjects()}
+            onRefresh={() => {
+              objectsGridRef.current?.refresh();
+              void refreshLookups();
+            }}
           />
-          {loadingObjects ? (
-            <CircularProgress size={24} />
-          ) : (
-            <TableContainer>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>ID</TableCell>
-                    <TableCell>클래스</TableCell>
-                    <TableCell>오브젝트 ID</TableCell>
-                    <TableCell>Owner SID</TableCell>
-                    <TableCell>상속</TableCell>
-                    <TableCell align="right">동작</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {objects.map((objectIdentity) => (
-                    <TableRow key={objectIdentity.id}>
-                      <TableCell>{objectIdentity.id}</TableCell>
-                      <TableCell>{objectIdentity.className}</TableCell>
-                      <TableCell>
-                        {String(objectIdentity.objectIdIdentity) === "__root__"
-                          ? "__root__"
-                          : String(objectIdentity.objectIdIdentity)}
-                      </TableCell>
-                      <TableCell>{objectIdentity.ownerSidId ? sidById[objectIdentity.ownerSidId]?.sid ?? objectIdentity.ownerSidId : "-"}</TableCell>
-                      <TableCell>
-                        <Chip size="small" label={objectIdentity.entriesInheriting ? "상속" : "비상속"} />
-                      </TableCell>
-                      <TableCell align="right">
-                        <IconButton color="error" size="small" onClick={() => void handleDeleteObject(objectIdentity.id)}>
-                          <DeleteOutlined fontSize="small" />
-                        </IconButton>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                  {objects.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={6}>
-                        <Typography color="text.secondary">등록된 오브젝트 아이덴티티가 없습니다.</Typography>
-                      </TableCell>
-                    </TableRow>
-                  ) : null}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
+          <PageableGridContent<AclObjectIdentityDto>
+            ref={objectsGridRef}
+            datasource={objectsDataSource}
+            columns={objectsColumnDefs}
+            height={280}
+          />
         </Stack>
       </Paper>
 
@@ -385,77 +461,14 @@ export function AclPage() {
           <SectionHeader
             title="ACL 엔트리"
             onAdd={() => setCreateEntryOpen(true)}
-            onRefresh={() => void loadEntries()}
+            onRefresh={() => entriesGridRef.current?.refresh()}
           />
-          {loadingEntries ? (
-            <CircularProgress size={24} />
-          ) : (
-            <TableContainer>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>ID</TableCell>
-                    <TableCell>오브젝트</TableCell>
-                    <TableCell>SID</TableCell>
-                    <TableCell>액션</TableCell>
-                    <TableCell>순서</TableCell>
-                    <TableCell>허용 여부</TableCell>
-                    <TableCell>감사</TableCell>
-                    <TableCell align="right">동작</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {entries.map((entry) => {
-                    const objectIdentity = objectById[entry.aclObjectIdentity];
-                    const sid = sidById[entry.sid];
-                    const action = actionByMask[entry.mask] ?? entry.mask;
-
-                    return (
-                      <TableRow key={entry.id}>
-                        <TableCell>{entry.id}</TableCell>
-                        <TableCell>
-                          {objectIdentity
-                            ? `${objectIdentity.className}#${String(objectIdentity.objectIdIdentity)}`
-                            : entry.aclObjectIdentity}
-                        </TableCell>
-                        <TableCell>{sid?.sid ?? entry.sid}</TableCell>
-                        <TableCell>{String(action)}</TableCell>
-                        <TableCell>{entry.aceOrder}</TableCell>
-                        <TableCell>
-                          <Chip
-                            size="small"
-                            color={entry.granting ? "success" : "error"}
-                            label={entry.granting ? "허용" : "거부"}
-                          />
-                        </TableCell>
-                        <TableCell>
-                          <Stack direction="row" spacing={0.5}>
-                            {entry.auditSuccess ? <Chip size="small" label="성공" /> : null}
-                            {entry.auditFailure ? <Chip size="small" label="실패" /> : null}
-                            {!entry.auditSuccess && !entry.auditFailure ? (
-                              <Typography color="text.secondary">-</Typography>
-                            ) : null}
-                          </Stack>
-                        </TableCell>
-                        <TableCell align="right">
-                          <IconButton color="error" size="small" onClick={() => void handleDeleteEntry(entry.id)}>
-                            <DeleteOutlined fontSize="small" />
-                          </IconButton>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                  {entries.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={8}>
-                        <Typography color="text.secondary">등록된 ACL 엔트리가 없습니다.</Typography>
-                      </TableCell>
-                    </TableRow>
-                  ) : null}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
+          <PageableGridContent<AclEntryDto>
+            ref={entriesGridRef}
+            datasource={entriesDataSource}
+            columns={entriesColumnDefs}
+            height={320}
+          />
         </Stack>
       </Paper>
 
@@ -464,19 +477,19 @@ export function AclPage() {
       <CreateClassDialog
         open={createClassOpen}
         onClose={() => setCreateClassOpen(false)}
-        onCreated={() => void loadClasses()}
+        onCreated={() => void refreshAllGrids()}
       />
       <CreateSidDialog
         open={createSidOpen}
         onClose={() => setCreateSidOpen(false)}
-        onCreated={() => void loadSids()}
+        onCreated={() => void refreshAllGrids()}
       />
       <CreateObjectDialog
         open={createObjectOpen}
         onClose={() => setCreateObjectOpen(false)}
         classes={classes}
         sids={sids}
-        onCreated={() => void loadObjects()}
+        onCreated={() => void refreshAllGrids()}
       />
       <CreateEntryDialog
         open={createEntryOpen}
@@ -485,7 +498,9 @@ export function AclPage() {
         sids={sids}
         objects={objects}
         actions={actions}
-        onCreated={() => void loadEntries()}
+        onCreated={() => {
+          entriesGridRef.current?.refresh();
+        }}
       />
     </Stack>
   );

--- a/src/react/pages/acl/CreateClassDialog.tsx
+++ b/src/react/pages/acl/CreateClassDialog.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import { reactAclApi } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function CreateClassDialog({ open, onClose, onCreated }: Props) {
+  const toast = useToast();
+  const [className, setClassName] = useState("");
+  const [classIdType, setClassIdType] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleCreate() {
+    if (!className.trim()) return;
+
+    setLoading(true);
+    try {
+      await reactAclApi.createClass({
+        className: className.trim(),
+        classIdType: classIdType.trim() || null,
+      });
+      toast.success("클래스가 생성되었습니다.");
+      setClassName("");
+      setClassIdType("");
+      onCreated();
+      onClose();
+    } catch {
+      toast.error("클래스 생성에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>ACL 클래스 생성</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="클래스명"
+            size="small"
+            fullWidth
+            value={className}
+            onChange={(event) => setClassName(event.target.value)}
+            required
+          />
+          <TextField
+            label="ID 타입"
+            size="small"
+            fullWidth
+            value={classIdType}
+            onChange={(event) => setClassIdType(event.target.value)}
+            helperText="예: Long, UUID"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          취소
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleCreate()}
+          disabled={loading || !className.trim()}
+        >
+          {loading ? <CircularProgress size={20} /> : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/acl/CreateEntryDialog.tsx
+++ b/src/react/pages/acl/CreateEntryDialog.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  MenuItem,
+  Stack,
+  Switch,
+  TextField,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import type {
+  AclActionMaskDto,
+} from "@/types/studio/ai";
+import type { AclClassDto, AclObjectIdentityDto, AclSidDto } from "@/types/studio/acl";
+import { reactAclApi } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  classes: AclClassDto[];
+  sids: AclSidDto[];
+  objects: AclObjectIdentityDto[];
+  actions: AclActionMaskDto[];
+  onCreated: () => void;
+}
+
+export function CreateEntryDialog({
+  open,
+  onClose,
+  classes: _classes,
+  sids,
+  objects,
+  actions,
+  onCreated,
+}: Props) {
+  const toast = useToast();
+  const [objectIdentityId, setObjectIdentityId] = useState("");
+  const [sidId, setSidId] = useState("");
+  const [mask, setMask] = useState("");
+  const [granting, setGranting] = useState(true);
+  const [aceOrder, setAceOrder] = useState("0");
+  const [auditSuccess, setAuditSuccess] = useState(false);
+  const [auditFailure, setAuditFailure] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function handleCreate() {
+    if (!objectIdentityId || !sidId || !mask) return;
+
+    setLoading(true);
+    try {
+      await reactAclApi.createEntry({
+        objectIdentityId: Number(objectIdentityId),
+        sidId: Number(sidId),
+        mask: Number(mask),
+        granting,
+        aceOrder: Number(aceOrder),
+        auditSuccess,
+        auditFailure,
+      });
+      toast.success("ACL 엔트리가 생성되었습니다.");
+      setObjectIdentityId("");
+      setSidId("");
+      setMask("");
+      setGranting(true);
+      setAceOrder("0");
+      setAuditSuccess(false);
+      setAuditFailure(false);
+      onCreated();
+      onClose();
+    } catch {
+      toast.error("ACL 엔트리 생성에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>ACL 엔트리 생성</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            select
+            label="오브젝트 아이덴티티"
+            size="small"
+            fullWidth
+            value={objectIdentityId}
+            onChange={(event) => setObjectIdentityId(event.target.value)}
+            required
+          >
+            {objects.map((objectIdentity) => (
+              <MenuItem key={objectIdentity.id} value={objectIdentity.id}>
+                {objectIdentity.className}#{String(objectIdentity.objectIdIdentity)}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            select
+            label="SID"
+            size="small"
+            fullWidth
+            value={sidId}
+            onChange={(event) => setSidId(event.target.value)}
+            required
+          >
+            {sids.map((sid) => (
+              <MenuItem key={sid.id} value={sid.id}>
+                {sid.sid}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            select
+            label="액션 마스크"
+            size="small"
+            fullWidth
+            value={mask}
+            onChange={(event) => setMask(event.target.value)}
+            required
+          >
+            {actions.map((action) => (
+              <MenuItem key={action.mask} value={action.mask}>
+                {action.action} ({action.mask})
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="ACE 순서"
+            size="small"
+            fullWidth
+            type="number"
+            value={aceOrder}
+            onChange={(event) => setAceOrder(event.target.value)}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={granting}
+                onChange={(event) => setGranting(event.target.checked)}
+              />
+            }
+            label={granting ? "허용" : "거부"}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={auditSuccess}
+                onChange={(event) => setAuditSuccess(event.target.checked)}
+              />
+            }
+            label="성공 시 감사"
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={auditFailure}
+                onChange={(event) => setAuditFailure(event.target.checked)}
+              />
+            }
+            label="실패 시 감사"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          취소
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleCreate()}
+          disabled={loading || !objectIdentityId || !sidId || !mask}
+        >
+          {loading ? <CircularProgress size={20} /> : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/acl/CreateObjectDialog.tsx
+++ b/src/react/pages/acl/CreateObjectDialog.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  MenuItem,
+  Stack,
+  Switch,
+  TextField,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import type { AclClassDto, AclSidDto } from "@/types/studio/acl";
+import { reactAclApi } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  classes: AclClassDto[];
+  sids: AclSidDto[];
+  onCreated: () => void;
+}
+
+export function CreateObjectDialog({
+  open,
+  onClose,
+  classes,
+  sids,
+  onCreated,
+}: Props) {
+  const toast = useToast();
+  const [classId, setClassId] = useState("");
+  const [objectIdIdentity, setObjectIdIdentity] = useState("");
+  const [ownerSidId, setOwnerSidId] = useState("");
+  const [entriesInheriting, setEntriesInheriting] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function handleCreate() {
+    if (!classId || !objectIdIdentity.trim()) return;
+
+    setLoading(true);
+    try {
+      await reactAclApi.createObject({
+        classId: Number(classId),
+        objectIdIdentity: objectIdIdentity.trim(),
+        ownerSidId: ownerSidId ? Number(ownerSidId) : null,
+        entriesInheriting,
+      });
+      toast.success("오브젝트 아이덴티티가 생성되었습니다.");
+      setClassId("");
+      setObjectIdIdentity("");
+      setOwnerSidId("");
+      setEntriesInheriting(false);
+      onCreated();
+      onClose();
+    } catch {
+      toast.error("오브젝트 생성에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>오브젝트 아이덴티티 생성</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            select
+            label="ACL 클래스"
+            size="small"
+            fullWidth
+            value={classId}
+            onChange={(event) => setClassId(event.target.value)}
+            required
+          >
+            {classes.map((aclClass) => (
+              <MenuItem key={aclClass.id} value={aclClass.id}>
+                {aclClass.className}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="오브젝트 ID"
+            size="small"
+            fullWidth
+            value={objectIdIdentity}
+            onChange={(event) => setObjectIdIdentity(event.target.value)}
+            helperText="숫자 또는 __root__"
+            required
+          />
+          <TextField
+            select
+            label="Owner SID"
+            size="small"
+            fullWidth
+            value={ownerSidId}
+            onChange={(event) => setOwnerSidId(event.target.value)}
+          >
+            <MenuItem value="">없음</MenuItem>
+            {sids.map((sid) => (
+              <MenuItem key={sid.id} value={sid.id}>
+                {sid.sid}
+              </MenuItem>
+            ))}
+          </TextField>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={entriesInheriting}
+                onChange={(event) => setEntriesInheriting(event.target.checked)}
+              />
+            }
+            label="상위 ACL에서 권한 상속"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          취소
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleCreate()}
+          disabled={loading || !classId || !objectIdIdentity.trim()}
+        >
+          {loading ? <CircularProgress size={20} /> : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/acl/CreateSidDialog.tsx
+++ b/src/react/pages/acl/CreateSidDialog.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Stack,
+  Switch,
+  TextField,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import { reactAclApi } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function CreateSidDialog({ open, onClose, onCreated }: Props) {
+  const toast = useToast();
+  const [sid, setSid] = useState("");
+  const [principal, setPrincipal] = useState(true);
+  const [loading, setLoading] = useState(false);
+
+  async function handleCreate() {
+    if (!sid.trim()) return;
+
+    setLoading(true);
+    try {
+      await reactAclApi.createSid({ sid: sid.trim(), principal });
+      toast.success("SID가 생성되었습니다.");
+      setSid("");
+      setPrincipal(true);
+      onCreated();
+      onClose();
+    } catch {
+      toast.error("SID 생성에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>ACL SID 생성</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="SID"
+            size="small"
+            fullWidth
+            value={sid}
+            onChange={(event) => setSid(event.target.value)}
+            required
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={principal}
+                onChange={(event) => setPrincipal(event.target.checked)}
+              />
+            }
+            label={principal ? "사용자 Principal" : "GrantedAuthority"}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          취소
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleCreate()}
+          disabled={loading || !sid.trim()}
+        >
+          {loading ? <CircularProgress size={20} /> : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/acl/api.ts
+++ b/src/react/pages/acl/api.ts
@@ -1,0 +1,38 @@
+import { apiRequest } from "@/react/query/fetcher";
+import type {
+  AclClassDto,
+  AclClassRequest,
+  AclEntryDto,
+  AclEntryRequest,
+  AclObjectIdentityDto,
+  AclObjectIdentityRequest,
+  AclSidDto,
+  AclSidRequest,
+} from "@/types/studio/acl";
+import type { AclActionMaskDto } from "@/types/studio/ai";
+
+const API_BASE = "/api/security/acl/admin";
+
+export const reactAclApi = {
+  listClasses: () => apiRequest<AclClassDto[]>("get", `${API_BASE}/classes`),
+  createClass: (payload: AclClassRequest) =>
+    apiRequest<AclClassDto>("post", `${API_BASE}/classes`, { data: payload }),
+  deleteClass: (id: number) => apiRequest<void>("delete", `${API_BASE}/classes/${id}`),
+
+  listSids: () => apiRequest<AclSidDto[]>("get", `${API_BASE}/sids`),
+  createSid: (payload: AclSidRequest) =>
+    apiRequest<AclSidDto>("post", `${API_BASE}/sids`, { data: payload }),
+  deleteSid: (id: number) => apiRequest<void>("delete", `${API_BASE}/sids/${id}`),
+
+  listObjects: () => apiRequest<AclObjectIdentityDto[]>("get", `${API_BASE}/objects`),
+  createObject: (payload: AclObjectIdentityRequest) =>
+    apiRequest<AclObjectIdentityDto>("post", `${API_BASE}/objects`, { data: payload }),
+  deleteObject: (id: number) => apiRequest<void>("delete", `${API_BASE}/objects/${id}`),
+
+  listEntries: () => apiRequest<AclEntryDto[]>("get", `${API_BASE}/entries`),
+  createEntry: (payload: AclEntryRequest) =>
+    apiRequest<AclEntryDto>("post", `${API_BASE}/entries`, { data: payload }),
+  deleteEntry: (id: number) => apiRequest<void>("delete", `${API_BASE}/entries/${id}`),
+
+  listActions: () => apiRequest<AclActionMaskDto[]>("get", `${API_BASE}/actions`),
+};

--- a/src/react/pages/acl/api.ts
+++ b/src/react/pages/acl/api.ts
@@ -10,26 +10,83 @@ import type {
   AclSidRequest,
 } from "@/types/studio/acl";
 import type { AclActionMaskDto } from "@/types/studio/ai";
+import type { PageResponse } from "@/types/studio/api-common";
 
 const API_BASE = "/api/security/acl/admin";
 
+function compareValues(left: unknown, right: unknown) {
+  if (left == null && right == null) return 0;
+  if (left == null) return -1;
+  if (right == null) return 1;
+
+  if (typeof left === "number" && typeof right === "number") {
+    return left - right;
+  }
+
+  return String(left).localeCompare(String(right));
+}
+
+function toPageResponse<T>(
+  items: T[],
+  page: number,
+  size: number,
+  sort?: string
+): PageResponse<T> {
+  let sortedItems = [...items];
+
+  if (sort) {
+    const [field, direction = "asc"] = sort.split(",");
+    sortedItems.sort((left, right) => {
+      const leftValue = (left as Record<string, unknown>)[field];
+      const rightValue = (right as Record<string, unknown>)[field];
+      const result = compareValues(leftValue, rightValue);
+      return direction === "desc" ? -result : result;
+    });
+  }
+
+  const start = page * size;
+  const content = sortedItems.slice(start, start + size);
+  const totalElements = sortedItems.length;
+  const totalPages = totalElements === 0 ? 1 : Math.ceil(totalElements / size);
+
+  return {
+    content,
+    totalElements,
+    totalPages,
+    size,
+    number: page,
+    numberOfElements: content.length,
+    first: page === 0,
+    last: page >= totalPages - 1,
+    empty: totalElements === 0,
+  };
+}
+
 export const reactAclApi = {
   listClasses: () => apiRequest<AclClassDto[]>("get", `${API_BASE}/classes`),
+  listClassesPage: async (params?: { page?: number; size?: number; sort?: string }) =>
+    toPageResponse(await reactAclApi.listClasses(), params?.page ?? 0, params?.size ?? 20, params?.sort),
   createClass: (payload: AclClassRequest) =>
     apiRequest<AclClassDto>("post", `${API_BASE}/classes`, { data: payload }),
   deleteClass: (id: number) => apiRequest<void>("delete", `${API_BASE}/classes/${id}`),
 
   listSids: () => apiRequest<AclSidDto[]>("get", `${API_BASE}/sids`),
+  listSidsPage: async (params?: { page?: number; size?: number; sort?: string }) =>
+    toPageResponse(await reactAclApi.listSids(), params?.page ?? 0, params?.size ?? 20, params?.sort),
   createSid: (payload: AclSidRequest) =>
     apiRequest<AclSidDto>("post", `${API_BASE}/sids`, { data: payload }),
   deleteSid: (id: number) => apiRequest<void>("delete", `${API_BASE}/sids/${id}`),
 
   listObjects: () => apiRequest<AclObjectIdentityDto[]>("get", `${API_BASE}/objects`),
+  listObjectsPage: async (params?: { page?: number; size?: number; sort?: string }) =>
+    toPageResponse(await reactAclApi.listObjects(), params?.page ?? 0, params?.size ?? 20, params?.sort),
   createObject: (payload: AclObjectIdentityRequest) =>
     apiRequest<AclObjectIdentityDto>("post", `${API_BASE}/objects`, { data: payload }),
   deleteObject: (id: number) => apiRequest<void>("delete", `${API_BASE}/objects/${id}`),
 
   listEntries: () => apiRequest<AclEntryDto[]>("get", `${API_BASE}/entries`),
+  listEntriesPage: async (params?: { page?: number; size?: number; sort?: string }) =>
+    toPageResponse(await reactAclApi.listEntries(), params?.page ?? 0, params?.size ?? 20, params?.sort),
   createEntry: (payload: AclEntryRequest) =>
     apiRequest<AclEntryDto>("post", `${API_BASE}/entries`, { data: payload }),
   deleteEntry: (id: number) => apiRequest<void>("delete", `${API_BASE}/entries/${id}`),

--- a/src/react/pages/acl/datasource.ts
+++ b/src/react/pages/acl/datasource.ts
@@ -1,0 +1,64 @@
+import { ReactPageDataSource } from "@/react/pages/admin/datasource";
+import type {
+  AclClassDto,
+  AclEntryDto,
+  AclObjectIdentityDto,
+  AclSidDto,
+} from "@/types/studio/acl";
+import { reactAclApi } from "./api";
+
+export class AclClassesDataSource extends ReactPageDataSource<AclClassDto> {
+  constructor() {
+    super("/api/security/acl/admin/classes");
+  }
+
+  override async fetchForAgGrid({ startRow, endRow, sortModel }: { startRow: number; endRow: number; sortModel?: { colId: string; sort: string }[]; }) {
+    const size = endRow - startRow || this.pageSize;
+    const page = Math.floor(startRow / size);
+    const sort = sortModel && sortModel.length > 0 ? `${sortModel[0].colId},${sortModel[0].sort}` : undefined;
+    const response = await reactAclApi.listClassesPage({ page, size, sort });
+    return { rows: response.content, total: response.totalElements };
+  }
+}
+
+export class AclSidsDataSource extends ReactPageDataSource<AclSidDto> {
+  constructor() {
+    super("/api/security/acl/admin/sids");
+  }
+
+  override async fetchForAgGrid({ startRow, endRow, sortModel }: { startRow: number; endRow: number; sortModel?: { colId: string; sort: string }[]; }) {
+    const size = endRow - startRow || this.pageSize;
+    const page = Math.floor(startRow / size);
+    const sort = sortModel && sortModel.length > 0 ? `${sortModel[0].colId},${sortModel[0].sort}` : undefined;
+    const response = await reactAclApi.listSidsPage({ page, size, sort });
+    return { rows: response.content, total: response.totalElements };
+  }
+}
+
+export class AclObjectsDataSource extends ReactPageDataSource<AclObjectIdentityDto> {
+  constructor() {
+    super("/api/security/acl/admin/objects");
+  }
+
+  override async fetchForAgGrid({ startRow, endRow, sortModel }: { startRow: number; endRow: number; sortModel?: { colId: string; sort: string }[]; }) {
+    const size = endRow - startRow || this.pageSize;
+    const page = Math.floor(startRow / size);
+    const sort = sortModel && sortModel.length > 0 ? `${sortModel[0].colId},${sortModel[0].sort}` : undefined;
+    const response = await reactAclApi.listObjectsPage({ page, size, sort });
+    return { rows: response.content, total: response.totalElements };
+  }
+}
+
+export class AclEntriesDataSource extends ReactPageDataSource<AclEntryDto> {
+  constructor() {
+    super("/api/security/acl/admin/entries");
+  }
+
+  override async fetchForAgGrid({ startRow, endRow, sortModel }: { startRow: number; endRow: number; sortModel?: { colId: string; sort: string }[]; }) {
+    const size = endRow - startRow || this.pageSize;
+    const page = Math.floor(startRow / size);
+    const sort = sortModel && sortModel.length > 0 ? `${sortModel[0].colId},${sortModel[0].sort}` : undefined;
+    const response = await reactAclApi.listEntriesPage({ page, size, sort });
+    return { rows: response.content, total: response.totalElements };
+  }
+}

--- a/src/react/pages/acl/queryKeys.ts
+++ b/src/react/pages/acl/queryKeys.ts
@@ -1,0 +1,3 @@
+import { createQueryKeys } from "@/react/query/keys";
+
+export const aclQueryKeys = createQueryKeys("acl");

--- a/src/react/router/AdminRoutes.tsx
+++ b/src/react/router/AdminRoutes.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from "react-router-dom";
 import { GroupsPage, RolesPage, UsersPage } from "@/react/pages/admin";
+import { AclPage } from "@/react/pages/acl/AclPage";
 import { GroupDetailPage } from "@/react/pages/admin/groups/GroupDetailPage";
 import { RoleDetailPage } from "@/react/pages/admin/roles/RoleDetailPage";
 import { UserDetailPage } from "@/react/pages/admin/users/UserDetailPage";
@@ -13,6 +14,7 @@ export function AdminRoutes() {
       <Route path="users/:userId" element={<UserDetailPage />} />
       <Route path="groups" element={<GroupsPage />} />
       <Route path="groups/:groupId" element={<GroupDetailPage />} />
+      <Route path="acl" element={<AclPage />} />
       <Route path="roles" element={<RolesPage />} />
       <Route path="roles/:roleId" element={<RoleDetailPage />} />
       <Route path="audit/login-failures" element={<LoginFailureLogPage />} />


### PR DESCRIPTION
## Related Issue
- Closes #35
- Related umbrella: #27

## Why
Track C ACL management was still missing after Track A, Track B, and the audit pages were merged. The admin runtime needed a reachable React ACL management surface for classes, SIDs, object identities, and entries.

## What
- add `AclPage` for `/admin/acl`
- add `CreateClassDialog`, `CreateSidDialog`, `CreateObjectDialog`, and `CreateEntryDialog`
- add feature-local ACL `api.ts` and `queryKeys.ts`
- register the ACL route in `AdminRoutes.tsx`

## Validation
- [x] build
- [ ] test
- [ ] manual verification
- [ ] analysis only (no code change)

Validation command:
- `npm run build`

## Checklist
- [x] working branch used or direct main change justified
- [x] commit message rule followed
- [x] issue template used where applicable and `AI-Assisted` handling remains documented by policy
- [x] no unrelated changes included
- [ ] documentation updated if needed
- [ ] changelog updated if needed
- [ ] AI-assisted change reviewed by human

## AI-Assisted
- [x] Yes
- [ ] No
