### PR TITLE
[ai-assisted] refactor(user): style active status chip

### DIFF
--- a/src/react/pages/admin/UsersPage.tsx
+++ b/src/react/pages/admin/UsersPage.tsx
@@ -106,9 +106,9 @@ export function UsersPage() {
               fontSize: 11,
               ...(params.value
                 ? {
-                    bgcolor: "#e0f2fe",
-                    color: "#0369a1",
-                    borderColor: "#bae6fd",
+                    bgcolor: "#2563eb",
+                    color: "#ffffff",
+                    borderColor: "#1d4ed8",
                   }
                 : {}),
             }}

--- a/src/react/pages/admin/UsersPage.tsx
+++ b/src/react/pages/admin/UsersPage.tsx
@@ -100,9 +100,18 @@ export function UsersPage() {
           <Chip
             size="small"
             label={params.value ? "활성" : "비활성"}
-            color={params.value ? "success" : "default"}
             variant={params.value ? "filled" : "outlined"}
-            sx={{ height: 22, fontSize: 11 }}
+            sx={{
+              height: 22,
+              fontSize: 11,
+              ...(params.value
+                ? {
+                    bgcolor: "#e0f2fe",
+                    color: "#0369a1",
+                    borderColor: "#bae6fd",
+                  }
+                : {}),
+            }}
           />
         ),
         cellStyle: { textAlign: "center" },


### PR DESCRIPTION
## Why
- 회원 목록의 `활성화` 컬럼에서 `활성` 상태를 더 진한 파랑 계열로 표시해 상태 가독성을 맞춥니다.

## What
- `UsersPage`의 `enabled` 컬럼에서 활성 Chip의 색상을 deep blue 배경과 white text로 변경했습니다.
- 비활성 Chip 스타일은 기존 outlined/default 스타일을 유지했습니다.

## Related Issues
- Related #66

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 보안/권한 동작 변경 없음. 표시 스타일만 변경합니다.
- Mitigation: typecheck/lint로 변경 범위를 확인했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
- Result:
  - `npm run typecheck`: 통과
  - `npm run lint`: 통과, 기존 warning 16개 유지
- Additional checks:
  - 회원 목록 `enabled` 컬럼의 활성/비활성 조건부 스타일 경로를 코드 리뷰로 확인했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [ ] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 독립적인 회원 목록 표시 스타일 변경입니다.
- Rollback plan: PR revert 시 활성 Chip이 기존 success/default 스타일로 돌아갑니다.
- Post-deploy checks: `/admin/users` 회원 목록에서 `활성` Chip이 진한 파랑 계열 배경으로 표시되는지 확인합니다.
