### PR TITLE
[ai-assisted] refactor(detail): standardize admin detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Managed detail pages for groups, roles, object types, and templates now follow the user detail page layout standard.
 - ACL management page and create dialogs now restore explanatory guidance from the legacy Vue implementation.
 - Issue `#59` split FullLayout navigation and user menu responsibilities into dedicated layout components.
 - Issue `#54` introduced a profile feature module pilot under `src/react/features/profile` while preserving the `/profile` route.
@@ -16,6 +17,10 @@
 
 ### Verification
 
+- Admin detail standardization: `npm run typecheck`
+- Admin detail standardization: `npm run lint`
+- Admin detail standardization: `npm run build`
+- Admin detail standardization: manual check - groups/roles/object type/template detail routes reviewed in code
 - ACL guidance restore: `npm run typecheck`
 - ACL guidance restore: `npm run lint`
 - Issue `#59`: `npm run typecheck`

--- a/src/react/pages/admin/groups/GroupDetailPage.tsx
+++ b/src/react/pages/admin/groups/GroupDetailPage.tsx
@@ -1,14 +1,22 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
-  Box, Stack, Breadcrumbs, Typography, Button, TextField, Divider, CircularProgress, Alert,
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Grid,
+  TextField,
+  Stack,
 } from "@mui/material";
-import { ArrowBackOutlined, SaveOutlined, GroupAddOutlined, ManageAccountsOutlined } from "@mui/icons-material";
+import { GroupAddOutlined, ManageAccountsOutlined, SaveOutlined } from "@mui/icons-material";
 import { useToast } from "@/react/feedback";
 import { reactGroupsApi } from "./api";
 import { GroupMembershipDialog } from "./GroupMembershipDialog";
 import { GroupRolesDialog } from "./GroupRolesDialog";
 import type { GroupDto } from "@/react/pages/admin/datasource";
+import { PageToolbar } from "@/react/components/page/PageToolbar";
 
 export function GroupDetailPage() {
   const { groupId } = useParams<{ groupId: string }>();
@@ -22,14 +30,23 @@ export function GroupDetailPage() {
   const [rolesOpen, setRolesOpen] = useState(false);
   const [form, setForm] = useState({ name: "", description: "" });
 
-  useEffect(() => {
+  const loadGroup = useCallback(() => {
     if (!groupId) return;
     setLoading(true);
-    reactGroupsApi.getGroup(Number(groupId))
-      .then(g => { setGroup(g); setForm({ name: g.name, description: g.description ?? "" }); setError(null); })
+    reactGroupsApi
+      .getGroup(Number(groupId))
+      .then((g) => {
+        setGroup(g);
+        setForm({ name: g.name, description: g.description ?? "" });
+        setError(null);
+      })
       .catch(() => setError("그룹을 불러오지 못했습니다."))
       .finally(() => setLoading(false));
   }, [groupId]);
+
+  useEffect(() => {
+    loadGroup();
+  }, [loadGroup]);
 
   async function handleSave() {
     if (!groupId) return;
@@ -44,35 +61,90 @@ export function GroupDetailPage() {
     }
   }
 
-  if (loading) return <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}><CircularProgress /></Box>;
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
   if (error) return <Alert severity="error">{error}</Alert>;
   if (!group) return null;
 
   return (
     <Stack spacing={2}>
-      <Breadcrumbs separator="›">
-        <Typography color="text.secondary">시스템관리</Typography>
-        <Typography color="text.secondary" sx={{ cursor: "pointer" }} onClick={() => navigate("/admin/groups")}>그룹</Typography>
-        <Typography color="text.primary">{group.name}</Typography>
-      </Breadcrumbs>
-      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <Typography variant="h5">그룹 상세</Typography>
-        <Stack direction="row" spacing={1}>
-          <Button startIcon={<GroupAddOutlined />} onClick={() => setMembersOpen(true)}>멤버 관리</Button>
-          <Button startIcon={<ManageAccountsOutlined />} onClick={() => setRolesOpen(true)}>역할 관리</Button>
-          <Button variant="outlined" startIcon={<ArrowBackOutlined />} onClick={() => navigate("/admin/groups")}>목록</Button>
-          <Button variant="contained" startIcon={<SaveOutlined />} onClick={handleSave} disabled={saving}>
-            {saving ? <CircularProgress size={20} /> : "저장"}
-          </Button>
-        </Stack>
-      </Box>
-      <Divider />
-      <Stack spacing={2} sx={{ maxWidth: 600 }}>
-        <TextField label="그룹명" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} size="small" />
-        <TextField label="설명" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} size="small" multiline rows={2} />
-      </Stack>
-      <GroupMembershipDialog open={membersOpen} onClose={() => setMembersOpen(false)} groupId={group.groupId} groupName={group.name} />
-      <GroupRolesDialog open={rolesOpen} onClose={() => setRolesOpen(false)} groupId={group.groupId} groupName={group.name} />
+      <PageToolbar
+        divider
+        breadcrumbs={["시스템관리", "보안관리", "그룹", group.name]}
+        label="그룹 정보를 조회하고 멤버와 역할을 관리합니다."
+        previous
+        onPrevious={() => navigate("/admin/groups")}
+        onRefresh={loadGroup}
+      />
+      <Container maxWidth="md" disableGutters>
+        <Grid container spacing={1} alignItems="center">
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="그룹명"
+              value={form.name}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+              size="small"
+              fullWidth
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="설명"
+              value={form.description}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, description: event.target.value }))
+              }
+              size="small"
+              multiline
+              rows={2}
+              fullWidth
+            />
+          </Grid>
+          <Grid size={12} sx={{ mt: 2 }}>
+            <Stack direction="row" spacing={1} justifyContent="flex-end">
+              <Button
+                variant="outlined"
+                startIcon={<GroupAddOutlined />}
+                onClick={() => setMembersOpen(true)}
+              >
+                멤버 관리
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<ManageAccountsOutlined />}
+                onClick={() => setRolesOpen(true)}
+              >
+                역할 관리
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<SaveOutlined />}
+                onClick={handleSave}
+                disabled={saving}
+              >
+                {saving ? <CircularProgress size={20} /> : "저장"}
+              </Button>
+            </Stack>
+          </Grid>
+        </Grid>
+      </Container>
+      <GroupMembershipDialog
+        open={membersOpen}
+        onClose={() => setMembersOpen(false)}
+        groupId={group.groupId}
+        groupName={group.name}
+      />
+      <GroupRolesDialog
+        open={rolesOpen}
+        onClose={() => setRolesOpen(false)}
+        groupId={group.groupId}
+        groupName={group.name}
+      />
     </Stack>
   );
 }

--- a/src/react/pages/admin/roles/RoleDetailPage.tsx
+++ b/src/react/pages/admin/roles/RoleDetailPage.tsx
@@ -1,14 +1,22 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
-  Box, Stack, Breadcrumbs, Typography, Button, TextField, Divider, CircularProgress, Alert,
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Grid,
+  TextField,
+  Stack,
 } from "@mui/material";
-import { ArrowBackOutlined, SaveOutlined, PersonAddOutlined, GroupAddOutlined } from "@mui/icons-material";
+import { GroupAddOutlined, PersonAddOutlined, SaveOutlined } from "@mui/icons-material";
 import { useToast } from "@/react/feedback";
 import { reactRolesApi } from "./api";
 import { RoleGrantedUsersDialog } from "./RoleGrantedUsersDialog";
 import { RoleGrantedGroupsDialog } from "./RoleGrantedGroupsDialog";
 import type { RoleDto } from "@/react/pages/admin/datasource";
+import { PageToolbar } from "@/react/components/page/PageToolbar";
 
 export function RoleDetailPage() {
   const { roleId } = useParams<{ roleId: string }>();
@@ -22,14 +30,23 @@ export function RoleDetailPage() {
   const [groupsOpen, setGroupsOpen] = useState(false);
   const [form, setForm] = useState({ name: "", description: "" });
 
-  useEffect(() => {
+  const loadRole = useCallback(() => {
     if (!roleId) return;
     setLoading(true);
-    reactRolesApi.getRole(Number(roleId))
-      .then(r => { setRole(r); setForm({ name: r.name, description: r.description ?? "" }); setError(null); })
+    reactRolesApi
+      .getRole(Number(roleId))
+      .then((r) => {
+        setRole(r);
+        setForm({ name: r.name, description: r.description ?? "" });
+        setError(null);
+      })
       .catch(() => setError("역할을 불러오지 못했습니다."))
       .finally(() => setLoading(false));
   }, [roleId]);
+
+  useEffect(() => {
+    loadRole();
+  }, [loadRole]);
 
   async function handleSave() {
     if (!roleId) return;
@@ -44,35 +61,90 @@ export function RoleDetailPage() {
     }
   }
 
-  if (loading) return <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}><CircularProgress /></Box>;
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
   if (error) return <Alert severity="error">{error}</Alert>;
   if (!role) return null;
 
   return (
     <Stack spacing={2}>
-      <Breadcrumbs separator="›">
-        <Typography color="text.secondary">시스템관리</Typography>
-        <Typography color="text.secondary" sx={{ cursor: "pointer" }} onClick={() => navigate("/admin/roles")}>역할</Typography>
-        <Typography color="text.primary">{role.name}</Typography>
-      </Breadcrumbs>
-      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <Typography variant="h5">역할 상세</Typography>
-        <Stack direction="row" spacing={1}>
-          <Button startIcon={<PersonAddOutlined />} onClick={() => setUsersOpen(true)}>사용자 관리</Button>
-          <Button startIcon={<GroupAddOutlined />} onClick={() => setGroupsOpen(true)}>그룹 관리</Button>
-          <Button variant="outlined" startIcon={<ArrowBackOutlined />} onClick={() => navigate("/admin/roles")}>목록</Button>
-          <Button variant="contained" startIcon={<SaveOutlined />} onClick={handleSave} disabled={saving}>
-            {saving ? <CircularProgress size={20} /> : "저장"}
-          </Button>
-        </Stack>
-      </Box>
-      <Divider />
-      <Stack spacing={2} sx={{ maxWidth: 600 }}>
-        <TextField label="역할명" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} size="small" />
-        <TextField label="설명" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} size="small" multiline rows={2} />
-      </Stack>
-      <RoleGrantedUsersDialog open={usersOpen} onClose={() => setUsersOpen(false)} roleId={role.roleId} roleName={role.name} />
-      <RoleGrantedGroupsDialog open={groupsOpen} onClose={() => setGroupsOpen(false)} roleId={role.roleId} roleName={role.name} />
+      <PageToolbar
+        divider
+        breadcrumbs={["시스템관리", "보안관리", "역할", role.name]}
+        label="역할 정보를 조회하고 사용자 및 그룹 할당을 관리합니다."
+        previous
+        onPrevious={() => navigate("/admin/roles")}
+        onRefresh={loadRole}
+      />
+      <Container maxWidth="md" disableGutters>
+        <Grid container spacing={1} alignItems="center">
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="역할명"
+              value={form.name}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+              size="small"
+              fullWidth
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="설명"
+              value={form.description}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, description: event.target.value }))
+              }
+              size="small"
+              multiline
+              rows={2}
+              fullWidth
+            />
+          </Grid>
+          <Grid size={12} sx={{ mt: 2 }}>
+            <Stack direction="row" spacing={1} justifyContent="flex-end">
+              <Button
+                variant="outlined"
+                startIcon={<PersonAddOutlined />}
+                onClick={() => setUsersOpen(true)}
+              >
+                사용자 관리
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<GroupAddOutlined />}
+                onClick={() => setGroupsOpen(true)}
+              >
+                그룹 관리
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<SaveOutlined />}
+                onClick={handleSave}
+                disabled={saving}
+              >
+                {saving ? <CircularProgress size={20} /> : "저장"}
+              </Button>
+            </Stack>
+          </Grid>
+        </Grid>
+      </Container>
+      <RoleGrantedUsersDialog
+        open={usersOpen}
+        onClose={() => setUsersOpen(false)}
+        roleId={role.roleId}
+        roleName={role.name}
+      />
+      <RoleGrantedGroupsDialog
+        open={groupsOpen}
+        onClose={() => setGroupsOpen(false)}
+        roleId={role.roleId}
+        roleName={role.name}
+      />
     </Stack>
   );
 }

--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -4,16 +4,13 @@ import {
   Box,
   Stack,
   Button,
-  IconButton,
+  Container,
+  Grid,
   TextField,
   CircularProgress,
   Alert,
-  Card,
-  CardContent,
-  CardHeader,
-  Tooltip,
 } from "@mui/material";
-import { DeleteOutlineOutlined, SaveOutlined } from "@mui/icons-material";
+import { SaveOutlined } from "@mui/icons-material";
 import { useConfirm, useToast } from "@/react/feedback";
 import { reactObjectTypeApi } from "./api";
 import type { ObjectTypeDto, ObjectTypePolicyDto } from "@/types/studio/objecttype";
@@ -147,69 +144,52 @@ export function ObjectTypeDetailPage() {
   return (
     <Stack spacing={2}>
       <PageToolbar
+        divider
         breadcrumbs={["정책", "오브젝트 타입", objectType.code]}
-        title="오브젝트 타입 상세"
         label="오브젝트 타입 기본 정보와 파일 정책을 관리합니다."
         previous
         onPrevious={() => navigate("/policy/object-types")}
         onRefresh={loadObjectType}
-        actions={
-          <>
-            <Tooltip title="오브젝트 타입 삭제">
-              <span>
-                <IconButton
-                  size="small"
-                  color="error"
-                  onClick={() => void handleDelete()}
-                  disabled={saving}
-                >
-                  <DeleteOutlineOutlined fontSize="small" />
-                </IconButton>
-              </span>
-            </Tooltip>
-            <Tooltip title="저장">
-              <span>
-                <IconButton
-                  size="small"
-                  color="primary"
-                  onClick={handleSave}
-                  disabled={saving}
-                >
-                  {saving ? <CircularProgress size={18} /> : <SaveOutlined fontSize="small" />}
-                </IconButton>
-              </span>
-            </Tooltip>
-          </>
-        }
       />
-      <Card variant="outlined">
-        <CardHeader title="기본 정보" />
-        <CardContent>
-          <Stack spacing={2} sx={{ maxWidth: 600 }}>
+      <Container maxWidth="md" disableGutters>
+        <Grid container spacing={1} alignItems="center">
+          <Grid size={{ xs: 12, md: 4 }}>
             <TextField
               label="코드"
               value={objectType.code}
               InputProps={{ readOnly: true }}
               size="small"
+              fullWidth
             />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
             <TextField
               label="이름"
               value={form.name}
               onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
               size="small"
+              fullWidth
             />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
             <TextField
               label="도메인"
               value={objectType.domain}
               InputProps={{ readOnly: true }}
               size="small"
+              fullWidth
             />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
             <TextField
               label="상태"
               value={form.status}
               onChange={(e) => setForm((f) => ({ ...f, status: e.target.value }))}
               size="small"
+              fullWidth
             />
+          </Grid>
+          <Grid size={{ xs: 12, md: 8 }}>
             <TextField
               label="설명"
               value={form.description}
@@ -217,52 +197,77 @@ export function ObjectTypeDetailPage() {
               size="small"
               multiline
               rows={2}
+              fullWidth
             />
-          </Stack>
-        </CardContent>
-      </Card>
-      {policy && (
-        <Card variant="outlined">
-          <CardHeader
-            title="파일 정책"
-            action={
+          </Grid>
+          <Grid size={12} sx={{ mt: 2 }}>
+            <Stack direction="row" spacing={1} justifyContent="flex-end">
               <Button
                 variant="outlined"
-                size="small"
                 startIcon={<SaveOutlined />}
-                onClick={handleSavePolicy}
+                color="error"
+                onClick={() => void handleDelete()}
                 disabled={saving}
               >
-                저장
+                삭제
               </Button>
-            }
-          />
-          <CardContent>
-            <Stack spacing={2} sx={{ maxWidth: 600 }}>
+              <Button
+                variant="outlined"
+                startIcon={<SaveOutlined />}
+                onClick={handleSave}
+                disabled={saving}
+              >
+                {saving ? <CircularProgress size={20} /> : "저장"}
+              </Button>
+            </Stack>
+          </Grid>
+        </Grid>
+      </Container>
+      <Container maxWidth="md" disableGutters>
+        <Grid container spacing={1} alignItems="center">
+          <Grid size={{ xs: 12, md: 4 }}>
               <TextField
                 label="최대 파일 크기 (MB)"
                 value={policyForm.maxFileMb}
                 onChange={(e) => setPolicyForm((f) => ({ ...f, maxFileMb: e.target.value }))}
                 size="small"
                 type="number"
+                fullWidth
               />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
               <TextField
                 label="허용 확장자"
                 value={policyForm.allowedExt}
                 onChange={(e) => setPolicyForm((f) => ({ ...f, allowedExt: e.target.value }))}
                 size="small"
                 helperText="예: jpg,png,pdf"
+                fullWidth
               />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
               <TextField
                 label="허용 MIME 타입"
                 value={policyForm.allowedMime}
                 onChange={(e) => setPolicyForm((f) => ({ ...f, allowedMime: e.target.value }))}
                 size="small"
+                fullWidth
               />
+          </Grid>
+          <Grid size={12} sx={{ mt: 2 }}>
+            <Stack direction="row" spacing={1} justifyContent="flex-end">
+              <Button
+                variant="outlined"
+                startIcon={<SaveOutlined />}
+                onClick={handleSavePolicy}
+                disabled={saving}
+              >
+                {saving ? <CircularProgress size={20} /> : "파일 정책 저장"}
+              </Button>
             </Stack>
-          </CardContent>
-        </Card>
-      )}
+          </Grid>
+        </Grid>
+      </Container>
     </Stack>
   );
 }

--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Stack,
   Button,
@@ -10,7 +13,7 @@ import {
   CircularProgress,
   Alert,
 } from "@mui/material";
-import { SaveOutlined } from "@mui/icons-material";
+import { ExpandMoreOutlined, SaveOutlined } from "@mui/icons-material";
 import { useConfirm, useToast } from "@/react/feedback";
 import { reactObjectTypeApi } from "./api";
 import type { ObjectTypeDto, ObjectTypePolicyDto } from "@/types/studio/objecttype";
@@ -224,49 +227,56 @@ export function ObjectTypeDetailPage() {
         </Grid>
       </Container>
       <Container maxWidth="md" disableGutters>
-        <Grid container spacing={1} alignItems="center">
-          <Grid size={{ xs: 12, md: 4 }}>
-              <TextField
-                label="최대 파일 크기 (MB)"
-                value={policyForm.maxFileMb}
-                onChange={(e) => setPolicyForm((f) => ({ ...f, maxFileMb: e.target.value }))}
-                size="small"
-                type="number"
-                fullWidth
-              />
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-              <TextField
-                label="허용 확장자"
-                value={policyForm.allowedExt}
-                onChange={(e) => setPolicyForm((f) => ({ ...f, allowedExt: e.target.value }))}
-                size="small"
-                helperText="예: jpg,png,pdf"
-                fullWidth
-              />
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-              <TextField
-                label="허용 MIME 타입"
-                value={policyForm.allowedMime}
-                onChange={(e) => setPolicyForm((f) => ({ ...f, allowedMime: e.target.value }))}
-                size="small"
-                fullWidth
-              />
-          </Grid>
-          <Grid size={12} sx={{ mt: 2 }}>
-            <Stack direction="row" spacing={1} justifyContent="flex-end">
-              <Button
-                variant="outlined"
-                startIcon={<SaveOutlined />}
-                onClick={handleSavePolicy}
-                disabled={saving}
-              >
-                {saving ? <CircularProgress size={20} /> : "파일 정책 저장"}
-              </Button>
-            </Stack>
-          </Grid>
-        </Grid>
+        <Accordion disableGutters>
+          <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
+            파일 정책
+          </AccordionSummary>
+          <AccordionDetails>
+            <Grid container spacing={1} alignItems="center">
+              <Grid size={{ xs: 12, md: 4 }}>
+                <TextField
+                  label="최대 파일 크기 (MB)"
+                  value={policyForm.maxFileMb}
+                  onChange={(e) => setPolicyForm((f) => ({ ...f, maxFileMb: e.target.value }))}
+                  size="small"
+                  type="number"
+                  fullWidth
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <TextField
+                  label="허용 확장자"
+                  value={policyForm.allowedExt}
+                  onChange={(e) => setPolicyForm((f) => ({ ...f, allowedExt: e.target.value }))}
+                  size="small"
+                  helperText="예: jpg,png,pdf"
+                  fullWidth
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <TextField
+                  label="허용 MIME 타입"
+                  value={policyForm.allowedMime}
+                  onChange={(e) => setPolicyForm((f) => ({ ...f, allowedMime: e.target.value }))}
+                  size="small"
+                  fullWidth
+                />
+              </Grid>
+              <Grid size={12} sx={{ mt: 2 }}>
+                <Stack direction="row" spacing={1} justifyContent="flex-end">
+                  <Button
+                    variant="outlined"
+                    startIcon={<SaveOutlined />}
+                    onClick={handleSavePolicy}
+                    disabled={saving}
+                  >
+                    {saving ? <CircularProgress size={20} /> : "파일 정책 저장"}
+                  </Button>
+                </Stack>
+              </Grid>
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
       </Container>
     </Stack>
   );

--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -237,11 +237,12 @@ export function ObjectTypeDetailPage() {
                 <TextField
                   label="최대 파일 크기 (MB)"
                   value={policyForm.maxFileMb}
-                  onChange={(e) => setPolicyForm((f) => ({ ...f, maxFileMb: e.target.value }))}
-                  size="small"
-                  type="number"
-                  fullWidth
-                />
+                onChange={(e) => setPolicyForm((f) => ({ ...f, maxFileMb: e.target.value }))}
+                size="small"
+                type="number"
+                helperText="예: 10"
+                fullWidth
+              />
               </Grid>
               <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
@@ -259,6 +260,7 @@ export function ObjectTypeDetailPage() {
                   value={policyForm.allowedMime}
                   onChange={(e) => setPolicyForm((f) => ({ ...f, allowedMime: e.target.value }))}
                   size="small"
+                  helperText="예: image/*,application/pdf"
                   fullWidth
                 />
               </Grid>

--- a/src/react/pages/templates/TemplateDetailsPage.tsx
+++ b/src/react/pages/templates/TemplateDetailsPage.tsx
@@ -1,21 +1,21 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
-  Box,
-  Stack,
-  Breadcrumbs,
-  Typography,
-  Button,
-  TextField,
-  Divider,
-  CircularProgress,
   Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Grid,
+  TextField,
+  Stack,
 } from "@mui/material";
-import { ArrowBackOutlined, SaveOutlined, PreviewOutlined } from "@mui/icons-material";
+import { PreviewOutlined, SaveOutlined } from "@mui/icons-material";
 import { useToast } from "@/react/feedback";
 import { PreviewTemplateDialog } from "@/react/pages/templates/PreviewTemplateDialog";
 import { reactTemplatesApi } from "./api";
 import type { TemplateDto } from "@/types/studio/template";
+import { PageToolbar } from "@/react/components/page/PageToolbar";
 
 export function TemplateDetailsPage() {
   const { templateId } = useParams<{ templateId: string }>();
@@ -34,7 +34,7 @@ export function TemplateDetailsPage() {
     body: "",
   });
 
-  useEffect(() => {
+  const loadTemplate = useCallback(() => {
     if (!templateId) return;
     setLoading(true);
     reactTemplatesApi
@@ -53,6 +53,10 @@ export function TemplateDetailsPage() {
       .catch(() => setError("템플릿을 불러오지 못했습니다."))
       .finally(() => setLoading(false));
   }, [templateId]);
+
+  useEffect(() => {
+    loadTemplate();
+  }, [loadTemplate]);
 
   async function handleSave() {
     if (!templateId || !template) return;
@@ -88,77 +92,86 @@ export function TemplateDetailsPage() {
 
   return (
     <Stack spacing={2}>
-      <Breadcrumbs separator="›">
-        <Typography color="text.secondary">애플리케이션</Typography>
-        <Typography
-          color="text.secondary"
-          sx={{ cursor: "pointer" }}
-          onClick={() => navigate("/application/templates")}
-        >
-          템플릿
-        </Typography>
-        <Typography color="text.primary">{template.name}</Typography>
-      </Breadcrumbs>
-      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <Typography variant="h5">템플릿 상세</Typography>
-        <Stack direction="row" spacing={1}>
-          <Button startIcon={<PreviewOutlined />} onClick={() => setPreviewOpen(true)}>
-            미리보기
-          </Button>
-          <Button
-            variant="outlined"
-            startIcon={<ArrowBackOutlined />}
-            onClick={() => navigate("/application/templates")}
-          >
-            목록
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={<SaveOutlined />}
-            onClick={handleSave}
-            disabled={saving}
-          >
-            {saving ? <CircularProgress size={20} /> : "저장"}
-          </Button>
-        </Stack>
-      </Box>
-      <Divider />
-      <Stack spacing={2} sx={{ maxWidth: 700 }}>
-        <TextField
-          label="이름"
-          value={form.name}
-          onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
-          size="small"
-        />
-        <TextField
-          label="표시 이름"
-          value={form.displayName}
-          onChange={(e) => setForm((f) => ({ ...f, displayName: e.target.value }))}
-          size="small"
-        />
-        <TextField
-          label="설명"
-          value={form.description}
-          onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
-          size="small"
-          multiline
-          rows={2}
-        />
-        <TextField
-          label="제목 (subject)"
-          value={form.subject}
-          onChange={(e) => setForm((f) => ({ ...f, subject: e.target.value }))}
-          size="small"
-        />
-        <TextField
-          label="본문 (body)"
-          value={form.body}
-          onChange={(e) => setForm((f) => ({ ...f, body: e.target.value }))}
-          size="small"
-          multiline
-          rows={10}
-        />
-      </Stack>
+      <PageToolbar
+        divider
+        breadcrumbs={["애플리케이션", "템플릿", template.name]}
+        label="템플릿 메타데이터와 본문을 관리합니다."
+        previous
+        onPrevious={() => navigate("/application/templates")}
+        onRefresh={loadTemplate}
+      />
+      <Container maxWidth="md" disableGutters>
+        <Grid container spacing={1} alignItems="center">
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="이름"
+              value={form.name}
+              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              size="small"
+              fullWidth
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="표시 이름"
+              value={form.displayName}
+              onChange={(e) => setForm((f) => ({ ...f, displayName: e.target.value }))}
+              size="small"
+              fullWidth
+            />
+          </Grid>
+          <Grid size={12}>
+            <TextField
+              label="설명"
+              value={form.description}
+              onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+              size="small"
+              multiline
+              rows={2}
+              fullWidth
+            />
+          </Grid>
+          <Grid size={12}>
+            <TextField
+              label="제목 (subject)"
+              value={form.subject}
+              onChange={(e) => setForm((f) => ({ ...f, subject: e.target.value }))}
+              size="small"
+              fullWidth
+            />
+          </Grid>
+          <Grid size={12}>
+            <TextField
+              label="본문 (body)"
+              value={form.body}
+              onChange={(e) => setForm((f) => ({ ...f, body: e.target.value }))}
+              size="small"
+              multiline
+              rows={10}
+              fullWidth
+            />
+          </Grid>
+          <Grid size={12} sx={{ mt: 2 }}>
+            <Stack direction="row" spacing={1} justifyContent="flex-end">
+              <Button
+                variant="outlined"
+                startIcon={<PreviewOutlined />}
+                onClick={() => setPreviewOpen(true)}
+              >
+                미리보기
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<SaveOutlined />}
+                onClick={handleSave}
+                disabled={saving}
+              >
+                {saving ? <CircularProgress size={20} /> : "저장"}
+              </Button>
+            </Stack>
+          </Grid>
+        </Grid>
+      </Container>
       <PreviewTemplateDialog
         open={previewOpen}
         onClose={() => setPreviewOpen(false)}


### PR DESCRIPTION
## Why
- Closes #74
- 관리형 상세 화면들이 각각 다른 breadcrumbs/header/action/form 레이아웃을 사용하고 있어 유지보수성과 사용 경험이 떨어졌습니다.
- 사용자 상세 화면을 기준 구현으로 삼아 그룹, 역할, 오브젝트 타입, 템플릿 상세를 같은 패턴으로 통일합니다.

## What
- 그룹 상세를 `PageToolbar + Container + Grid + 하단 outlined 버튼` 구조로 정리했습니다.
- 역할 상세를 같은 구조로 정리했습니다.
- 오브젝트 타입 상세는 상단 toolbar action을 refresh만 남기고, 기본 정보와 파일 정책 섹션을 `Container + Grid` 기준으로 재배치했습니다.
- 오브젝트 타입 상세의 삭제/저장/파일 정책 저장 액션을 하단 outlined 버튼으로 이동했습니다.
- 템플릿 상세를 `PageToolbar + Container + Grid + 하단 outlined 버튼` 구조로 정리했습니다.
- 미리보기/저장 액션도 하단 버튼 영역으로 이동했습니다.
- `CHANGELOG.md`에 issue #74 변경과 검증 기록을 추가했습니다.

## Related Issues
- Closes #74

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 보안/권한 동작 변경 없음. 상세 화면의 UI 구조와 액션 배치만 변경합니다.
- Mitigation: 기존 API 호출, 저장 로직, 미리보기/삭제/관리 dialog open/close 로직은 유지하고 typecheck/lint/build를 실행했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - `npm run typecheck`: 통과
  - `npm run lint`: 통과, 기존 warning 15개 유지
  - `npm run build`: 통과, 기존 Vite large chunk warning 유지
- Additional checks:
  - 그룹/역할/오브젝트 타입/템플릿 상세의 PageToolbar previous/refresh와 하단 outlined action button 경로를 코드 리뷰로 확인했습니다.
  - 오브젝트 타입 상세의 파일 정책 섹션이 유지되는 것을 확인했습니다.
  - 브라우저 smoke test는 현재 환경에서 수행하지 못했습니다. 머지 전 각 상세 route에서 toolbar와 하단 버튼 동작을 수동 확인해야 합니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 관리형 상세 UI 표준화 작업입니다.
- Rollback plan: PR revert 시 각 상세 화면이 기존 개별 header/action 구조로 돌아갑니다.
- Post-deploy checks: `/admin/groups/:groupId`, `/admin/roles/:roleId`, `/policy/object-types/:objectTypeId`, `/application/templates/:templateId`에서 toolbar, 하단 버튼, 저장/관리/미리보기/삭제 동작을 확인합니다.