### PR TITLE
[ai-assisted] refactor(acl): sync side menu and restore guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- ACL management page and create dialogs now restore explanatory guidance from the legacy Vue implementation.
 - Issue `#59` split FullLayout navigation and user menu responsibilities into dedicated layout components.
 - Issue `#54` introduced a profile feature module pilot under `src/react/features/profile` while preserving the `/profile` route.
 - Issue `#66` restored object type creation in the React `/policy/object-types` page, including Vue-parity ID/code validation fields, array-backed list loading, list ID display, PageToolbar detail header, and detail deletion.
@@ -15,6 +16,8 @@
 
 ### Verification
 
+- ACL guidance restore: `npm run typecheck`
+- ACL guidance restore: `npm run lint`
 - Issue `#59`: `npm run typecheck`
 - Issue `#59`: `npm run lint`
 - Issue `#59`: `npm run build`

--- a/src/react/pages/acl/AclPage.tsx
+++ b/src/react/pages/acl/AclPage.tsx
@@ -412,6 +412,15 @@ export function AclPage() {
     ];
 
     function updateActiveSection() {
+      const lastSectionKey = sectionEntries[sectionEntries.length - 1].key;
+      const isAtPageBottom =
+        window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 8;
+
+      if (isAtPageBottom) {
+        setActiveSection(lastSectionKey);
+        return;
+      }
+
       const scrollAnchor = 120;
       const visibleSection =
         sectionEntries

--- a/src/react/pages/acl/AclPage.tsx
+++ b/src/react/pages/acl/AclPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   Box,
@@ -401,6 +401,53 @@ export function AclPage() {
     }[section]?.current;
     target?.scrollIntoView({ behavior: "smooth", block: "start" });
   }
+
+  useEffect(() => {
+    let frameId = 0;
+    const sectionEntries = [
+      { key: "classes", ref: classesSectionRef },
+      { key: "sids", ref: sidsSectionRef },
+      { key: "objects", ref: objectsSectionRef },
+      { key: "entries", ref: entriesSectionRef },
+    ];
+
+    function updateActiveSection() {
+      const scrollAnchor = 120;
+      const visibleSection =
+        sectionEntries
+          .map(({ key, ref }) => ({
+            key,
+            top: ref.current?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY,
+          }))
+          .filter((section) => Number.isFinite(section.top))
+          .reduce(
+            (current, section) => {
+              if (section.top <= scrollAnchor && section.top > current.top) {
+                return section;
+              }
+              return current;
+            },
+            { key: sectionEntries[0].key, top: Number.NEGATIVE_INFINITY }
+          ).key;
+
+      setActiveSection(visibleSection);
+    }
+
+    function scheduleUpdate() {
+      window.cancelAnimationFrame(frameId);
+      frameId = window.requestAnimationFrame(updateActiveSection);
+    }
+
+    updateActiveSection();
+    window.addEventListener("scroll", scheduleUpdate, { passive: true });
+    window.addEventListener("resize", scheduleUpdate);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      window.removeEventListener("scroll", scheduleUpdate);
+      window.removeEventListener("resize", scheduleUpdate);
+    };
+  }, []);
 
   return (
     <Stack spacing={1}>

--- a/src/react/pages/acl/AclPage.tsx
+++ b/src/react/pages/acl/AclPage.tsx
@@ -22,7 +22,6 @@ import type {
   AclObjectIdentityDto,
   AclSidDto,
 } from "@/types/studio/acl";
-import type { AclActionMaskDto } from "@/types/studio/ai";
 import { aclQueryKeys } from "./queryKeys";
 import { reactAclApi } from "./api";
 import {
@@ -481,6 +480,10 @@ export function AclPage() {
                   void refreshLookups();
                 }}
               />
+              <Alert severity="info">
+                ACL이 적용되는 보호 대상의 종류를 정의합니다. 도메인 객체 이름이나 클래스(FQCN)를
+                등록해 이후 오브젝트 아이덴티티와 권한 엔트리의 기준으로 사용합니다.
+              </Alert>
               <PageableGridContent<AclClassDto>
                 ref={classesGridRef}
                 datasource={classesDataSource}
@@ -500,6 +503,10 @@ export function AclPage() {
                   void refreshLookups();
                 }}
               />
+              <Alert severity="info">
+                권한을 부여할 대상(SID)을 정의합니다. 사용자 Principal 또는 ROLE 접두어를 제외한 권한/롤을
+                등록해 ACL 엔트리에서 선택합니다.
+              </Alert>
               <PageableGridContent<AclSidDto>
                 ref={sidsGridRef}
                 datasource={sidsDataSource}
@@ -519,6 +526,10 @@ export function AclPage() {
                   void refreshLookups();
                 }}
               />
+              <Alert severity="info">
+                도메인 객체 ID 값 `__root__`는 도메인 또는 클래스 전체를 의미하는 가상 객체입니다.
+                루트 객체에 ACL을 부여하면 해당 도메인 또는 클래스 전체에 대한 권한을 적용할 수 있습니다.
+              </Alert>
               <PageableGridContent<AclObjectIdentityDto>
                 ref={objectsGridRef}
                 datasource={objectsDataSource}
@@ -535,6 +546,10 @@ export function AclPage() {
                 onAdd={() => setCreateEntryOpen(true)}
                 onRefresh={() => entriesGridRef.current?.refresh()}
               />
+              <Alert severity="info">
+                권한 엔트리는 OID(객체 식별자)와 순서 값을 기준으로 평가됩니다. 동일 OID에 여러 권한을
+                추가할 때는 평가 순서 값을 다르게 지정해야 합니다.
+              </Alert>
               <PageableGridContent<AclEntryDto>
                 ref={entriesGridRef}
                 datasource={entriesDataSource}

--- a/src/react/pages/acl/CreateClassDialog.tsx
+++ b/src/react/pages/acl/CreateClassDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import {
+  Alert,
   Button,
   CircularProgress,
   Dialog,
@@ -50,6 +51,9 @@ export function CreateClassDialog({ open, onClose, onCreated }: Props) {
       <DialogTitle>ACL 클래스 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
+          <Alert severity="info">
+            클래스(FQCN) 또는 도메인 객체는 ACL(Access Control List)이 적용되는 객체의 종류를 정의합니다.
+          </Alert>
           <TextField
             label="클래스명"
             size="small"

--- a/src/react/pages/acl/CreateEntryDialog.tsx
+++ b/src/react/pages/acl/CreateEntryDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import {
+  Alert,
   Button,
   CircularProgress,
   Dialog,
@@ -84,6 +85,9 @@ export function CreateEntryDialog({
       <DialogTitle>ACL 엔트리 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
+          <Alert severity="info">
+            특정 객체에 대해 누구(SID)에게 어떤 권한(mask)을 허용하거나 거부할지 한 줄씩 정의합니다.
+          </Alert>
           <TextField
             select
             label="오브젝트 아이덴티티"

--- a/src/react/pages/acl/CreateObjectDialog.tsx
+++ b/src/react/pages/acl/CreateObjectDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import {
+  Alert,
   Button,
   CircularProgress,
   Dialog,
@@ -68,6 +69,10 @@ export function CreateObjectDialog({
       <DialogTitle>오브젝트 아이덴티티 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
+          <Alert severity="info">
+            종류(도메인 또는 클래스)에 해당하는 객체를 정의합니다. 전체를 표현하려면 대상 ID 값으로
+            `__root__`를 입력하세요.
+          </Alert>
           <TextField
             select
             label="ACL 클래스"

--- a/src/react/pages/acl/CreateSidDialog.tsx
+++ b/src/react/pages/acl/CreateSidDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import {
+  Alert,
   Button,
   CircularProgress,
   Dialog,
@@ -49,6 +50,9 @@ export function CreateSidDialog({ open, onClose, onCreated }: Props) {
       <DialogTitle>ACL SID 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
+          <Alert severity="info">
+            권한을 부여할 대상(사용자 또는 롤)을 정의합니다. 롤은 ROLE_ 접두어를 제외하고 입력합니다.
+          </Alert>
           <TextField
             label="SID"
             size="small"


### PR DESCRIPTION
## Why
- `/admin/acl` 페이지에서 본문을 스크롤해도 우측 contents 메뉴의 활성 섹션이 자동으로 바뀌지 않았습니다.
- 마지막 섹션은 페이지 하단에서 기준선까지 올라오지 못해 active 상태가 끝까지 갱신되지 않는 경우가 있었습니다.
- 기존 Vue ACL 화면에 있던 개념 설명 문구가 React 화면에서 많이 빠져 있어 관리자가 ACL 구조를 이해하기 어려웠습니다.

## What
- ACL 페이지에 scroll/resize listener를 추가해 현재 스크롤 위치 기준으로 우측 contents 메뉴의 `activeSection`을 자동 갱신했습니다.
- 페이지 하단 도달 시 마지막 섹션(`ACL 엔트리`)이 active가 되도록 보정했습니다.
- ACL 클래스, SID, 오브젝트 아이덴티티, 엔트리 섹션에 기존 Vue 안내 문구 기반 `Alert` 설명을 추가했습니다.
- ACL 생성 다이얼로그 4종에 안내 `Alert`를 추가했습니다.
  - 클래스 생성
  - SID 생성
  - 오브젝트 아이덴티티 생성
  - ACL 엔트리 생성
- 사용하지 않던 `AclActionMaskDto` import를 제거했습니다.
- `CHANGELOG.md`에 ACL 안내 복원과 검증 기록을 추가했습니다.

## Related Issues
- Related #54

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 보안/권한 정책 변경 없음. ACL 데이터 모델이나 API 요청은 변경하지 않고, UI 안내와 scroll active state만 변경합니다.
- Mitigation: 삭제/생성 API 호출 경로는 기존 로직을 유지하고 typecheck/lint/build를 실행했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - `npm run typecheck`: 통과
  - `npm run lint`: 통과, 기존 warning 15개 유지
  - `npm run build`: 통과, 기존 Vite large chunk warning 유지
- Additional checks:
  - 기존 Vue ACL 화면(`src/views/studio/mgmt/security/acl/**`)의 안내 문구를 참고해 React 섹션/다이얼로그 안내 문구를 대조했습니다.
  - 우측 contents 메뉴 클릭 스크롤과 수동 스크롤 active state 갱신 경로를 코드 리뷰로 확인했습니다.
  - 브라우저 smoke test는 현재 환경에서 수행하지 못했습니다. 머지 전 `/admin/acl`에서 우측 메뉴 active 상태, 마지막 섹션 active 보정, 생성 다이얼로그 안내 문구 표시를 수동 확인해야 합니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [ ] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 독립적인 ACL 화면 UX/문구 보완 작업입니다.
- Rollback plan: PR revert 시 ACL 우측 메뉴 scroll sync와 안내 문구가 이전 상태로 돌아갑니다.
- Post-deploy checks: `/admin/acl`에서 스크롤 시 우측 메뉴 active 상태가 따라오는지, 마지막 섹션까지 이동되는지, 각 안내 문구가 표시되는지 확인합니다.