### PR TITLE
[ai-assisted] refactor(toolbar): remove action icon left margin

### DIFF
--- a/src/react/components/page/PageToolbar.tsx
+++ b/src/react/components/page/PageToolbar.tsx
@@ -115,7 +115,17 @@ export function PageToolbar({
             </Box>
           </Stack>
 
-          <Stack direction="row" spacing={1} alignItems="center" flexShrink={0}>
+          <Stack
+            direction="row"
+            spacing={0}
+            alignItems="center"
+            flexShrink={0}
+            sx={{
+              "& .MuiIconButton-root": {
+                ml: 0,
+              },
+            }}
+          >
             {actions}
             {onSearch ? (
               <Box


### PR DESCRIPTION
## Why
- PageToolbar 우측 action icon 버튼의 좌측 마진을 제거해 목록/상세 화면의 toolbar action 정렬을 맞춥니다.

## What
- PageToolbar 우측 action group의 `spacing`을 `0`으로 변경했습니다.
- action group 내부 `IconButton`의 `ml`을 `0`으로 고정했습니다.

## Related Issues
- Related #66

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 보안/권한 동작 변경 없음. toolbar spacing 스타일만 변경합니다.
- Mitigation: typecheck/lint로 컴포넌트 변경을 확인했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
- Result:
  - `npm run typecheck`: 통과
  - `npm run lint`: 통과, 기존 warning 16개 유지
- Additional checks:
  - PageToolbar 우측 action group 스타일 변경 범위를 코드 리뷰로 확인했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [ ] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 독립적인 toolbar spacing 정리입니다.
- Rollback plan: PR revert 시 PageToolbar action group spacing이 이전 값으로 돌아갑니다.
- Post-deploy checks: PageToolbar 우측 아이콘 버튼의 좌측 여백이 0인지 확인합니다.