### PR TITLE
[ai-assisted] refactor(layout): split full layout responsibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Issue `#59` split FullLayout navigation and user menu responsibilities into dedicated layout components.
 - Issue `#54` introduced a profile feature module pilot under `src/react/features/profile` while preserving the `/profile` route.
 - Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID/code validation fields, array-backed list loading, list ID display, PageToolbar detail header, and detail deletion.
 - Issue `#58` removed inactive legacy Vue view sources, Vue component files, and the dangling legacy Vue AG Grid options file outside the React runtime.
@@ -14,6 +15,10 @@
 
 ### Verification
 
+- Issue `#59`: `npm run typecheck`
+- Issue `#59`: `npm run lint`
+- Issue `#59`: `npm run build`
+- Issue `#59`: manual check - dashboard/profile/admin route and navigation behavior reviewed in code
 - Issue `#54`: `npm run typecheck`
 - Issue `#54`: `npm run lint`
 - Issue `#54`: `npm run build`

--- a/src/react/layouts/FullLayout.tsx
+++ b/src/react/layouts/FullLayout.tsx
@@ -17,6 +17,7 @@ import NO_AVATAR from "@/assets/images/users/no-avatar.png";
 import { useThemeMode } from "@/react/theme/AppThemeProvider";
 import {
   buildNavSections,
+  COLLAPSED_DRAWER_WIDTH,
   DRAWER_WIDTH,
   FullLayoutNavigation,
   matchesPath,
@@ -72,7 +73,7 @@ export function FullLayout() {
     });
   }, [sectionDefaults]);
 
-  const drawerWidth = collapsed ? 0 : DRAWER_WIDTH;
+  const drawerWidth = collapsed ? COLLAPSED_DRAWER_WIDTH : DRAWER_WIDTH;
   const displayName = user?.name || user?.username || "사용자";
   const emailOrUsername = user?.email || user?.username || "";
   const profileImageUrl = user?.username
@@ -91,7 +92,10 @@ export function FullLayout() {
           [title]: !current[title],
         }))
       }
-      onNavigate={(path) => navigate(path)}
+      onNavigate={(path) => {
+        navigate(path);
+        setMobileOpen(false);
+      }}
     />
   );
 
@@ -146,12 +150,12 @@ export function FullLayout() {
               width: drawerWidth,
               flexShrink: 0,
               overflow: "hidden",
-              borderRight: collapsed ? "none" : "1px solid",
+              borderRight: "1px solid",
               borderColor: "divider",
               transition: "width 160ms ease, border-color 160ms ease",
             }}
           >
-            {!collapsed ? navigation : null}
+            {navigation}
           </Box>
         ) : (
           <Drawer

--- a/src/react/layouts/FullLayout.tsx
+++ b/src/react/layouts/FullLayout.tsx
@@ -1,48 +1,11 @@
 import {
   Box,
-  Avatar,
-  Button,
-  ClickAwayListener,
-  Divider,
   Drawer,
-  ToggleButton,
-  ToggleButtonGroup,
-  Paper,
-  Popper,
   IconButton,
-  List,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Tooltip,
-  Typography,
-  MenuItem,
-  ListItemText as MuiListItemText,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import {
-  AccountCircleOutlined,
-  ArticleOutlined,
-  DashboardOutlined,
-  ExpandLess,
-  ExpandMore,
-  FolderOpenOutlined,
-  ForumOutlined,
-  GroupOutlined,
-  Inventory2Outlined,
-  MailOutline,
-  Menu,
-  PsychologyAltOutlined,
-  RuleOutlined,
-  StorageOutlined,
-  TopicOutlined,
-  LogoutOutlined,
-  ListAltOutlined,
-  ComputerOutlined,
-  LightModeOutlined,
-  DarkModeOutlined,
-} from "@mui/icons-material";
+import { Menu } from "@mui/icons-material";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useEffect, useMemo, useState } from "react";
 import { AppShellHeader } from "@/react/layouts/AppShellHeader";
@@ -52,32 +15,13 @@ import { SessionStatusChip } from "@/react/components/auth/SessionStatusChip";
 import { API_BASE_URL } from "@/config/backend";
 import NO_AVATAR from "@/assets/images/users/no-avatar.png";
 import { useThemeMode } from "@/react/theme/AppThemeProvider";
-
-const DRAWER_WIDTH = 248;
-
-type NavItem = {
-  label: string;
-  path: string;
-  icon: React.ReactNode;
-  match?: (pathname: string) => boolean;
-};
-
-type NavSection = {
-  title: string;
-  items: NavItem[];
-};
-
-function matchesPath(pathname: string, item: NavItem) {
-  if (item.match) {
-    return item.match(pathname);
-  }
-
-  if (item.path === "/") {
-    return pathname === "/";
-  }
-
-  return pathname === item.path || pathname.startsWith(`${item.path}/`);
-}
+import {
+  buildNavSections,
+  DRAWER_WIDTH,
+  FullLayoutNavigation,
+  matchesPath,
+} from "@/react/layouts/FullLayoutNavigation";
+import { FullLayoutUserMenu } from "@/react/layouts/FullLayoutUserMenu";
 
 export function FullLayout() {
   const theme = useTheme();
@@ -91,99 +35,9 @@ export function FullLayout() {
   const { mode: themeMode, setMode: setThemeMode } = useThemeMode();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
-  const [profileAnchor, setProfileAnchor] = useState<HTMLElement | null>(null);
   const [passwordDialogOpen, setPasswordDialogOpen] = useState(false);
-  const profileOpen = Boolean(profileAnchor);
 
-  const sections = useMemo<NavSection[]>(
-    () => [
-      {
-        title: "General",
-        items: [
-          { label: "대시보드", path: "/", icon: <DashboardOutlined fontSize="small" /> },
-          { label: "내 프로필", path: "/profile", icon: <AccountCircleOutlined fontSize="small" /> },
-        ],
-      },
-      {
-        title: "Application",
-        items: [
-          {
-            label: "메일",
-            path: "/application/mail/inbox",
-            icon: <MailOutline fontSize="small" />,
-            match: (pathname) => pathname.startsWith("/application/mail"),
-          },
-          {
-            label: "포럼 관리",
-            path: "/admin/forums",
-            icon: <ForumOutlined fontSize="small" />,
-          },
-        ],
-      },
-      {
-        title: "Resource",
-        items: [
-          { label: "파일", path: "/application/files", icon: <FolderOpenOutlined fontSize="small" /> },
-          {
-            label: "문서",
-            path: "/application/documents",
-            icon: <ArticleOutlined fontSize="small" />,
-          },
-          {
-            label: "템플릿",
-            path: "/application/templates",
-            icon: <Inventory2Outlined fontSize="small" />,
-          },
-        ],
-      },
-      {
-        title: "Policy",
-        items: [
-          {
-            label: "오브젝트 타입",
-            path: "/policy/object-types",
-            icon: <RuleOutlined fontSize="small" />,
-          },
-          { label: "ACL", path: "/admin/acl", icon: <RuleOutlined fontSize="small" /> },
-        ],
-      },
-      {
-        title: "Services",
-        items: [
-          {
-            label: "Object Storage",
-            path: "/services/object-storage",
-            icon: <StorageOutlined fontSize="small" />,
-          },
-          {
-            label: "AI Chat",
-            path: "/services/ai/chat",
-            icon: <PsychologyAltOutlined fontSize="small" />,
-          },
-          {
-            label: "AI RAG",
-            path: "/services/ai/rag",
-            icon: <TopicOutlined fontSize="small" />,
-          },
-        ],
-      },
-      {
-        title: "Admin",
-        items: [
-          { label: "회원", path: "/admin/users", icon: <AccountCircleOutlined fontSize="small" /> },
-          { label: "그룹", path: "/admin/groups", icon: <GroupOutlined fontSize="small" /> },
-          { label: "역할", path: "/admin/roles", icon: <RuleOutlined fontSize="small" /> },
-          {
-            label: "로그인 실패 감사",
-            path: "/admin/audit/login-failures",
-            icon: <ArticleOutlined fontSize="small" />,
-          },
-        ],
-      },
-    ],
-    []
-  );
-
+  const sections = useMemo(() => buildNavSections(), []);
   const sectionDefaults = useMemo(
     () =>
       Object.fromEntries(
@@ -194,7 +48,6 @@ export function FullLayout() {
       ) as Record<string, boolean>,
     [location.pathname, sections]
   );
-
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(
     sectionDefaults
   );
@@ -221,150 +74,25 @@ export function FullLayout() {
 
   const drawerWidth = collapsed ? 0 : DRAWER_WIDTH;
   const displayName = user?.name || user?.username || "사용자";
+  const emailOrUsername = user?.email || user?.username || "";
   const profileImageUrl = user?.username
     ? `${API_BASE_URL}/api/profile/${encodeURIComponent(user.username)}/avatar`
     : NO_AVATAR;
 
-  const drawerContent = (
-    <Box
-      sx={{
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        bgcolor: "#ffffff",
-        color: "#1f2937",
-      }}
-    >
-      <Box sx={{ flex: 1, overflowY: "auto", py: 2 }}>
-        {sections.map((section) => (
-          <Box
-            key={section.title}
-            sx={{
-              mb: 1,
-              px: 2,
-            }}
-          >
-            {!collapsed ? (
-              <ListItemButton
-                onClick={() =>
-                  setExpandedSections((current) => ({
-                    ...current,
-                    [section.title]: !current[section.title],
-                  }))
-                }
-                sx={{
-                  minHeight: 34,
-                  borderRadius: 1,
-                  px: 0,
-                  py: 0.5,
-                  justifyContent: "space-between",
-                  color: "#111827",
-                  bgcolor: "transparent",
-                  "&:hover": {
-                    bgcolor: "transparent",
-                    color: "#2563eb",
-                  },
-                }}
-              >
-                <Typography
-                  variant="caption"
-                  sx={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 0.5,
-                    textTransform: "uppercase",
-                    fontWeight: 500,
-                    letterSpacing: 0.2,
-                  }}
-                >
-                  {section.title}
-                </Typography>
-                {expandedSections[section.title] ? (
-                  <ExpandLess fontSize="small" />
-                ) : (
-                  <ExpandMore fontSize="small" />
-                )}
-              </ListItemButton>
-            ) : null}
-            <List
-              disablePadding
-              sx={{
-                ml: 0,
-                pl: 1.5,
-                pr: 0,
-                borderLeft: "1px solid rgba(148,163,184,0.45)",
-                display: collapsed || expandedSections[section.title] ? "block" : "none",
-              }}
-            >
-              {section.items.map((item) => {
-                const active = matchesPath(location.pathname, item);
-                const button = (
-                  <ListItemButton
-                    key={item.path}
-                    selected={active}
-                    onClick={() => navigate(item.path)}
-                    sx={{
-                      position: "relative",
-                      minHeight: 30,
-                      borderRadius: 1,
-                      mb: 0.25,
-                      px: 1,
-                      py: 0.25,
-                      ml: -0.5,
-                      justifyContent: collapsed ? "center" : "flex-start",
-                      color: active ? "#2563eb" : "#4b5563",
-                      "&.Mui-selected": {
-                        bgcolor: "transparent",
-                        color: "#2563eb",
-                        fontWeight: 700,
-                      },
-                      "&.Mui-selected:hover": {
-                        bgcolor: "rgba(37,99,235,0.06)",
-                      },
-                      "&:hover": {
-                        bgcolor: "rgba(37,99,235,0.06)",
-                        color: "#2563eb",
-                      },
-                    }}
-                  >
-                    <ListItemIcon
-                      sx={{
-                        minWidth: collapsed ? 0 : 30,
-                        color: "inherit",
-                        justifyContent: "center",
-                        "& svg": {
-                          fontSize: 18,
-                        },
-                      }}
-                    >
-                      {item.icon}
-                    </ListItemIcon>
-                    {!collapsed ? (
-                      <ListItemText
-                        primary={item.label}
-                        primaryTypographyProps={{
-                          fontSize: 14,
-                          fontWeight: active ? 600 : 500,
-                          color: "inherit",
-                        }}
-                      />
-                    ) : null}
-                  </ListItemButton>
-                );
-
-                return collapsed ? (
-                  <Tooltip key={item.path} title={item.label} placement="right">
-                    {button}
-                  </Tooltip>
-                ) : (
-                  button
-                );
-              })}
-            </List>
-          </Box>
-        ))}
-      </Box>
-    </Box>
+  const navigation = (
+    <FullLayoutNavigation
+      sections={sections}
+      pathname={location.pathname}
+      collapsed={collapsed}
+      expandedSections={expandedSections}
+      onToggleSection={(title) =>
+        setExpandedSections((current) => ({
+          ...current,
+          [title]: !current[title],
+        }))
+      }
+      onNavigate={(path) => navigate(path)}
+    />
   );
 
   return (
@@ -396,153 +124,18 @@ export function FullLayout() {
           <Box sx={{ display: { xs: "none", md: "block" } }}>
             <SessionStatusChip token={token} refreshTokens={refreshTokens} />
           </Box>
-          <Box sx={{ textAlign: "right", display: { xs: "none", sm: "block" } }}>
-            <Typography variant="caption" color="text.primary" fontWeight={600} sx={{ lineHeight: 1.1, display: "block" }}>
-              {displayName}
-            </Typography>
-            <Typography variant="caption" color="text.secondary" sx={{ fontSize: 11, lineHeight: 1.1 }}>
-              {user?.email || user?.username || ""}
-            </Typography>
-          </Box>
-          <IconButton
-            onClick={(event) =>
-              setProfileAnchor((anchor) => (anchor ? null : event.currentTarget))
-            }
-            size="small"
-            aria-label="사용자 메뉴"
-          >
-            <Avatar
-              alt={displayName}
-              src={profileImageUrl}
-              imgProps={{
-                onError: (event) => {
-                  event.currentTarget.src = NO_AVATAR;
-                },
-              }}
-              sx={{ width: 30, height: 30, bgcolor: "grey.200" }}
-            />
-          </IconButton>
-          <Popper
-            open={profileOpen}
-            anchorEl={profileAnchor}
-            placement="bottom-end"
-            sx={{ zIndex: (muiTheme) => muiTheme.zIndex.modal }}
-          >
-            <ClickAwayListener onClickAway={() => setProfileAnchor(null)}>
-              <Paper
-                elevation={8}
-                sx={{
-                  width: 320,
-                  mt: 1,
-                  borderRadius: 3,
-                  overflow: "hidden",
-                  border: "1px solid",
-                  borderColor: "divider",
-                }}
-              >
-              <Box
-                sx={{
-                  px: 2.5,
-                  py: 2,
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1.5,
-                  bgcolor: "rgba(37,99,235,0.04)",
-                  borderBottom: "1px solid",
-                  borderColor: "divider",
-                }}
-              >
-                <Avatar
-                  alt={displayName}
-                  src={profileImageUrl}
-                  imgProps={{
-                    onError: (event) => {
-                      event.currentTarget.src = NO_AVATAR;
-                    },
-                  }}
-                  sx={{ width: 42, height: 42, bgcolor: "grey.200" }}
-                />
-                <Box sx={{ minWidth: 0 }}>
-                  <Typography variant="subtitle2" noWrap>
-                    {displayName}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary" noWrap>
-                    {user?.email || user?.username || ""}
-                  </Typography>
-                </Box>
-              </Box>
-            <MenuItem
-              onClick={() => {
-                setProfileAnchor(null);
-                navigate("/profile");
-              }}
-              sx={{ px: 2.5, py: 1.25 }}
-            >
-              <ListItemIcon>
-                <AccountCircleOutlined fontSize="small" />
-              </ListItemIcon>
-              <MuiListItemText primary="내 프로필" secondary={user?.username} />
-            </MenuItem>
-            <MenuItem
-              onClick={() => {
-                setProfileAnchor(null);
-                setPasswordDialogOpen(true);
-              }}
-              sx={{ px: 2.5, py: 1.25 }}
-            >
-              <ListItemIcon>
-                <ListAltOutlined fontSize="small" />
-              </ListItemIcon>
-              <MuiListItemText primary="비밀번호 변경" />
-            </MenuItem>
-            <Divider />
-            <Box sx={{ px: 2.5, py: 1.5 }}>
-              <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
-                테마
-              </Typography>
-              <ToggleButtonGroup
-                exclusive
-                fullWidth
-                size="small"
-                value={themeMode}
-                onChange={(_, nextMode) => {
-                  if (nextMode) {
-                    setThemeMode(nextMode);
-                  }
-                }}
-              >
-                <ToggleButton value="system" sx={{ gap: 0.5 }}>
-                  <ComputerOutlined fontSize="small" />
-                  시스템
-                </ToggleButton>
-                <ToggleButton value="light" sx={{ gap: 0.5 }}>
-                  <LightModeOutlined fontSize="small" />
-                  라이트
-                </ToggleButton>
-                <ToggleButton value="dark" sx={{ gap: 0.5 }}>
-                  <DarkModeOutlined fontSize="small" />
-                  다크
-                </ToggleButton>
-              </ToggleButtonGroup>
-            </Box>
-            <Divider />
-            <Box sx={{ px: 2.5, py: 2 }}>
-              <Button
-                variant="outlined"
-                color="primary"
-                fullWidth
-                startIcon={<LogoutOutlined fontSize="small" />}
-                onClick={() => {
-                  setProfileAnchor(null);
-                  void logoutEverywhere();
-                }}
-              >
-                로그아웃
-              </Button>
-            </Box>
-              </Paper>
-            </ClickAwayListener>
-          </Popper>
+          <FullLayoutUserMenu
+            displayName={displayName}
+            emailOrUsername={emailOrUsername}
+            profileImageUrl={profileImageUrl}
+            fallbackImageUrl={NO_AVATAR}
+            username={user?.username}
+            themeMode={themeMode}
+            onThemeModeChange={setThemeMode}
+            onProfile={() => navigate("/profile")}
+            onPasswordChange={() => setPasswordDialogOpen(true)}
+            onLogout={() => void logoutEverywhere()}
+          />
         </Box>
       </AppShellHeader>
       <Box sx={{ display: "flex", minHeight: "calc(100vh - 64px)" }}>
@@ -558,7 +151,7 @@ export function FullLayout() {
               transition: "width 160ms ease, border-color 160ms ease",
             }}
           >
-            {!collapsed ? drawerContent : null}
+            {!collapsed ? navigation : null}
           </Box>
         ) : (
           <Drawer
@@ -568,7 +161,7 @@ export function FullLayout() {
             ModalProps={{ keepMounted: true }}
             PaperProps={{ sx: { width: DRAWER_WIDTH } }}
           >
-            {drawerContent}
+            {navigation}
           </Drawer>
         )}
         <Box

--- a/src/react/layouts/FullLayoutNavigation.tsx
+++ b/src/react/layouts/FullLayoutNavigation.tsx
@@ -25,6 +25,7 @@ import {
 } from "@mui/icons-material";
 
 export const DRAWER_WIDTH = 248;
+export const COLLAPSED_DRAWER_WIDTH = 64;
 
 export type NavItem = {
   label: string;
@@ -171,7 +172,7 @@ export function FullLayoutNavigation({
             key={section.title}
             sx={{
               mb: 1,
-              px: 2,
+              px: collapsed ? 1 : 2,
             }}
           >
             {!collapsed ? (
@@ -215,9 +216,9 @@ export function FullLayoutNavigation({
               disablePadding
               sx={{
                 ml: 0,
-                pl: 1.5,
+                pl: collapsed ? 0 : 1.5,
                 pr: 0,
-                borderLeft: "1px solid rgba(148,163,184,0.45)",
+                borderLeft: collapsed ? "none" : "1px solid rgba(148,163,184,0.45)",
                 display: collapsed || expandedSections[section.title] ? "block" : "none",
               }}
             >

--- a/src/react/layouts/FullLayoutNavigation.tsx
+++ b/src/react/layouts/FullLayoutNavigation.tsx
@@ -1,0 +1,294 @@
+import {
+  Box,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  AccountCircleOutlined,
+  ArticleOutlined,
+  DashboardOutlined,
+  ExpandLess,
+  ExpandMore,
+  FolderOpenOutlined,
+  ForumOutlined,
+  GroupOutlined,
+  Inventory2Outlined,
+  MailOutline,
+  PsychologyAltOutlined,
+  RuleOutlined,
+  StorageOutlined,
+  TopicOutlined,
+} from "@mui/icons-material";
+
+export const DRAWER_WIDTH = 248;
+
+export type NavItem = {
+  label: string;
+  path: string;
+  icon: React.ReactNode;
+  match?: (pathname: string) => boolean;
+};
+
+export type NavSection = {
+  title: string;
+  items: NavItem[];
+};
+
+export function matchesPath(pathname: string, item: NavItem) {
+  if (item.match) {
+    return item.match(pathname);
+  }
+
+  if (item.path === "/") {
+    return pathname === "/";
+  }
+
+  return pathname === item.path || pathname.startsWith(`${item.path}/`);
+}
+
+export function buildNavSections(): NavSection[] {
+  return [
+    {
+      title: "General",
+      items: [
+        { label: "대시보드", path: "/", icon: <DashboardOutlined fontSize="small" /> },
+        { label: "내 프로필", path: "/profile", icon: <AccountCircleOutlined fontSize="small" /> },
+      ],
+    },
+    {
+      title: "Application",
+      items: [
+        {
+          label: "메일",
+          path: "/application/mail/inbox",
+          icon: <MailOutline fontSize="small" />,
+          match: (pathname) => pathname.startsWith("/application/mail"),
+        },
+        {
+          label: "포럼 관리",
+          path: "/admin/forums",
+          icon: <ForumOutlined fontSize="small" />,
+        },
+      ],
+    },
+    {
+      title: "Resource",
+      items: [
+        { label: "파일", path: "/application/files", icon: <FolderOpenOutlined fontSize="small" /> },
+        {
+          label: "문서",
+          path: "/application/documents",
+          icon: <ArticleOutlined fontSize="small" />,
+        },
+        {
+          label: "템플릿",
+          path: "/application/templates",
+          icon: <Inventory2Outlined fontSize="small" />,
+        },
+      ],
+    },
+    {
+      title: "Policy",
+      items: [
+        {
+          label: "오브젝트 타입",
+          path: "/policy/object-types",
+          icon: <RuleOutlined fontSize="small" />,
+        },
+        { label: "ACL", path: "/admin/acl", icon: <RuleOutlined fontSize="small" /> },
+      ],
+    },
+    {
+      title: "Services",
+      items: [
+        {
+          label: "Object Storage",
+          path: "/services/object-storage",
+          icon: <StorageOutlined fontSize="small" />,
+        },
+        {
+          label: "AI Chat",
+          path: "/services/ai/chat",
+          icon: <PsychologyAltOutlined fontSize="small" />,
+        },
+        {
+          label: "AI RAG",
+          path: "/services/ai/rag",
+          icon: <TopicOutlined fontSize="small" />,
+        },
+      ],
+    },
+    {
+      title: "Admin",
+      items: [
+        { label: "회원", path: "/admin/users", icon: <AccountCircleOutlined fontSize="small" /> },
+        { label: "그룹", path: "/admin/groups", icon: <GroupOutlined fontSize="small" /> },
+        { label: "역할", path: "/admin/roles", icon: <RuleOutlined fontSize="small" /> },
+        {
+          label: "로그인 실패 감사",
+          path: "/admin/audit/login-failures",
+          icon: <ArticleOutlined fontSize="small" />,
+        },
+      ],
+    },
+  ];
+}
+
+interface FullLayoutNavigationProps {
+  sections: NavSection[];
+  pathname: string;
+  collapsed: boolean;
+  expandedSections: Record<string, boolean>;
+  onToggleSection: (title: string) => void;
+  onNavigate: (path: string) => void;
+}
+
+export function FullLayoutNavigation({
+  sections,
+  pathname,
+  collapsed,
+  expandedSections,
+  onToggleSection,
+  onNavigate,
+}: FullLayoutNavigationProps) {
+  return (
+    <Box
+      sx={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        bgcolor: "#ffffff",
+        color: "#1f2937",
+      }}
+    >
+      <Box sx={{ flex: 1, overflowY: "auto", py: 2 }}>
+        {sections.map((section) => (
+          <Box
+            key={section.title}
+            sx={{
+              mb: 1,
+              px: 2,
+            }}
+          >
+            {!collapsed ? (
+              <ListItemButton
+                onClick={() => onToggleSection(section.title)}
+                sx={{
+                  minHeight: 34,
+                  borderRadius: 1,
+                  px: 0,
+                  py: 0.5,
+                  justifyContent: "space-between",
+                  color: "#111827",
+                  bgcolor: "transparent",
+                  "&:hover": {
+                    bgcolor: "transparent",
+                    color: "#2563eb",
+                  },
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                    textTransform: "uppercase",
+                    fontWeight: 500,
+                    letterSpacing: 0.2,
+                  }}
+                >
+                  {section.title}
+                </Typography>
+                {expandedSections[section.title] ? (
+                  <ExpandLess fontSize="small" />
+                ) : (
+                  <ExpandMore fontSize="small" />
+                )}
+              </ListItemButton>
+            ) : null}
+            <List
+              disablePadding
+              sx={{
+                ml: 0,
+                pl: 1.5,
+                pr: 0,
+                borderLeft: "1px solid rgba(148,163,184,0.45)",
+                display: collapsed || expandedSections[section.title] ? "block" : "none",
+              }}
+            >
+              {section.items.map((item) => {
+                const active = matchesPath(pathname, item);
+                const button = (
+                  <ListItemButton
+                    key={item.path}
+                    selected={active}
+                    onClick={() => onNavigate(item.path)}
+                    sx={{
+                      position: "relative",
+                      minHeight: 30,
+                      borderRadius: 1,
+                      mb: 0.25,
+                      px: 1,
+                      py: 0.25,
+                      ml: -0.5,
+                      justifyContent: collapsed ? "center" : "flex-start",
+                      color: active ? "#2563eb" : "#4b5563",
+                      "&.Mui-selected": {
+                        bgcolor: "transparent",
+                        color: "#2563eb",
+                        fontWeight: 700,
+                      },
+                      "&.Mui-selected:hover": {
+                        bgcolor: "rgba(37,99,235,0.06)",
+                      },
+                      "&:hover": {
+                        bgcolor: "rgba(37,99,235,0.06)",
+                        color: "#2563eb",
+                      },
+                    }}
+                  >
+                    <ListItemIcon
+                      sx={{
+                        minWidth: collapsed ? 0 : 30,
+                        color: "inherit",
+                        justifyContent: "center",
+                        "& svg": {
+                          fontSize: 18,
+                        },
+                      }}
+                    >
+                      {item.icon}
+                    </ListItemIcon>
+                    {!collapsed ? (
+                      <ListItemText
+                        primary={item.label}
+                        primaryTypographyProps={{
+                          fontSize: 14,
+                          fontWeight: active ? 600 : 500,
+                          color: "inherit",
+                        }}
+                      />
+                    ) : null}
+                  </ListItemButton>
+                );
+
+                return collapsed ? (
+                  <Tooltip key={item.path} title={item.label} placement="right">
+                    {button}
+                  </Tooltip>
+                ) : (
+                  button
+                );
+              })}
+            </List>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/react/layouts/FullLayoutUserMenu.tsx
+++ b/src/react/layouts/FullLayoutUserMenu.tsx
@@ -1,0 +1,211 @@
+import {
+  Avatar,
+  Box,
+  Button,
+  ClickAwayListener,
+  Divider,
+  IconButton,
+  ListItemIcon,
+  ListItemText as MuiListItemText,
+  MenuItem,
+  Paper,
+  Popper,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
+import {
+  AccountCircleOutlined,
+  ComputerOutlined,
+  DarkModeOutlined,
+  LightModeOutlined,
+  ListAltOutlined,
+  LogoutOutlined,
+} from "@mui/icons-material";
+import { useState } from "react";
+import type { ThemeMode } from "@/react/theme/AppThemeProvider";
+
+interface FullLayoutUserMenuProps {
+  displayName: string;
+  emailOrUsername: string;
+  profileImageUrl: string;
+  fallbackImageUrl: string;
+  username?: string;
+  themeMode: ThemeMode;
+  onThemeModeChange: (mode: ThemeMode) => void;
+  onProfile: () => void;
+  onPasswordChange: () => void;
+  onLogout: () => void;
+}
+
+export function FullLayoutUserMenu({
+  displayName,
+  emailOrUsername,
+  profileImageUrl,
+  fallbackImageUrl,
+  username,
+  themeMode,
+  onThemeModeChange,
+  onProfile,
+  onPasswordChange,
+  onLogout,
+}: FullLayoutUserMenuProps) {
+  const [profileAnchor, setProfileAnchor] = useState<HTMLElement | null>(null);
+  const profileOpen = Boolean(profileAnchor);
+
+  function closeMenu() {
+    setProfileAnchor(null);
+  }
+
+  return (
+    <>
+      <Box sx={{ textAlign: "right", display: { xs: "none", sm: "block" } }}>
+        <Typography variant="caption" color="text.primary" fontWeight={600} sx={{ lineHeight: 1.1, display: "block" }}>
+          {displayName}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ fontSize: 11, lineHeight: 1.1 }}>
+          {emailOrUsername}
+        </Typography>
+      </Box>
+      <IconButton
+        onClick={(event) =>
+          setProfileAnchor((anchor) => (anchor ? null : event.currentTarget))
+        }
+        size="small"
+        aria-label="사용자 메뉴"
+      >
+        <Avatar
+          alt={displayName}
+          src={profileImageUrl}
+          imgProps={{
+            onError: (event) => {
+              event.currentTarget.src = fallbackImageUrl;
+            },
+          }}
+          sx={{ width: 30, height: 30, bgcolor: "grey.200" }}
+        />
+      </IconButton>
+      <Popper
+        open={profileOpen}
+        anchorEl={profileAnchor}
+        placement="bottom-end"
+        sx={{ zIndex: (muiTheme) => muiTheme.zIndex.modal }}
+      >
+        <ClickAwayListener onClickAway={closeMenu}>
+          <Paper
+            elevation={8}
+            sx={{
+              width: 320,
+              mt: 1,
+              borderRadius: 3,
+              overflow: "hidden",
+              border: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <Box
+              sx={{
+                px: 2.5,
+                py: 2,
+                display: "flex",
+                alignItems: "center",
+                gap: 1.5,
+                bgcolor: "rgba(37,99,235,0.04)",
+                borderBottom: "1px solid",
+                borderColor: "divider",
+              }}
+            >
+              <Avatar
+                alt={displayName}
+                src={profileImageUrl}
+                imgProps={{
+                  onError: (event) => {
+                    event.currentTarget.src = fallbackImageUrl;
+                  },
+                }}
+                sx={{ width: 42, height: 42, bgcolor: "grey.200" }}
+              />
+              <Box sx={{ minWidth: 0 }}>
+                <Typography variant="subtitle2" noWrap>
+                  {displayName}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  {emailOrUsername}
+                </Typography>
+              </Box>
+            </Box>
+            <MenuItem
+              onClick={() => {
+                closeMenu();
+                onProfile();
+              }}
+              sx={{ px: 2.5, py: 1.25 }}
+            >
+              <ListItemIcon>
+                <AccountCircleOutlined fontSize="small" />
+              </ListItemIcon>
+              <MuiListItemText primary="내 프로필" secondary={username} />
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                closeMenu();
+                onPasswordChange();
+              }}
+              sx={{ px: 2.5, py: 1.25 }}
+            >
+              <ListItemIcon>
+                <ListAltOutlined fontSize="small" />
+              </ListItemIcon>
+              <MuiListItemText primary="비밀번호 변경" />
+            </MenuItem>
+            <Divider />
+            <Box sx={{ px: 2.5, py: 1.5 }}>
+              <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+                테마
+              </Typography>
+              <ToggleButtonGroup
+                exclusive
+                fullWidth
+                size="small"
+                value={themeMode}
+                onChange={(_, nextMode) => {
+                  if (nextMode) {
+                    onThemeModeChange(nextMode);
+                  }
+                }}
+              >
+                <ToggleButton value="system" sx={{ gap: 0.5 }}>
+                  <ComputerOutlined fontSize="small" />
+                  시스템
+                </ToggleButton>
+                <ToggleButton value="light" sx={{ gap: 0.5 }}>
+                  <LightModeOutlined fontSize="small" />
+                  라이트
+                </ToggleButton>
+                <ToggleButton value="dark" sx={{ gap: 0.5 }}>
+                  <DarkModeOutlined fontSize="small" />
+                  다크
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </Box>
+            <Divider />
+            <Box sx={{ px: 2.5, py: 2 }}>
+              <Button
+                variant="outlined"
+                color="primary"
+                fullWidth
+                startIcon={<LogoutOutlined fontSize="small" />}
+                onClick={() => {
+                  closeMenu();
+                  onLogout();
+                }}
+              >
+                로그아웃
+              </Button>
+            </Box>
+          </Paper>
+        </ClickAwayListener>
+      </Popper>
+    </>
+  );
+}


### PR DESCRIPTION
## Why
- Closes #59
- `FullLayout.tsx`가 app shell 조립, navigation 설정/렌더링, header user menu, theme/logout/profile action을 한 파일에서 모두 담당해 변경 위험이 컸습니다.
- 후속 feature module 및 router 정리 전에 shell 내부 책임을 분리해 변경 경계를 줄입니다.

## What
- navigation 설정과 drawer rendering을 `FullLayoutNavigation.tsx`로 분리했습니다.
- header user/profile/theme/logout menu를 `FullLayoutUserMenu.tsx`로 분리했습니다.
- `FullLayout.tsx`는 shell state, header composition, drawer composition, `Outlet` rendering 중심으로 축소했습니다.
- desktop collapsed 상태에서도 64px icon rail navigation이 계속 렌더링되도록 유지했습니다.
- mobile drawer navigation item 클릭 시 drawer가 직접 닫히도록 수정했습니다.
- route path와 navigation item은 기존 값을 유지했습니다.
- `CHANGELOG.md`에 issue #59 변경과 검증 기록을 추가했습니다.

## Related Issues
- Closes #59
- Related #54

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 보안/권한 동작 변경 없음. logout/profile/theme menu 동작은 기존 callback을 새 user menu 컴포넌트로 전달하는 방식으로 유지합니다.
- Mitigation: shell route/path 동작을 변경하지 않고 typecheck/lint/build를 실행했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - `npm run typecheck`: 통과
  - `npm run lint`: 통과, 기존 warning 16개 유지
  - `npm run build`: 통과, 기존 Vite large chunk warning 유지
- Additional checks:
  - dashboard/profile/admin route와 navigation collapse/session UI 경로를 코드 리뷰로 확인했습니다.
  - collapsed desktop navigation은 64px icon rail로 렌더링되도록 확인했습니다.
  - mobile drawer navigation item 클릭 시 `setMobileOpen(false)`가 호출되도록 확인했습니다.
  - 브라우저 smoke test는 현재 환경에서 수행하지 못했습니다. 머지 전 대시보드, `/profile`, `/admin/users`, navigation collapse, user menu, password dialog, logout action을 수동 확인해야 합니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: #54 profile feature module 파일럿 이후 진행한 shell 책임 분리 작업입니다.
- Rollback plan: PR revert 시 navigation/user menu 코드가 기존 `FullLayout.tsx` 단일 파일 구조로 돌아갑니다.
- Post-deploy checks: 대표 route 진입, drawer collapse/mobile drawer, user menu, theme toggle, password dialog, logout action을 확인합니다.
