### PR TITLE
[ai-assisted] feat(objecttype): restore create dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID/code validation fields, array-backed list loading, list ID display, and detail deletion.
+- Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID/code validation fields, array-backed list loading, list ID display, PageToolbar detail header, and detail deletion.
 - Issue `#58` removed inactive legacy Vue view sources, Vue component files, and the dangling legacy Vue AG Grid options file outside the React runtime.
 - Issue `#60` renamed the misspelled AG Grid shared type path to `src/types/ag-grid`.
 - Issue `#53` moved React-facing document, object storage, forum role matrix, and AG Grid locale dependencies into the React TypeScript runtime boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID/code validation fields, array-backed list loading, and detail deletion.
+- Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID/code validation fields, array-backed list loading, list ID display, and detail deletion.
 - Issue `#58` removed inactive legacy Vue view sources, Vue component files, and the dangling legacy Vue AG Grid options file outside the React runtime.
 - Issue `#60` renamed the misspelled AG Grid shared type path to `src/types/ag-grid`.
 - Issue `#53` moved React-facing document, object storage, forum role matrix, and AG Grid locale dependencies into the React TypeScript runtime boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Issue `#66` restored object type creation in the React `/policy/object-types` page.
 - Issue `#58` removed inactive legacy Vue view sources, Vue component files, and the dangling legacy Vue AG Grid options file outside the React runtime.
 - Issue `#60` renamed the misspelled AG Grid shared type path to `src/types/ag-grid`.
 - Issue `#53` moved React-facing document, object storage, forum role matrix, and AG Grid locale dependencies into the React TypeScript runtime boundary.
@@ -12,6 +13,10 @@
 
 ### Verification
 
+- Issue `#66`: `npm run typecheck`
+- Issue `#66`: `npm run lint`
+- Issue `#66`: `npm run build`
+- Issue `#66`: manual check - `/policy/object-types` create dialog validation path reviewed
 - Issue `#58`: confirmed React runtime paths do not import `src/views` or deleted Vue component files
 - Issue `#58`: `npm run typecheck`
 - Issue `#58`: `npm run lint`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID and code validation fields.
+- Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID/code validation fields and array-backed list loading.
 - Issue `#58` removed inactive legacy Vue view sources, Vue component files, and the dangling legacy Vue AG Grid options file outside the React runtime.
 - Issue `#60` renamed the misspelled AG Grid shared type path to `src/types/ag-grid`.
 - Issue `#53` moved React-facing document, object storage, forum role matrix, and AG Grid locale dependencies into the React TypeScript runtime boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Issue `#66` restored object type creation in the React `/policy/object-types` page.
+- Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID and code validation fields.
 - Issue `#58` removed inactive legacy Vue view sources, Vue component files, and the dangling legacy Vue AG Grid options file outside the React runtime.
 - Issue `#60` renamed the misspelled AG Grid shared type path to `src/types/ag-grid`.
 - Issue `#53` moved React-facing document, object storage, forum role matrix, and AG Grid locale dependencies into the React TypeScript runtime boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID/code validation fields and array-backed list loading.
+- Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID/code validation fields, array-backed list loading, and detail deletion.
 - Issue `#58` removed inactive legacy Vue view sources, Vue component files, and the dangling legacy Vue AG Grid options file outside the React runtime.
 - Issue `#60` renamed the misspelled AG Grid shared type path to `src/types/ag-grid`.
 - Issue `#53` moved React-facing document, object storage, forum role matrix, and AG Grid locale dependencies into the React TypeScript runtime boundary.

--- a/src/react/components/page/PageToolbar.tsx
+++ b/src/react/components/page/PageToolbar.tsx
@@ -9,7 +9,7 @@ import {
   Typography,
 } from "@mui/material";
 import {
-  ArrowBackIosNewOutlined,
+  ArrowBackOutlined,
   CloseOutlined,
   RefreshOutlined,
   SearchOutlined,
@@ -96,7 +96,7 @@ export function PageToolbar({
             {previous ? (
               <Tooltip title="이전">
                 <IconButton size="small" onClick={onPrevious}>
-                  <ArrowBackIosNewOutlined fontSize="small" />
+                  <ArrowBackOutlined fontSize="small" />
                 </IconButton>
               </Tooltip>
             ) : null}

--- a/src/react/pages/objecttype/CreateObjectTypeDialog.tsx
+++ b/src/react/pages/objecttype/CreateObjectTypeDialog.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  Stack,
+  TextField,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import { useAuthStore } from "@/react/auth/store";
+import { reactObjectTypeApi } from "./api";
+import type { ObjectTypeDto, ObjectTypeStatus } from "@/types/studio/objecttype";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (objectType: ObjectTypeDto) => void;
+}
+
+const statusOptions: Array<{ label: string; value: ObjectTypeStatus }> = [
+  { label: "활성", value: "ACTIVE" },
+  { label: "Deprecated", value: "DEPRECATED" },
+  { label: "비활성", value: "DISABLED" },
+];
+
+export function CreateObjectTypeDialog({ open, onClose, onCreated }: Props) {
+  const toast = useToast();
+  const { user } = useAuthStore();
+  const [code, setCode] = useState("");
+  const [name, setName] = useState("");
+  const [domain, setDomain] = useState("");
+  const [status, setStatus] = useState<ObjectTypeStatus>("ACTIVE");
+  const [description, setDescription] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const canSubmit = !!user && !!code.trim() && !!name.trim() && !!domain.trim();
+
+  function resetForm() {
+    setCode("");
+    setName("");
+    setDomain("");
+    setStatus("ACTIVE");
+    setDescription("");
+  }
+
+  function handleClose() {
+    if (saving) return;
+    onClose();
+  }
+
+  async function handleCreate() {
+    if (!user || !canSubmit) return;
+
+    setSaving(true);
+    try {
+      const created = await reactObjectTypeApi.create({
+        code: code.trim(),
+        name: name.trim(),
+        domain: domain.trim(),
+        status,
+        description: description.trim() || null,
+        createdBy: user.username,
+        createdById: user.userId,
+        updatedBy: user.username,
+        updatedById: user.userId,
+      });
+      toast.success("오브젝트 타입이 생성되었습니다.");
+      resetForm();
+      onCreated(created);
+      onClose();
+    } catch {
+      toast.error("오브젝트 타입 생성에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>오브젝트 타입 생성</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="코드"
+            size="small"
+            fullWidth
+            value={code}
+            onChange={(event) => setCode(event.target.value)}
+            required
+          />
+          <TextField
+            label="이름"
+            size="small"
+            fullWidth
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            required
+          />
+          <TextField
+            label="도메인"
+            size="small"
+            fullWidth
+            value={domain}
+            onChange={(event) => setDomain(event.target.value)}
+            required
+          />
+          <TextField
+            select
+            label="상태"
+            size="small"
+            fullWidth
+            value={status}
+            onChange={(event) => setStatus(event.target.value as ObjectTypeStatus)}
+            required
+          >
+            {statusOptions.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="설명"
+            size="small"
+            fullWidth
+            multiline
+            rows={3}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={saving}>
+          취소
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleCreate()}
+          disabled={saving || !canSubmit}
+        >
+          {saving ? <CircularProgress size={20} /> : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/objecttype/CreateObjectTypeDialog.tsx
+++ b/src/react/pages/objecttype/CreateObjectTypeDialog.tsx
@@ -30,6 +30,7 @@ const statusOptions: Array<{ label: string; value: ObjectTypeStatus }> = [
 export function CreateObjectTypeDialog({ open, onClose, onCreated }: Props) {
   const toast = useToast();
   const { user } = useAuthStore();
+  const [objectType, setObjectType] = useState("");
   const [code, setCode] = useState("");
   const [name, setName] = useState("");
   const [domain, setDomain] = useState("");
@@ -37,9 +38,21 @@ export function CreateObjectTypeDialog({ open, onClose, onCreated }: Props) {
   const [description, setDescription] = useState("");
   const [saving, setSaving] = useState(false);
 
-  const canSubmit = !!user && !!code.trim() && !!name.trim() && !!domain.trim();
+  const trimmedCode = code.trim();
+  const isCodeValid = /^[a-z][a-z0-9_-]{1,79}$/.test(trimmedCode);
+  const objectTypeNumber = objectType.trim() === "" ? null : Number(objectType);
+  const isObjectTypeValid =
+    objectTypeNumber == null ||
+    (Number.isInteger(objectTypeNumber) && objectTypeNumber >= 0);
+  const canSubmit =
+    !!user &&
+    isObjectTypeValid &&
+    isCodeValid &&
+    !!name.trim() &&
+    !!domain.trim();
 
   function resetForm() {
+    setObjectType("");
     setCode("");
     setName("");
     setDomain("");
@@ -58,7 +71,8 @@ export function CreateObjectTypeDialog({ open, onClose, onCreated }: Props) {
     setSaving(true);
     try {
       const created = await reactObjectTypeApi.create({
-        code: code.trim(),
+        objectType: objectTypeNumber,
+        code: trimmedCode,
         name: name.trim(),
         domain: domain.trim(),
         status,
@@ -85,11 +99,23 @@ export function CreateObjectTypeDialog({ open, onClose, onCreated }: Props) {
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
           <TextField
+            label="객체 유형"
+            size="small"
+            fullWidth
+            value={objectType}
+            onChange={(event) => setObjectType(event.target.value)}
+            type="number"
+            helperText="비워두면 서버에서 새 ID를 할당합니다."
+            error={!isObjectTypeValid}
+          />
+          <TextField
             label="코드"
             size="small"
             fullWidth
             value={code}
             onChange={(event) => setCode(event.target.value)}
+            error={!!trimmedCode && !isCodeValid}
+            helperText="소문자로 시작하고 소문자, 숫자, _, - 조합으로 2~80자 입력합니다."
             required
           />
           <TextField

--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -13,7 +13,7 @@ import {
   CardHeader,
   Tooltip,
 } from "@mui/material";
-import { ArrowBackOutlined, DeleteOutlineOutlined, SaveOutlined } from "@mui/icons-material";
+import { DeleteOutlineOutlined, SaveOutlined } from "@mui/icons-material";
 import { useConfirm, useToast } from "@/react/feedback";
 import { reactObjectTypeApi } from "./api";
 import type { ObjectTypeDto, ObjectTypePolicyDto } from "@/types/studio/objecttype";
@@ -155,11 +155,6 @@ export function ObjectTypeDetailPage() {
         onRefresh={loadObjectType}
         actions={
           <>
-            <Tooltip title="목록으로 이동">
-              <IconButton size="small" onClick={() => navigate("/policy/object-types")}>
-                <ArrowBackOutlined fontSize="small" />
-              </IconButton>
-            </Tooltip>
             <Tooltip title="오브젝트 타입 삭제">
               <span>
                 <IconButton

--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -1,13 +1,10 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
   Box,
   Stack,
-  Breadcrumbs,
-  Typography,
   Button,
   TextField,
-  Divider,
   CircularProgress,
   Alert,
   Card,
@@ -19,6 +16,7 @@ import { useConfirm, useToast } from "@/react/feedback";
 import { reactObjectTypeApi } from "./api";
 import type { ObjectTypeDto, ObjectTypePolicyDto } from "@/types/studio/objecttype";
 import { useAuthStore } from "@/react/auth/store";
+import { PageToolbar } from "@/react/components/page/PageToolbar";
 
 export function ObjectTypeDetailPage() {
   const { objectTypeId } = useParams<{ objectTypeId: string }>();
@@ -38,7 +36,7 @@ export function ObjectTypeDetailPage() {
     allowedMime: "",
   });
 
-  useEffect(() => {
+  const loadObjectType = useCallback(() => {
     if (!objectTypeId) return;
     setLoading(true);
     Promise.all([
@@ -65,6 +63,10 @@ export function ObjectTypeDetailPage() {
       .catch(() => setError("오브젝트 타입을 불러오지 못했습니다."))
       .finally(() => setLoading(false));
   }, [objectTypeId]);
+
+  useEffect(() => {
+    loadObjectType();
+  }, [loadObjectType]);
 
   async function handleSave() {
     if (!objectTypeId || !user) return;
@@ -142,47 +144,42 @@ export function ObjectTypeDetailPage() {
 
   return (
     <Stack spacing={2}>
-      <Breadcrumbs separator="›">
-        <Typography color="text.secondary">정책</Typography>
-        <Typography
-          color="text.secondary"
-          sx={{ cursor: "pointer" }}
-          onClick={() => navigate("/policy/object-types")}
-        >
-          오브젝트 타입
-        </Typography>
-        <Typography color="text.primary">{objectType.code}</Typography>
-      </Breadcrumbs>
-      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <Typography variant="h5">오브젝트 타입 상세</Typography>
-        <Stack direction="row" spacing={1}>
-          <Button
-            variant="outlined"
-            startIcon={<ArrowBackOutlined />}
-            onClick={() => navigate("/policy/object-types")}
-          >
-            목록
-          </Button>
-          <Button
-            variant="outlined"
-            color="error"
-            startIcon={<DeleteOutlineOutlined />}
-            onClick={() => void handleDelete()}
-            disabled={saving}
-          >
-            삭제
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={<SaveOutlined />}
-            onClick={handleSave}
-            disabled={saving}
-          >
-            {saving ? <CircularProgress size={20} /> : "저장"}
-          </Button>
-        </Stack>
-      </Box>
-      <Divider />
+      <PageToolbar
+        breadcrumbs={["정책", "오브젝트 타입", objectType.code]}
+        title="오브젝트 타입 상세"
+        label="오브젝트 타입 기본 정보와 파일 정책을 관리합니다."
+        previous
+        onPrevious={() => navigate("/policy/object-types")}
+        onRefresh={loadObjectType}
+        actions={
+          <>
+            <Button
+              variant="outlined"
+              startIcon={<ArrowBackOutlined />}
+              onClick={() => navigate("/policy/object-types")}
+            >
+              목록
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              startIcon={<DeleteOutlineOutlined />}
+              onClick={() => void handleDelete()}
+              disabled={saving}
+            >
+              삭제
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={<SaveOutlined />}
+              onClick={handleSave}
+              disabled={saving}
+            >
+              {saving ? <CircularProgress size={20} /> : "저장"}
+            </Button>
+          </>
+        }
+      />
       <Card variant="outlined">
         <CardHeader title="기본 정보" />
         <CardContent>

--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -4,12 +4,14 @@ import {
   Box,
   Stack,
   Button,
+  IconButton,
   TextField,
   CircularProgress,
   Alert,
   Card,
   CardContent,
   CardHeader,
+  Tooltip,
 } from "@mui/material";
 import { ArrowBackOutlined, DeleteOutlineOutlined, SaveOutlined } from "@mui/icons-material";
 import { useConfirm, useToast } from "@/react/feedback";
@@ -153,30 +155,35 @@ export function ObjectTypeDetailPage() {
         onRefresh={loadObjectType}
         actions={
           <>
-            <Button
-              variant="outlined"
-              startIcon={<ArrowBackOutlined />}
-              onClick={() => navigate("/policy/object-types")}
-            >
-              목록
-            </Button>
-            <Button
-              variant="outlined"
-              color="error"
-              startIcon={<DeleteOutlineOutlined />}
-              onClick={() => void handleDelete()}
-              disabled={saving}
-            >
-              삭제
-            </Button>
-            <Button
-              variant="contained"
-              startIcon={<SaveOutlined />}
-              onClick={handleSave}
-              disabled={saving}
-            >
-              {saving ? <CircularProgress size={20} /> : "저장"}
-            </Button>
+            <Tooltip title="목록으로 이동">
+              <IconButton size="small" onClick={() => navigate("/policy/object-types")}>
+                <ArrowBackOutlined fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="오브젝트 타입 삭제">
+              <span>
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => void handleDelete()}
+                  disabled={saving}
+                >
+                  <DeleteOutlineOutlined fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="저장">
+              <span>
+                <IconButton
+                  size="small"
+                  color="primary"
+                  onClick={handleSave}
+                  disabled={saving}
+                >
+                  {saving ? <CircularProgress size={18} /> : <SaveOutlined fontSize="small" />}
+                </IconButton>
+              </span>
+            </Tooltip>
           </>
         }
       />

--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -14,8 +14,8 @@ import {
   CardContent,
   CardHeader,
 } from "@mui/material";
-import { ArrowBackOutlined, SaveOutlined } from "@mui/icons-material";
-import { useToast } from "@/react/feedback";
+import { ArrowBackOutlined, DeleteOutlineOutlined, SaveOutlined } from "@mui/icons-material";
+import { useConfirm, useToast } from "@/react/feedback";
 import { reactObjectTypeApi } from "./api";
 import type { ObjectTypeDto, ObjectTypePolicyDto } from "@/types/studio/objecttype";
 import { useAuthStore } from "@/react/auth/store";
@@ -24,6 +24,7 @@ export function ObjectTypeDetailPage() {
   const { objectTypeId } = useParams<{ objectTypeId: string }>();
   const navigate = useNavigate();
   const toast = useToast();
+  const confirm = useConfirm();
   const { user } = useAuthStore();
   const [objectType, setObjectType] = useState<ObjectTypeDto | null>(null);
   const [policy, setPolicy] = useState<ObjectTypePolicyDto | null>(null);
@@ -106,6 +107,29 @@ export function ObjectTypeDetailPage() {
     }
   }
 
+  async function handleDelete() {
+    if (!objectTypeId || !objectType) return;
+
+    const ok = await confirm({
+      title: "오브젝트 타입 삭제",
+      message: `${objectType.code} 오브젝트 타입을 삭제하시겠습니까?`,
+      okText: "삭제",
+      cancelText: "취소",
+    });
+    if (!ok) return;
+
+    setSaving(true);
+    try {
+      await reactObjectTypeApi.delete(Number(objectTypeId));
+      toast.success("오브젝트 타입이 삭제되었습니다.");
+      navigate("/policy/object-types");
+    } catch {
+      toast.error("삭제에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
   if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
@@ -138,6 +162,15 @@ export function ObjectTypeDetailPage() {
             onClick={() => navigate("/policy/object-types")}
           >
             목록
+          </Button>
+          <Button
+            variant="outlined"
+            color="error"
+            startIcon={<DeleteOutlineOutlined />}
+            onClick={() => void handleDelete()}
+            disabled={saving}
+          >
+            삭제
           </Button>
           <Button
             variant="contained"

--- a/src/react/pages/objecttype/ObjectTypeListPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeListPage.tsx
@@ -1,3 +1,4 @@
+import type { SortModelItem } from "ag-grid-community";
 import { useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
@@ -14,10 +15,44 @@ import { ReactPageDataSource } from "@/react/pages/admin/datasource";
 import type { ObjectTypeDto } from "@/types/studio/objecttype";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
 import { CreateObjectTypeDialog } from "./CreateObjectTypeDialog";
+import { reactObjectTypeApi } from "./api";
 
 class ObjectTypesDataSource extends ReactPageDataSource<ObjectTypeDto> {
   constructor() {
     super("/api/mgmt/object-types");
+  }
+
+  async fetch() {
+    this.loading = true;
+    this.error = null;
+    try {
+      const rows = await reactObjectTypeApi.list(this.filter);
+      this.dataItems = Array.isArray(rows) ? rows : [];
+      this.total = this.dataItems.length;
+      this.page = 0;
+      this.isLoaded = true;
+    } catch (error) {
+      this.error = error;
+      throw error;
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  async fetchForAgGrid({
+    startRow,
+    endRow,
+  }: {
+    startRow: number;
+    endRow: number;
+    sortModel?: SortModelItem[];
+    filterModel?: Record<string, unknown>;
+  }) {
+    await this.fetch();
+    return {
+      rows: this.dataItems.slice(startRow, endRow),
+      total: this.total,
+    };
   }
 }
 

--- a/src/react/pages/objecttype/ObjectTypeListPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeListPage.tsx
@@ -1,15 +1,19 @@
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Box,
+  IconButton,
   Stack,
+  Tooltip,
 } from "@mui/material";
+import { AddCircleOutlineOutlined } from "@mui/icons-material";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
 import { PageableGridContent } from "@/react/components/ag-grid";
 import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
 import { ReactPageDataSource } from "@/react/pages/admin/datasource";
 import type { ObjectTypeDto } from "@/types/studio/objecttype";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
+import { CreateObjectTypeDialog } from "./CreateObjectTypeDialog";
 
 class ObjectTypesDataSource extends ReactPageDataSource<ObjectTypeDto> {
   constructor() {
@@ -21,6 +25,7 @@ export function ObjectTypeListPage() {
   const navigate = useNavigate();
   const gridRef = useRef<PageableGridContentHandle<ObjectTypeDto>>(null);
   const dataSource = useMemo(() => new ObjectTypesDataSource(), []);
+  const [createOpen, setCreateOpen] = useState(false);
 
   const columnDefs = useMemo<ColDef<ObjectTypeDto>[]>(
     () => [
@@ -65,11 +70,26 @@ export function ObjectTypeListPage() {
         breadcrumbs={["정책", "오브젝트 타입"]}
         label="데이터 타입 정의를 조회하고 관리합니다."
         onRefresh={() => gridRef.current?.refresh()}
+        actions={
+          <Tooltip title="새 오브젝트 타입을 생성합니다.">
+            <IconButton size="small" onClick={() => setCreateOpen(true)}>
+              <AddCircleOutlineOutlined fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        }
       />
       <PageableGridContent<ObjectTypeDto>
         ref={gridRef}
         datasource={dataSource}
         columns={columnDefs}
+      />
+      <CreateObjectTypeDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={(objectType) => {
+          gridRef.current?.refresh();
+          navigate(`/policy/object-types/${objectType.objectType}`);
+        }}
       />
     </Stack>
   );

--- a/src/react/pages/objecttype/ObjectTypeListPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeListPage.tsx
@@ -65,6 +65,14 @@ export function ObjectTypeListPage() {
   const columnDefs = useMemo<ColDef<ObjectTypeDto>[]>(
     () => [
       {
+        field: "objectType",
+        headerName: "ID",
+        type: "number",
+        maxWidth: 90,
+        sortable: true,
+        filter: false,
+      },
+      {
         field: "code",
         headerName: "코드",
         flex: 1.2,

--- a/src/react/pages/objecttype/api.ts
+++ b/src/react/pages/objecttype/api.ts
@@ -22,6 +22,9 @@ export const reactObjectTypeApi = {
   patch: (objectType: number, payload: ObjectTypePatchRequest) =>
     apiRequest<ObjectTypeDto>("patch", `${BASE}/${objectType}`, { data: payload }),
 
+  delete: (objectType: number) =>
+    apiRequest<void>("delete", `${BASE}/${objectType}`),
+
   getPolicy: (objectType: number) =>
     apiRequest<ObjectTypePolicyDto>("get", `${BASE}/${objectType}/policy`),
 

--- a/src/react/pages/objecttype/api.ts
+++ b/src/react/pages/objecttype/api.ts
@@ -4,6 +4,7 @@ import type {
   ObjectTypePatchRequest,
   ObjectTypePolicyDto,
   ObjectTypePolicyUpsertRequest,
+  ObjectTypeUpsertRequest,
 } from "@/types/studio/objecttype";
 
 const BASE = "/api/mgmt/object-types";
@@ -14,6 +15,9 @@ export const reactObjectTypeApi = {
 
   get: (objectType: number) =>
     apiRequest<ObjectTypeDto>("get", `${BASE}/${objectType}`),
+
+  create: (payload: ObjectTypeUpsertRequest) =>
+    apiRequest<ObjectTypeDto, ObjectTypeUpsertRequest>("post", BASE, { data: payload }),
 
   patch: (objectType: number, payload: ObjectTypePatchRequest) =>
     apiRequest<ObjectTypeDto>("patch", `${BASE}/${objectType}`, { data: payload }),


### PR DESCRIPTION
## Why
- Closes #66
- React `/policy/object-types` 목록 화면에는 조회와 상세 이동만 있고, 기존 Vue 화면에 있던 새 오브젝트 타입 생성 경로가 빠져 있었습니다.
- 또한 object-types 조회 API는 기존 Vue store처럼 배열을 반환하지만, React 목록은 page 응답으로 해석하고 있어 생성 후 데이터가 있어도 목록이 비어 보일 수 있었습니다.
- 상세 화면에서도 오브젝트 타입을 제거할 수 있도록 삭제 액션을 추가하고, 상세 헤더를 React `PageToolbar` 패턴에 맞춥니다.

## What
- `/policy/object-types` 목록 툴바에 새 오브젝트 타입 생성 액션을 추가했습니다.
- 목록에 기존 Vue 화면과 동일하게 `objectType` ID 컬럼을 추가했습니다.
- code, name, domain, status, description을 입력하는 React 생성 다이얼로그를 추가했습니다.
- 기존 Vue 생성 폼에 있던 optional objectType ID 입력과 code 형식 검증을 반영했습니다.
- `reactObjectTypeApi.create`를 추가해 `/api/mgmt/object-types` POST 요청을 보냅니다.
- 생성 payload에 로그인 사용자 기반 `createdBy`, `createdById`, `updatedBy`, `updatedById` 값을 포함합니다.
- 생성 성공 시 success feedback을 표시하고 생성된 상세 화면으로 이동합니다.
- React object type 목록 datasource가 배열 응답을 직접 로드하도록 수정했습니다.
- `reactObjectTypeApi.delete`와 상세 화면 삭제 버튼을 추가했습니다.
- 삭제 전 confirm dialog를 표시하고, 삭제 성공 시 목록 화면으로 이동합니다.
- 상세 화면의 custom breadcrumb/header 영역을 `PageToolbar`로 교체하고 previous/refresh/actions를 연결했습니다.
- 상세 화면 `PageToolbar` actions를 tooltip이 있는 icon button으로 변경했습니다.
- 공용 `PageToolbar` previous 아이콘을 `ArrowBackOutlined`로 변경했습니다.
- `CHANGELOG.md`에 issue #66 변경과 검증 기록을 추가했습니다.

## Related Issues
- Closes #66

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 권한 정책 자체 변경은 없습니다. 기존 인증 사용자 정보로 생성 요청 audit 필드를 채우고, 삭제 요청은 기존 인증 API client 경로를 사용합니다.
- Mitigation: 인증 사용자가 없으면 생성 submit이 비활성화되며, 삭제는 confirm dialog를 통과한 경우에만 요청합니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - `npm run typecheck`: 통과
  - `npm run lint`: 통과, 기존 warning 17개 유지
  - `npm run build`: 통과, 기존 Vite large chunk warning 유지
- Additional checks:
  - main 브랜치의 Vue `ObjectTypeListPage.vue`, `ObjectTypeDetailPage.vue`, `objecttype.store.ts` 생성/목록 흐름과 입력 필드를 대조했습니다.
  - `/policy/object-types` 생성 다이얼로그 표시와 필수 입력/code 형식 검증 경로를 코드 리뷰로 확인했습니다.
  - 목록의 objectType ID 컬럼 표시 경로를 코드 리뷰로 확인했습니다.
  - 상세 화면 `PageToolbar` previous/refresh/actions 및 tooltip icon action 경로를 코드 리뷰로 확인했습니다.
  - 상세 화면 삭제 confirm 및 삭제 성공 후 목록 이동 경로를 코드 리뷰로 확인했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: React parity 보완 기능으로, 별도 migration 순서 요구는 없습니다.
- Rollback plan: PR revert 시 React 오브젝트 타입 생성/삭제 UI, API create/delete method, 배열 기반 목록 datasource 수정, ID 컬럼 표시, 상세 PageToolbar 적용, PageToolbar previous icon 변경이 제거됩니다.
- Post-deploy checks: `/policy/object-types`에서 기존 데이터와 ID 컬럼이 목록에 표시되는지, 생성 다이얼로그 표시와 생성 성공 후 상세 화면 이동, 상세 화면 PageToolbar icon actions 및 삭제 confirm/삭제 후 목록 이동이 동작하는지 확인합니다.
