### PR TITLE
[ai-assisted] feat(service-ops): add react mail storage and ai pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- React migration issue `#38` added React mail operations, object storage browsing, and AI chat/RAG pages with route wiring for the `2.x` runtime.
 - React migration issue `#39` cleanup removed directly superseded Vue admin pages for ACL, forum admin, and login-failure audit after their React replacements were merged.
 - Repository policy documents and issue/MR templates were updated to tighten single-selection rules, add subagent usage recording, and expand policy source precedence.
 - `docs/remaining-react-migration-plan.md` now defines a parallel wave-based execution order instead of a purely sequential five-track order.
@@ -11,6 +12,8 @@
 
 ### Verification
 
+- `npm run typecheck`
+- `npm run build`
 - Confirmed the React router and page tree now cover the removed ACL/forum-admin/login-failure paths before deleting the legacy Vue files.
 - Reviewed updated policy/template diffs for `AGENTS.md`, `AI_DEVELOPMENT_POLICY.md`, `CONTRIBUTING.md`, `.gitlab/issue_templates/default.md`, and `.gitlab/merge_request_templates/default.md`.
 - Reviewed the updated migration plan structure against `AGENTS.md`, `AI_DEVELOPMENT_POLICY.md`, and `.gitlab/issue_templates/default.md`.

--- a/src/react/pages/ai/ChatPage.tsx
+++ b/src/react/pages/ai/ChatPage.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Breadcrumbs,
+  Button,
+  Card,
+  CardContent,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { reactAiApi } from "@/react/pages/ai/api";
+import type { AiInfoResponse, ChatMessageDto, ProviderInfo } from "@/types/studio/ai";
+import { resolveAxiosError } from "@/utils/helpers";
+
+type ChatMessage = ChatMessageDto & { model?: string };
+
+export function ChatPage() {
+  const [aiInfo, setAiInfo] = useState<AiInfoResponse | null>(null);
+  const [provider, setProvider] = useState("");
+  const [model, setModel] = useState("");
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  const providers = useMemo<ProviderInfo[]>(() => aiInfo?.providers ?? [], [aiInfo]);
+
+  useEffect(() => {
+    reactAiApi
+      .fetchProviders()
+      .then((data) => {
+        setAiInfo(data);
+        setProvider(data.defaultProvider);
+        const match = data.providers.find((item) => item.name === data.defaultProvider);
+        setModel(match?.chat.model ?? "");
+      })
+      .catch((loadError) => setError(resolveAxiosError(loadError)));
+  }, []);
+
+  function handleProviderChange(nextProvider: string) {
+    setProvider(nextProvider);
+    const match = providers.find((item) => item.name === nextProvider);
+    setModel(match?.chat.model ?? "");
+  }
+
+  async function handleSend() {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return;
+    }
+    const userMessage: ChatMessage = { role: "user", content: trimmed };
+    const nextMessages: ChatMessage[] = [...messages, userMessage];
+    setMessages(nextMessages);
+    setInput("");
+    setSending(true);
+    setError(null);
+    try {
+      const response = await reactAiApi.sendChat({
+        provider: provider || undefined,
+        model: model || undefined,
+        messages: nextMessages,
+        systemPrompt: systemPrompt.trim() || undefined,
+      });
+      const assistant = [...response.messages].reverse().find((item) => item.role === "assistant");
+      if (assistant) {
+        setMessages((current) => [...current, { ...assistant, model: response.model ?? model }]);
+      }
+    } catch (sendError) {
+      const message = resolveAxiosError(sendError);
+      setError(message);
+      setMessages((current) => [...current, { role: "assistant", content: `오류: ${message}`, model }]);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">서비스 관리</Typography>
+        <Typography color="text.secondary">AI</Typography>
+        <Typography color="text.primary">Chat</Typography>
+      </Breadcrumbs>
+      <Typography variant="h5">AI Chat</Typography>
+      {error ? <Alert severity="error">{error}</Alert> : null}
+      <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+        <TextField
+          select
+          label="Provider"
+          value={provider}
+          onChange={(event) => handleProviderChange(event.target.value)}
+          fullWidth
+        >
+          {providers.map((item) => (
+            <MenuItem key={item.name} value={item.name}>
+              {item.name}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField label="Model" value={model} onChange={(event) => setModel(event.target.value)} fullWidth />
+      </Stack>
+      <TextField
+        label="System Prompt"
+        value={systemPrompt}
+        onChange={(event) => setSystemPrompt(event.target.value)}
+        multiline
+        minRows={2}
+      />
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={1.5}>
+            {messages.length === 0 ? (
+              <Typography color="text.secondary">대화를 시작하세요.</Typography>
+            ) : (
+              messages.map((message, index) => (
+                <Box
+                  key={`${message.role}-${index}`}
+                  sx={{
+                    alignSelf: message.role === "user" ? "flex-end" : "flex-start",
+                    maxWidth: "80%",
+                    p: 1.5,
+                    borderRadius: 1,
+                    bgcolor: message.role === "user" ? "primary.light" : "grey.100",
+                  }}
+                >
+                  <Typography variant="caption" color="text.secondary">
+                    {message.role}
+                    {message.model ? ` · ${message.model}` : ""}
+                  </Typography>
+                  <Typography>{message.content}</Typography>
+                </Box>
+              ))
+            )}
+          </Stack>
+        </CardContent>
+      </Card>
+      <TextField
+        label="Text"
+        value={input}
+        onChange={(event) => setInput(event.target.value)}
+        multiline
+        minRows={3}
+      />
+      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+        <Button variant="contained" onClick={() => void handleSend()} disabled={sending || !input.trim()}>
+          전송
+        </Button>
+      </Box>
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/RagPage.tsx
+++ b/src/react/pages/ai/RagPage.tsx
@@ -14,7 +14,12 @@ import {
 import type { ColDef } from "ag-grid-community";
 import { GridContent } from "@/react/components/ag-grid";
 import { reactAiApi } from "@/react/pages/ai/api";
-import type { AiInfoResponse, ProviderInfo, VectorSearchResultDto } from "@/types/studio/ai";
+import type {
+  AiInfoResponse,
+  ChatMessageDto,
+  ProviderInfo,
+  VectorSearchResultDto,
+} from "@/types/studio/ai";
 import { resolveAxiosError } from "@/utils/helpers";
 
 export function RagPage() {
@@ -26,6 +31,8 @@ export function RagPage() {
   const [expandedQuery, setExpandedQuery] = useState("");
   const [expandedKeywords, setExpandedKeywords] = useState<string[]>([]);
   const [rows, setRows] = useState<VectorSearchResultDto[]>([]);
+  const [chatInput, setChatInput] = useState("");
+  const [chatMessages, setChatMessages] = useState<ChatMessageDto[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   const providers = useMemo<ProviderInfo[]>(() => aiInfo?.providers ?? [], [aiInfo]);
@@ -76,6 +83,44 @@ export function RagPage() {
     }
   }
 
+  async function handleRagChat() {
+    const trimmed = chatInput.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const nextMessages: ChatMessageDto[] = [
+      ...chatMessages,
+      { role: "user", content: trimmed },
+    ];
+
+    setChatMessages(nextMessages);
+    setChatInput("");
+    setError(null);
+
+    try {
+      const response = await reactAiApi.sendRagChat({
+        chat: {
+          provider: provider || undefined,
+          model: model || undefined,
+          messages: nextMessages,
+        },
+        ragQuery: expandedQuery.trim() || query.trim() || trimmed,
+        ragTopK: Number(topK) || 3,
+      });
+
+      const assistant = [...response.messages]
+        .reverse()
+        .find((message) => message.role === "assistant");
+
+      if (assistant) {
+        setChatMessages((current) => [...current, assistant]);
+      }
+    } catch (chatError) {
+      setError(resolveAxiosError(chatError));
+    }
+  }
+
   return (
     <Stack spacing={2}>
       <Breadcrumbs separator="›">
@@ -119,6 +164,41 @@ export function RagPage() {
           확장 쿼리로 검색
         </Button>
       </Stack>
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={2}>
+            <Typography variant="subtitle2">RAG Chat</Typography>
+            <Stack spacing={1}>
+              {chatMessages.length === 0 ? (
+                <Typography color="text.secondary">RAG 대화를 시작하세요.</Typography>
+              ) : (
+                chatMessages.map((message, index) => (
+                  <TextField
+                    key={`${message.role}-${index}`}
+                    label={message.role}
+                    value={message.content}
+                    InputProps={{ readOnly: true }}
+                    multiline
+                    minRows={2}
+                  />
+                ))
+              )}
+            </Stack>
+            <TextField
+              label="RAG 질문"
+              value={chatInput}
+              onChange={(event) => setChatInput(event.target.value)}
+              multiline
+              minRows={3}
+            />
+            <Stack direction="row" justifyContent="flex-end">
+              <Button variant="contained" onClick={() => void handleRagChat()} disabled={!chatInput.trim()}>
+                RAG 요청
+              </Button>
+            </Stack>
+          </Stack>
+        </CardContent>
+      </Card>
       {expandedKeywords.length > 0 ? (
         <Card variant="outlined">
           <CardContent>

--- a/src/react/pages/ai/RagPage.tsx
+++ b/src/react/pages/ai/RagPage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Breadcrumbs,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import type { ColDef } from "ag-grid-community";
+import { GridContent } from "@/react/components/ag-grid";
+import { reactAiApi } from "@/react/pages/ai/api";
+import type { AiInfoResponse, ProviderInfo, VectorSearchResultDto } from "@/types/studio/ai";
+import { resolveAxiosError } from "@/utils/helpers";
+
+export function RagPage() {
+  const [aiInfo, setAiInfo] = useState<AiInfoResponse | null>(null);
+  const [provider, setProvider] = useState("");
+  const [model, setModel] = useState("");
+  const [query, setQuery] = useState("");
+  const [topK, setTopK] = useState("3");
+  const [expandedQuery, setExpandedQuery] = useState("");
+  const [expandedKeywords, setExpandedKeywords] = useState<string[]>([]);
+  const [rows, setRows] = useState<VectorSearchResultDto[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const providers = useMemo<ProviderInfo[]>(() => aiInfo?.providers ?? [], [aiInfo]);
+
+  useEffect(() => {
+    reactAiApi
+      .fetchProviders()
+      .then((data) => {
+        setAiInfo(data);
+        setProvider(data.defaultProvider);
+        const match = data.providers.find((item) => item.name === data.defaultProvider);
+        setModel(match?.chat.model ?? "");
+      })
+      .catch((loadError) => setError(resolveAxiosError(loadError)));
+  }, []);
+
+  const columnDefs = useMemo<ColDef<VectorSearchResultDto>[]>(
+    () => [
+      { field: "id", headerName: "ID", flex: 0.5 },
+      { field: "score", headerName: "유사도", flex: 0.3, sortable: true },
+      { field: "content", headerName: "콘텐츠", flex: 1.3 },
+    ],
+    []
+  );
+
+  async function handleSearch(usingExpandedQuery = false) {
+    setError(null);
+    try {
+      const data = await reactAiApi.searchVector({
+        query: usingExpandedQuery ? expandedQuery : query,
+        topK: Number(topK) || 3,
+        hybrid: true,
+      });
+      setRows(data);
+    } catch (searchError) {
+      setError(resolveAxiosError(searchError));
+    }
+  }
+
+  async function handleRewrite() {
+    setError(null);
+    try {
+      const data = await reactAiApi.rewriteQuery({ query });
+      setExpandedQuery(data.expandedQuery);
+      setExpandedKeywords(data.keywords);
+    } catch (rewriteError) {
+      setError(resolveAxiosError(rewriteError));
+    }
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">서비스 관리</Typography>
+        <Typography color="text.secondary">AI</Typography>
+        <Typography color="text.primary">RAG</Typography>
+      </Breadcrumbs>
+      <Typography variant="h5">RAG Search</Typography>
+      {error ? <Alert severity="error">{error}</Alert> : null}
+      <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+        <TextField
+          select
+          label="Provider"
+          value={provider}
+          onChange={(event) => {
+            const nextProvider = event.target.value;
+            setProvider(nextProvider);
+            const match = providers.find((item) => item.name === nextProvider);
+            setModel(match?.chat.model ?? "");
+          }}
+          fullWidth
+        >
+          {providers.map((item) => (
+            <MenuItem key={item.name} value={item.name}>
+              {item.name}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField label="Model" value={model} onChange={(event) => setModel(event.target.value)} fullWidth />
+        <TextField label="topK" value={topK} onChange={(event) => setTopK(event.target.value)} sx={{ maxWidth: 140 }} />
+      </Stack>
+      <TextField label="쿼리" value={query} onChange={(event) => setQuery(event.target.value)} />
+      <Stack direction="row" spacing={1}>
+        <Button variant="contained" onClick={() => void handleSearch(false)} disabled={!query.trim()}>
+          검색
+        </Button>
+        <Button variant="outlined" onClick={() => void handleRewrite()} disabled={!query.trim()}>
+          쿼리 확장
+        </Button>
+        <Button variant="text" onClick={() => void handleSearch(true)} disabled={!expandedQuery.trim()}>
+          확장 쿼리로 검색
+        </Button>
+      </Stack>
+      {expandedKeywords.length > 0 ? (
+        <Card variant="outlined">
+          <CardContent>
+            <Stack spacing={1}>
+              <Typography variant="subtitle2">확장 키워드</Typography>
+              <Stack direction="row" spacing={1} flexWrap="wrap">
+                {expandedKeywords.map((keyword) => (
+                  <Chip key={keyword} label={keyword} />
+                ))}
+              </Stack>
+              <TextField label="확장 쿼리" value={expandedQuery} InputProps={{ readOnly: true }} />
+            </Stack>
+          </CardContent>
+        </Card>
+      ) : null}
+      <GridContent<VectorSearchResultDto> columns={columnDefs} rowData={rows} height={360} />
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/api.ts
+++ b/src/react/pages/ai/api.ts
@@ -1,0 +1,35 @@
+import { apiRequest } from "@/react/query/fetcher";
+import type {
+  AiInfoResponse,
+  ChatRagRequestDto,
+  ChatRequestDto,
+  ChatResponseDto,
+  QueryRewriteRequestDto,
+  QueryRewriteResponseDto,
+  VectorSearchRequestDto,
+  VectorSearchResultDto,
+} from "@/types/studio/ai";
+
+const BASE = "/api/ai";
+
+export const reactAiApi = {
+  sendChat(req: ChatRequestDto) {
+    return apiRequest<ChatResponseDto>("post", `${BASE}/chat`, { data: req });
+  },
+
+  sendRagChat(req: ChatRagRequestDto) {
+    return apiRequest<ChatResponseDto>("post", `${BASE}/chat/rag`, { data: req });
+  },
+
+  fetchProviders() {
+    return apiRequest<AiInfoResponse>("get", `${BASE}/info/providers`);
+  },
+
+  searchVector(req: VectorSearchRequestDto) {
+    return apiRequest<VectorSearchResultDto[]>("post", `${BASE}/vectors/search`, { data: req });
+  },
+
+  rewriteQuery(req: QueryRewriteRequestDto) {
+    return apiRequest<QueryRewriteResponseDto>("post", `${BASE}/query-rewrite`, { data: req });
+  },
+};

--- a/src/react/pages/ai/queryKeys.ts
+++ b/src/react/pages/ai/queryKeys.ts
@@ -1,0 +1,3 @@
+import { createQueryKeys } from "@/react/query/keys";
+
+export const aiQueryKeys = createQueryKeys("ai");

--- a/src/react/pages/mail/MailInboxPage.tsx
+++ b/src/react/pages/mail/MailInboxPage.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from "@mui/material";
 import { DeleteOutlined, RefreshOutlined, SearchOutlined } from "@mui/icons-material";
+import DOMPurify from "dompurify";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
 import { PageableGridContent } from "@/react/components/ag-grid";
 import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
@@ -47,7 +48,9 @@ function MailDetailDialog({
             </Typography>
             <Box
               sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1, p: 2 }}
-              dangerouslySetInnerHTML={{ __html: message.body || "<p>메일 본문이 없습니다.</p>" }}
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(message.body || "<p>메일 본문이 없습니다.</p>"),
+              }}
             />
           </Stack>
         ) : null}

--- a/src/react/pages/mail/MailInboxPage.tsx
+++ b/src/react/pages/mail/MailInboxPage.tsx
@@ -1,0 +1,199 @@
+import { useMemo, useRef, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { DeleteOutlined, RefreshOutlined, SearchOutlined } from "@mui/icons-material";
+import type { ColDef, ICellRendererParams } from "ag-grid-community";
+import { PageableGridContent } from "@/react/components/ag-grid";
+import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
+import { confirm, toast } from "@/react/feedback";
+import { MailInboxDataSource } from "@/react/pages/mail/datasource";
+import { reactMailApi } from "@/react/pages/mail/api";
+import type { MailMessageDto } from "@/types/studio/mail";
+import { resolveAxiosError } from "@/utils/helpers";
+
+function MailDetailDialog({
+  open,
+  onClose,
+  message,
+}: {
+  open: boolean;
+  onClose: () => void;
+  message: MailMessageDto | null;
+}) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>{message?.subject || "(제목 없음)"}</DialogTitle>
+      <DialogContent dividers>
+        {message ? (
+          <Stack spacing={2}>
+            <Typography variant="body2" color="text.secondary">
+              보낸 사람: {message.fromAddress || "-"}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              받는 사람: {message.toAddress || "-"}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              수신일: {message.receivedAt ? new Date(message.receivedAt).toLocaleString() : "-"}
+            </Typography>
+            <Box
+              sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1, p: 2 }}
+              dangerouslySetInnerHTML={{ __html: message.body || "<p>메일 본문이 없습니다.</p>" }}
+            />
+          </Stack>
+        ) : null}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export function MailInboxPage() {
+  const gridRef = useRef<PageableGridContentHandle<MailMessageDto>>(null);
+  const dataSource = useMemo(() => new MailInboxDataSource(), []);
+  const [searchInput, setSearchInput] = useState("");
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [selectedMessage, setSelectedMessage] = useState<MailMessageDto | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const columnDefs = useMemo<ColDef<MailMessageDto>[]>(
+    () => [
+      { field: "fromAddress", headerName: "보낸 사람", flex: 0.8, sortable: true },
+      { field: "folder", headerName: "폴더", flex: 0.35, sortable: true },
+      {
+        field: "subject",
+        headerName: "제목",
+        flex: 1.2,
+        sortable: true,
+        cellRenderer: (params: ICellRendererParams<MailMessageDto>) => (
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => {
+              setSelectedMessage(params.data ?? null);
+              setDetailOpen(true);
+            }}
+          >
+            {params.value || "(제목 없음)"}
+          </Button>
+        ),
+      },
+      {
+        field: "sentAt",
+        headerName: "발송일",
+        flex: 0.45,
+        sortable: true,
+        valueFormatter: (params) => (params.value ? new Date(params.value).toLocaleString() : ""),
+      },
+      {
+        field: "receivedAt",
+        headerName: "수신일",
+        flex: 0.45,
+        sortable: true,
+        valueFormatter: (params) => (params.value ? new Date(params.value).toLocaleString() : ""),
+      },
+    ],
+    []
+  );
+
+  function handleSearch() {
+    setError(null);
+    dataSource.applyFilter(
+      searchInput.trim()
+        ? { q: searchInput.trim(), fields: "fromAddress,toAddress,subject,body" }
+        : {}
+    );
+    gridRef.current?.refresh();
+  }
+
+  async function handleDeleteSelected() {
+    const rows = gridRef.current?.selectedRows() ?? [];
+    const ids = rows
+      .map((row) => Number(row.mailId))
+      .filter((id) => Number.isFinite(id) && id > 0);
+    if (ids.length === 0) {
+      return;
+    }
+    const ok = await confirm({
+      title: "메일 삭제",
+      message: `선택한 ${ids.length}개의 메일을 삭제하시겠습니까?`,
+      okText: "삭제",
+      cancelText: "취소",
+    });
+    if (!ok) {
+      return;
+    }
+    try {
+      await Promise.all(ids.map((id) => reactMailApi.deleteMessage(id)));
+      toast.success("선택한 메일을 삭제했습니다.");
+      gridRef.current?.deselectAll();
+      gridRef.current?.refresh();
+    } catch (deleteError) {
+      const message = resolveAxiosError(deleteError);
+      setError(message);
+      toast.error(message);
+    }
+  }
+
+  return (
+    <>
+      <Stack spacing={2}>
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <Typography variant="h6">메일 Inbox</Typography>
+          <Stack direction="row" spacing={1}>
+            <Button startIcon={<DeleteOutlined />} color="error" onClick={() => void handleDeleteSelected()}>
+              선택 삭제
+            </Button>
+            <Button startIcon={<RefreshOutlined />} onClick={() => gridRef.current?.refresh()}>
+              새로고침
+            </Button>
+          </Stack>
+        </Box>
+
+        <TextField
+          label="검색어"
+          value={searchInput}
+          onChange={(event) => setSearchInput(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              handleSearch();
+            }
+          }}
+          InputProps={{
+            endAdornment: (
+              <Button size="small" startIcon={<SearchOutlined />} onClick={handleSearch}>
+                검색
+              </Button>
+            ),
+          }}
+        />
+
+        {error ? <Alert severity="error">{error}</Alert> : null}
+
+        <PageableGridContent<MailMessageDto>
+          ref={gridRef}
+          datasource={dataSource}
+          columns={columnDefs}
+          rowSelection="multiple"
+        />
+      </Stack>
+
+      <MailDetailDialog
+        open={detailOpen}
+        onClose={() => setDetailOpen(false)}
+        message={selectedMessage}
+      />
+    </>
+  );
+}

--- a/src/react/pages/mail/MailPage.tsx
+++ b/src/react/pages/mail/MailPage.tsx
@@ -1,0 +1,38 @@
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Box, Breadcrumbs, Button, Stack, Typography } from "@mui/material";
+
+export function MailPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isInbox = location.pathname.endsWith("/inbox") || location.pathname.endsWith("/mail");
+  const isSync = location.pathname.endsWith("/sync");
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">응용프로그램</Typography>
+        <Typography color="text.primary">메일</Typography>
+      </Breadcrumbs>
+
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">메일 운영</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant={isInbox ? "contained" : "text"}
+            onClick={() => navigate("/application/mail/inbox")}
+          >
+            Inbox
+          </Button>
+          <Button
+            variant={isSync ? "contained" : "text"}
+            onClick={() => navigate("/application/mail/sync")}
+          >
+            Sync
+          </Button>
+        </Stack>
+      </Box>
+
+      <Outlet />
+    </Stack>
+  );
+}

--- a/src/react/pages/mail/MailSyncPage.tsx
+++ b/src/react/pages/mail/MailSyncPage.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Alert, Box, Button, Stack, Typography } from "@mui/material";
+import { EmailOutlined, RefreshOutlined } from "@mui/icons-material";
+import type { ColDef } from "ag-grid-community";
+import { PageableGridContent } from "@/react/components/ag-grid";
+import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
+import { reactMailApi } from "@/react/pages/mail/api";
+import { MailSyncLogDataSource } from "@/react/pages/mail/datasource";
+import { toast } from "@/react/feedback";
+import type { MailSyncLogDto } from "@/types/studio/mail";
+import { resolveAxiosError } from "@/utils/helpers";
+
+export function MailSyncPage() {
+  const gridRef = useRef<PageableGridContentHandle<MailSyncLogDto>>(null);
+  const dataSource = useMemo(() => new MailSyncLogDataSource(), []);
+  const [error, setError] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+
+  const columnDefs = useMemo<ColDef<MailSyncLogDto>[]>(
+    () => [
+      { field: "logId", headerName: "ID", flex: 0.25, sortable: true },
+      { field: "processed", headerName: "처리건수", flex: 0.3, sortable: true },
+      { field: "succeeded", headerName: "성공건수", flex: 0.3, sortable: true },
+      { field: "failed", headerName: "실패건수", flex: 0.3, sortable: true },
+      {
+        field: "startedAt",
+        headerName: "시작일",
+        flex: 0.55,
+        sortable: true,
+        valueFormatter: (params) => (params.value ? new Date(params.value).toLocaleString() : ""),
+      },
+      {
+        field: "finishedAt",
+        headerName: "종료일",
+        flex: 0.55,
+        sortable: true,
+        valueFormatter: (params) => (params.value ? new Date(params.value).toLocaleString() : ""),
+      },
+      { field: "status", headerName: "상태", flex: 0.3, sortable: true },
+      { field: "message", headerName: "메시지", flex: 1 },
+      { field: "triggeredBy", headerName: "방법", flex: 0.45 },
+    ],
+    []
+  );
+
+  useEffect(() => {
+    const unsubscribe = reactMailApi.subscribeSync(
+      (payload) => {
+        if (payload.status === "completed") {
+          toast.success(`메일 동기화 완료 (#${payload.logId})`);
+          gridRef.current?.refresh();
+          setSyncing(false);
+        } else if (payload.status === "failed") {
+          toast.error(payload.message || `메일 동기화 실패 (#${payload.logId})`);
+          gridRef.current?.refresh();
+          setSyncing(false);
+        }
+      },
+      () => {
+        setError("메일 동기화 SSE 연결에 실패했습니다.");
+      }
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  async function handleSync() {
+    setError(null);
+    setSyncing(true);
+    try {
+      await reactMailApi.startSync();
+      toast.info("메일 동기화를 요청했습니다.");
+    } catch (syncError) {
+      const message = resolveAxiosError(syncError);
+      setError(message);
+      toast.error(message);
+      setSyncing(false);
+    }
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h6">메일 동기화</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            startIcon={<EmailOutlined />}
+            variant="contained"
+            onClick={() => void handleSync()}
+            disabled={syncing}
+          >
+            메일 동기화 요청
+          </Button>
+          <Button startIcon={<RefreshOutlined />} onClick={() => gridRef.current?.refresh()}>
+            새로고침
+          </Button>
+        </Stack>
+      </Box>
+
+      {error ? <Alert severity="error">{error}</Alert> : null}
+
+      <PageableGridContent<MailSyncLogDto>
+        ref={gridRef}
+        datasource={dataSource}
+        columns={columnDefs}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/mail/api.ts
+++ b/src/react/pages/mail/api.ts
@@ -1,0 +1,37 @@
+import { apiRequest } from "@/react/query/fetcher";
+import { subscribeMailSync as subscribeMailSyncSource } from "@/data/studio/mgmt/mail";
+import type { PageResponse } from "@/types/studio/api-common";
+import type { MailMessageDto, MailSyncLogDto } from "@/types/studio/mail";
+
+const BASE = "/api/mgmt/mail";
+
+export const reactMailApi = {
+  listInbox(params?: { page?: number; size?: number; q?: string; fields?: string }) {
+    return apiRequest<PageResponse<MailMessageDto>>("get", BASE, { params });
+  },
+
+  getMessage(mailId: number) {
+    return apiRequest<MailMessageDto>("get", `${BASE}/${mailId}`);
+  },
+
+  deleteMessage(mailId: number) {
+    return apiRequest<void>("delete", `${BASE}/${mailId}`);
+  },
+
+  startSync() {
+    return apiRequest<number>("post", `${BASE}/sync`);
+  },
+
+  listSyncLogs(params?: { page?: number; size?: number }) {
+    return apiRequest<PageResponse<MailSyncLogDto>>("get", `${BASE}/sync/logs/page`, {
+      params,
+    });
+  },
+
+  subscribeSync(
+    onMessage: (payload: MailSyncLogDto) => void,
+    onError?: (err: unknown) => void
+  ) {
+    return subscribeMailSyncSource(onMessage, onError, true);
+  },
+};

--- a/src/react/pages/mail/datasource.ts
+++ b/src/react/pages/mail/datasource.ts
@@ -1,0 +1,19 @@
+import { ReactPageDataSource } from "@/react/pages/admin/datasource";
+import type { MailMessageDto, MailSyncLogDto } from "@/types/studio/mail";
+import { apiRequest } from "@/react/query/fetcher";
+
+export class MailInboxDataSource extends ReactPageDataSource<MailMessageDto> {
+  constructor() {
+    super("/api/mgmt/mail");
+  }
+
+  getMessage(mailId: number) {
+    return apiRequest<MailMessageDto>("get", `/api/mgmt/mail/${mailId}`);
+  }
+}
+
+export class MailSyncLogDataSource extends ReactPageDataSource<MailSyncLogDto> {
+  constructor() {
+    super("/api/mgmt/mail/sync/logs/page");
+  }
+}

--- a/src/react/pages/mail/queryKeys.ts
+++ b/src/react/pages/mail/queryKeys.ts
@@ -1,0 +1,3 @@
+import { createQueryKeys } from "@/react/query/keys";
+
+export const mailQueryKeys = createQueryKeys("mail");

--- a/src/react/pages/objectstorage/ObjectDialog.tsx
+++ b/src/react/pages/objectstorage/ObjectDialog.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+} from "@mui/material";
+import { toast } from "@/react/feedback";
+import { reactObjectStorageApi } from "@/react/pages/objectstorage/api";
+import type { BucketDto, ObjectInfoDto, PresignedUrlDto } from "@/types/studio/storage";
+import { resolveAxiosError } from "@/utils/helpers";
+
+export function ObjectDialog({
+  open,
+  onClose,
+  bucket,
+  objectKey,
+}: {
+  open: boolean;
+  onClose: () => void;
+  bucket?: BucketDto | null;
+  objectKey?: string;
+}) {
+  const [head, setHead] = useState<ObjectInfoDto | null>(null);
+  const [presigned, setPresigned] = useState<PresignedUrlDto | null>(null);
+
+  useEffect(() => {
+    if (!open || !bucket || !objectKey) {
+      return;
+    }
+    reactObjectStorageApi
+      .fetchObjectHead({
+        providerId: bucket.providerId,
+        bucket: bucket.bucket,
+        key: objectKey,
+      })
+      .then(setHead)
+      .catch((error) => toast.error(resolveAxiosError(error)));
+  }, [open, bucket, objectKey]);
+
+  async function handlePresign() {
+    if (!bucket || !objectKey) {
+      return;
+    }
+    try {
+      const data = await reactObjectStorageApi.presignGet({
+        providerId: bucket.providerId,
+        bucket: bucket.bucket,
+        key: objectKey,
+      });
+      setPresigned(data);
+    } catch (error) {
+      toast.error(resolveAxiosError(error));
+    }
+  }
+
+  async function handleDownload() {
+    if (!bucket || !head?.key) {
+      return;
+    }
+    try {
+      await reactObjectStorageApi.downloadFile(bucket.providerId, bucket.bucket, head.key, head.name);
+    } catch (error) {
+      toast.error(resolveAxiosError(error));
+    }
+  }
+
+  async function handlePreview() {
+    if (!bucket || !head?.key) {
+      return;
+    }
+    try {
+      await reactObjectStorageApi.openInNewTab(bucket.providerId, bucket.bucket, head.key);
+    } catch (error) {
+      toast.error(resolveAxiosError(error));
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{objectKey || "Object"}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={1.5} sx={{ mt: 1 }}>
+          <TextField label="이름" value={head?.name ?? ""} InputProps={{ readOnly: true }} />
+          <TextField label="콘텐츠 종류" value={head?.contentType ?? ""} InputProps={{ readOnly: true }} />
+          <TextField label="크기" value={head?.size ?? ""} InputProps={{ readOnly: true }} />
+          <TextField label="etag" value={head?.eTag ?? ""} InputProps={{ readOnly: true }} />
+          <TextField
+            label="Pre Signed URL"
+            value={presigned?.url ?? ""}
+            InputProps={{ readOnly: true }}
+            multiline
+            minRows={2}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => void handlePresign()}>URL 생성</Button>
+        <Button onClick={() => void handleDownload()}>다운로드</Button>
+        <Button onClick={() => void handlePreview()}>미리보기</Button>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/objectstorage/ObjectStorageListPage.tsx
+++ b/src/react/pages/objectstorage/ObjectStorageListPage.tsx
@@ -1,0 +1,68 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { Alert, Box, Breadcrumbs, Button, Stack, Typography } from "@mui/material";
+import { RefreshOutlined } from "@mui/icons-material";
+import type { ColDef, ICellRendererParams } from "ag-grid-community";
+import { GridContent } from "@/react/components/ag-grid";
+import type { GridContentHandle } from "@/react/components/ag-grid/types";
+import { reactObjectStorageApi } from "@/react/pages/objectstorage/api";
+import { objectStorageQueryKeys } from "@/react/pages/objectstorage/queryKeys";
+import type { ProviderDto } from "@/types/studio/storage";
+
+export function ObjectStorageListPage() {
+  const navigate = useNavigate();
+  const gridRef = useRef<GridContentHandle<ProviderDto>>(null);
+
+  const providersQuery = useQuery({
+    queryKey: objectStorageQueryKeys.custom("providers"),
+    queryFn: () => reactObjectStorageApi.fetchProviders(),
+  });
+
+  const columnDefs = useMemo<ColDef<ProviderDto>[]>(
+    () => [
+      {
+        field: "name",
+        headerName: "ID",
+        flex: 0.7,
+        sortable: true,
+        cellRenderer: (params: ICellRendererParams<ProviderDto>) => (
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => navigate(`/services/object-storage/${params.data?.name}`)}
+          >
+            {params.value}
+          </Button>
+        ),
+      },
+      { field: "type", headerName: "유형", flex: 0.4, sortable: true },
+      { field: "health", headerName: "상태", flex: 0.35, sortable: true },
+      { field: "region", headerName: "리전", flex: 0.35, sortable: true },
+      { field: "endpointMasked", headerName: "엔드포인트", flex: 1.2 },
+    ],
+    [navigate]
+  );
+
+  return (
+    <Stack spacing={2}>
+      <Breadcrumbs separator="›">
+        <Typography color="text.secondary">서비스 관리</Typography>
+        <Typography color="text.primary">Object Storage</Typography>
+      </Breadcrumbs>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="h5">Providers</Typography>
+        <Button startIcon={<RefreshOutlined />} onClick={() => providersQuery.refetch()}>
+          새로고침
+        </Button>
+      </Box>
+      {providersQuery.isError ? <Alert severity="error">Provider 목록을 불러오지 못했습니다.</Alert> : null}
+      <GridContent<ProviderDto>
+        ref={gridRef}
+        columns={columnDefs}
+        rowData={providersQuery.data ?? []}
+        height={320}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/objectstorage/ObjectStoragePage.tsx
+++ b/src/react/pages/objectstorage/ObjectStoragePage.tsx
@@ -1,0 +1,178 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import { Alert, Box, Breadcrumbs, Button, Chip, Stack, Typography } from "@mui/material";
+import type { ColDef, ICellRendererParams } from "ag-grid-community";
+import { GridContent } from "@/react/components/ag-grid";
+import { objectStorageQueryKeys } from "@/react/pages/objectstorage/queryKeys";
+import { reactObjectStorageApi } from "@/react/pages/objectstorage/api";
+import { ObjectDialog } from "@/react/pages/objectstorage/ObjectDialog";
+import type { BucketDto, ObjectListItemDto } from "@/types/studio/storage";
+
+export function ObjectStoragePage() {
+  const { providerId = "" } = useParams();
+  const [bucket, setBucket] = useState<BucketDto | null>(null);
+  const [prefix, setPrefix] = useState("");
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  const bucketsQuery = useQuery({
+    queryKey: objectStorageQueryKeys.custom("buckets", providerId),
+    queryFn: () => reactObjectStorageApi.fetchBuckets({ providerId }),
+    enabled: Boolean(providerId),
+  });
+
+  const objectsQuery = useQuery({
+    queryKey: objectStorageQueryKeys.custom("objects", providerId, bucket?.bucket ?? "", prefix),
+    queryFn: () =>
+      reactObjectStorageApi.fetchObjects({
+        providerId,
+        bucket: bucket?.bucket ?? "",
+        prefix: prefix || undefined,
+      }),
+    enabled: Boolean(providerId) && Boolean(bucket?.bucket),
+  });
+
+  const rows = useMemo(
+    () =>
+      objectsQuery.data
+        ? reactObjectStorageApi.toRows(objectsQuery.data, true).filter((item) => {
+            if (!prefix) return true;
+            const slash = prefix.endsWith("/") ? prefix : `${prefix}/`;
+            const noSlash = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+            return item.key !== slash && item.key !== noSlash;
+          })
+        : [],
+    [objectsQuery.data, prefix]
+  );
+
+  const bucketColumns = useMemo<ColDef<BucketDto>[]>(
+    () => [
+      {
+        field: "bucket",
+        headerName: "버킷",
+        flex: 1,
+        sortable: true,
+        cellRenderer: (params: ICellRendererParams<BucketDto>) => (
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => {
+              setBucket(params.data ?? null);
+              setPrefix("");
+            }}
+          >
+            {params.value}
+          </Button>
+        ),
+      },
+      { field: "objectStorageType", headerName: "유형", flex: 0.45, sortable: true },
+      {
+        field: "createdDate",
+        headerName: "생성일",
+        flex: 0.45,
+        sortable: true,
+        valueFormatter: (params) => (params.value ? new Date(params.value).toLocaleString() : ""),
+      },
+    ],
+    []
+  );
+
+  const objectColumns = useMemo<ColDef<ObjectListItemDto>[]>(
+    () => [
+      {
+        field: "key",
+        headerName: "이름",
+        flex: 1.2,
+        sortable: true,
+        cellRenderer: (params: ICellRendererParams<ObjectListItemDto>) => (
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => {
+              const row = params.data;
+              if (!row) return;
+              if (row.folder) {
+                setPrefix(row.key);
+                return;
+              }
+              setSelectedKey(row.key);
+            }}
+          >
+            {prefix ? params.value?.replace(prefix, "") : params.value}
+          </Button>
+        ),
+      },
+      { field: "size", headerName: "크기", flex: 0.4, sortable: true },
+      {
+        field: "lastModified",
+        headerName: "수정일",
+        flex: 0.5,
+        sortable: true,
+        valueFormatter: (params) => (params.value ? new Date(params.value).toLocaleString() : ""),
+      },
+      {
+        field: "folder",
+        headerName: "종류",
+        flex: 0.3,
+        valueFormatter: (params) => (params.value ? "폴더" : "파일"),
+      },
+    ],
+    [prefix]
+  );
+
+  const breadcrumbs = reactObjectStorageApi.buildBreadcrumb(prefix, {
+    rootLabel: bucket?.bucket ?? "root",
+    rootDisabled: false,
+  });
+
+  return (
+    <>
+      <Stack spacing={2}>
+        <Breadcrumbs separator="›">
+          <Typography color="text.secondary">서비스 관리</Typography>
+          <Typography color="text.secondary">Object Storage</Typography>
+          <Typography color="text.primary">{providerId}</Typography>
+        </Breadcrumbs>
+
+        <Typography variant="h5">Buckets</Typography>
+        {bucketsQuery.isError ? <Alert severity="error">버킷 목록을 불러오지 못했습니다.</Alert> : null}
+        <GridContent<BucketDto> columns={bucketColumns} rowData={bucketsQuery.data ?? []} height={280} />
+
+        {bucket ? (
+          <Stack spacing={2}>
+            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <Stack direction="row" spacing={1} flexWrap="wrap">
+                {breadcrumbs.map((item) => (
+                  <Chip
+                    key={item.prefix}
+                    label={item.label}
+                    onClick={item.disabled ? undefined : () => setPrefix(item.prefix)}
+                    variant={item.disabled ? "filled" : "outlined"}
+                  />
+                ))}
+              </Stack>
+              {reactObjectStorageApi.hasMore(objectsQuery.data?.truncated, objectsQuery.data?.nextToken) ? (
+                <Button
+                  onClick={() => {
+                    void objectsQuery.refetch();
+                  }}
+                >
+                  더 불러오기
+                </Button>
+              ) : null}
+            </Box>
+            {objectsQuery.isError ? <Alert severity="error">오브젝트 목록을 불러오지 못했습니다.</Alert> : null}
+            <GridContent<ObjectListItemDto> columns={objectColumns} rowData={rows} height={360} />
+          </Stack>
+        ) : null}
+      </Stack>
+
+      <ObjectDialog
+        open={!!selectedKey}
+        onClose={() => setSelectedKey(null)}
+        bucket={bucket}
+        objectKey={selectedKey ?? undefined}
+      />
+    </>
+  );
+}

--- a/src/react/pages/objectstorage/ObjectStoragePage.tsx
+++ b/src/react/pages/objectstorage/ObjectStoragePage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { Alert, Box, Breadcrumbs, Button, Chip, Stack, Typography } from "@mui/material";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
@@ -8,12 +8,17 @@ import { objectStorageQueryKeys } from "@/react/pages/objectstorage/queryKeys";
 import { reactObjectStorageApi } from "@/react/pages/objectstorage/api";
 import { ObjectDialog } from "@/react/pages/objectstorage/ObjectDialog";
 import type { BucketDto, ObjectListItemDto } from "@/types/studio/storage";
+import { resolveAxiosError } from "@/utils/helpers";
 
 export function ObjectStoragePage() {
   const { providerId = "" } = useParams();
   const [bucket, setBucket] = useState<BucketDto | null>(null);
   const [prefix, setPrefix] = useState("");
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [rows, setRows] = useState<ObjectListItemDto[]>([]);
+  const [nextToken, setNextToken] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
 
   const bucketsQuery = useQuery({
     queryKey: objectStorageQueryKeys.custom("buckets", providerId),
@@ -28,22 +33,33 @@ export function ObjectStoragePage() {
         providerId,
         bucket: bucket?.bucket ?? "",
         prefix: prefix || undefined,
-      }),
+    }),
     enabled: Boolean(providerId) && Boolean(bucket?.bucket),
   });
 
-  const rows = useMemo(
-    () =>
-      objectsQuery.data
-        ? reactObjectStorageApi.toRows(objectsQuery.data, true).filter((item) => {
-            if (!prefix) return true;
-            const slash = prefix.endsWith("/") ? prefix : `${prefix}/`;
-            const noSlash = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
-            return item.key !== slash && item.key !== noSlash;
-          })
-        : [],
-    [objectsQuery.data, prefix]
-  );
+  useEffect(() => {
+    if (!objectsQuery.data) {
+      setRows([]);
+      setNextToken(null);
+      setHasMore(false);
+      return;
+    }
+
+    const filteredRows = reactObjectStorageApi
+      .toRows(objectsQuery.data, true)
+      .filter((item) => {
+        if (!prefix) return true;
+        const slash = prefix.endsWith("/") ? prefix : `${prefix}/`;
+        const noSlash = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+        return item.key !== slash && item.key !== noSlash;
+      });
+
+    setRows(filteredRows);
+    setNextToken(objectsQuery.data.nextToken ?? null);
+    setHasMore(
+      reactObjectStorageApi.hasMore(objectsQuery.data.truncated, objectsQuery.data.nextToken)
+    );
+  }, [objectsQuery.data, prefix]);
 
   const bucketColumns = useMemo<ColDef<BucketDto>[]>(
     () => [
@@ -125,6 +141,48 @@ export function ObjectStoragePage() {
     rootDisabled: false,
   });
 
+  async function handleLoadMore() {
+    if (!bucket || !nextToken || loadingMore) {
+      return;
+    }
+
+    setLoadingMore(true);
+    try {
+      const response = await reactObjectStorageApi.fetchObjects({
+        providerId,
+        bucket: bucket.bucket,
+        prefix: prefix || undefined,
+        token: nextToken,
+      });
+
+      const appendedRows = reactObjectStorageApi.toRows(response, true).filter((item) => {
+        if (!prefix) return true;
+        const slash = prefix.endsWith("/") ? prefix : `${prefix}/`;
+        const noSlash = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+        return item.key !== slash && item.key !== noSlash;
+      });
+
+      setRows((current) => {
+        const seen = new Set(current.map((item) => item.key));
+        const merged = [...current];
+        for (const item of appendedRows) {
+          if (!seen.has(item.key)) {
+            merged.push(item);
+            seen.add(item.key);
+          }
+        }
+        return merged;
+      });
+      setNextToken(response.nextToken ?? null);
+      setHasMore(reactObjectStorageApi.hasMore(response.truncated, response.nextToken));
+    } catch (error) {
+      console.error(error);
+      setHasMore(false);
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
   return (
     <>
       <Stack spacing={2}>
@@ -151,11 +209,10 @@ export function ObjectStoragePage() {
                   />
                 ))}
               </Stack>
-              {reactObjectStorageApi.hasMore(objectsQuery.data?.truncated, objectsQuery.data?.nextToken) ? (
+              {hasMore ? (
                 <Button
-                  onClick={() => {
-                    void objectsQuery.refetch();
-                  }}
+                  onClick={() => void handleLoadMore()}
+                  disabled={loadingMore}
                 >
                   더 불러오기
                 </Button>

--- a/src/react/pages/objectstorage/api.ts
+++ b/src/react/pages/objectstorage/api.ts
@@ -1,0 +1,25 @@
+import {
+  buildBreadcrumb,
+  downloadFile,
+  fetchBuckets,
+  fetchObjectHead,
+  fetchObjects,
+  fetchProviders,
+  hasMore,
+  openInNewTab,
+  presignGet,
+  toRows,
+} from "@/data/studio/mgmt/storage";
+
+export const reactObjectStorageApi = {
+  fetchProviders,
+  fetchBuckets,
+  fetchObjects,
+  fetchObjectHead,
+  presignGet,
+  buildBreadcrumb,
+  toRows,
+  hasMore,
+  downloadFile,
+  openInNewTab,
+};

--- a/src/react/pages/objectstorage/queryKeys.ts
+++ b/src/react/pages/objectstorage/queryKeys.ts
@@ -1,0 +1,3 @@
+import { createQueryKeys } from "@/react/query/keys";
+
+export const objectStorageQueryKeys = createQueryKeys("object-storage");

--- a/src/react/router/AppRouter.tsx
+++ b/src/react/router/AppRouter.tsx
@@ -7,13 +7,20 @@ import { ForumListPage } from "@/react/pages/community/ForumListPage";
 import { ForumTopicDetailPage } from "@/react/pages/community/ForumTopicDetailPage";
 import { ForumTopicListPage } from "@/react/pages/community/ForumTopicListPage";
 import { DashboardPage } from "@/react/pages/DashboardPage";
+import { ChatPage } from "@/react/pages/ai/ChatPage";
+import { RagPage } from "@/react/pages/ai/RagPage";
 import { DocumentListPage } from "@/react/pages/documents/DocumentListPage";
 import { DocumentEditorPage } from "@/react/pages/documents/DocumentEditorPage";
 import { FilesPage } from "@/react/pages/files/FilesPage";
 import { LoginPage } from "@/react/pages/LoginPage";
+import { MailInboxPage } from "@/react/pages/mail/MailInboxPage";
+import { MailPage } from "@/react/pages/mail/MailPage";
+import { MailSyncPage } from "@/react/pages/mail/MailSyncPage";
 import { NotFoundPage } from "@/react/pages/NotFoundPage";
 import { ObjectTypeDetailPage } from "@/react/pages/objecttype/ObjectTypeDetailPage";
 import { ObjectTypeListPage } from "@/react/pages/objecttype/ObjectTypeListPage";
+import { ObjectStorageListPage } from "@/react/pages/objectstorage/ObjectStorageListPage";
+import { ObjectStoragePage } from "@/react/pages/objectstorage/ObjectStoragePage";
 import { MyProfilePage } from "@/react/pages/profile/MyProfilePage";
 import { TemplateDetailsPage } from "@/react/pages/templates/TemplateDetailsPage";
 import { TemplatesPage } from "@/react/pages/templates/TemplatesPage";
@@ -43,6 +50,11 @@ export function AppRouter() {
           <Route index element={<DashboardPage />} />
           <Route path="profile" element={<MyProfilePage />} />
           <Route path="application/files" element={<FilesPage />} />
+          <Route path="application/mail" element={<MailPage />}>
+            <Route index element={<Navigate to="inbox" replace />} />
+            <Route path="inbox" element={<MailInboxPage />} />
+            <Route path="sync" element={<MailSyncPage />} />
+          </Route>
           <Route path="application/documents" element={<DocumentListPage />} />
           <Route
             path="application/documents/:documentId"
@@ -58,6 +70,13 @@ export function AppRouter() {
             path="policy/object-types/:objectTypeId"
             element={<ObjectTypeDetailPage />}
           />
+          <Route path="services/object-storage" element={<ObjectStorageListPage />} />
+          <Route
+            path="services/object-storage/:providerId"
+            element={<ObjectStoragePage />}
+          />
+          <Route path="services/ai/chat" element={<ChatPage />} />
+          <Route path="services/ai/rag" element={<RagPage />} />
           {/* Admin and Security Pages */}
           <Route path="admin/*" element={<AdminRoutes />} />
         </Route>


### PR DESCRIPTION
## Why
- implement issue #38 on the React 2.x runtime for mail operations, object storage browsing, and AI chat/RAG flows
- replace remaining service-ops Vue dependencies on the active runtime with React routes and feature-local modules

## What
- add React mail pages for inbox and sync operations with feature-local API/query modules
- add React object storage provider, bucket/object browsing, and object detail dialog with presigned actions
- add React AI chat and RAG pages, route wiring, and changelog entry

## Related Issues
- Closes #38
- Related #27

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk:
  - service-op screens now expose operational actions through new React routes
- Mitigation:
  - existing backend APIs and helper utilities are reused, and local typecheck/build passed after route wiring

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run build`
- Result:
  - both commands passed locally
- Additional checks:
  - added route coverage for `/application/mail`, `/application/mail/inbox`, `/application/mail/sync`, `/services/object-storage`, `/services/object-storage/:providerId`, `/services/ai/chat`, `/services/ai/rag`
  - reused existing storage/mail helpers and replaced Vue-dependent AI provider fetch logic with React-side API wrappers

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks:
  - react-specialist implementation lane requested for issue #38 service-ops migration
- Ownership (files/modules/tasks):
  - Main author: route integration, API/page implementation, validation, git/PR integration
  - Subagent: requested React-focused execution lane for service-ops work
- Main author post-integration validation:
  - `npm run typecheck`
  - `npm run build`

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - merge after confirming the new React service-op routes cover the required operator entry points on `2.x`
- Rollback plan:
  - revert commit `10d636d`
- Post-deploy checks:
  - verify mail inbox/sync, object storage provider-to-object navigation, and AI chat/RAG request flows in the browser