### PR TITLE
[ai-assisted] refactor(user): improve roles dialog UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- User roles management dialog now distinguishes group-inherited roles from directly granted roles and uses a transfer-list style editor for direct assignments.
 - Managed detail pages for groups, roles, object types, and templates now follow the user detail page layout standard.
 - ACL management page and create dialogs now restore explanatory guidance from the legacy Vue implementation.
 - Issue `#59` split FullLayout navigation and user menu responsibilities into dedicated layout components.
@@ -17,6 +18,9 @@
 
 ### Verification
 
+- User roles dialog UX: `npm run typecheck`
+- User roles dialog UX: `npm run lint`
+- User roles dialog UX: `npm run build`
 - Admin detail standardization: `npm run typecheck`
 - Admin detail standardization: `npm run lint`
 - Admin detail standardization: `npm run build`

--- a/src/react/pages/admin/users/UserRolesDialog.tsx
+++ b/src/react/pages/admin/users/UserRolesDialog.tsx
@@ -1,13 +1,30 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
-  Dialog, DialogTitle, DialogContent, DialogActions,
-  Button, List, ListItem, ListItemText, IconButton, Divider,
-  Typography, CircularProgress, Stack, TextField,
+  Alert,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  List,
+  ListItemButton,
+  ListItemText,
+  Stack,
+  TextField,
+  Typography,
 } from "@mui/material";
-import { DeleteOutlined, AddOutlined } from "@mui/icons-material";
-import { useToast } from "@/react/feedback";
+import {
+  ArrowBackOutlined,
+  ArrowForwardOutlined,
+} from "@mui/icons-material";
+import { useConfirm, useToast } from "@/react/feedback";
 import { reactUsersApi } from "./api";
 import type { UserRoleDto } from "./api";
+import type { RoleDto } from "@/react/pages/admin/datasource";
 
 interface Props {
   open: boolean;
@@ -16,79 +33,318 @@ interface Props {
   username: string;
 }
 
+function byName(left: { name: string }, right: { name: string }) {
+  return left.name.localeCompare(right.name);
+}
+
 export function UserRolesDialog({ open, onClose, userId, username }: Props) {
   const toast = useToast();
-  const [roles, setRoles] = useState<UserRoleDto[]>([]);
+  const confirm = useConfirm();
   const [loading, setLoading] = useState(false);
-  const [roleIdInput, setRoleIdInput] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [allRoles, setAllRoles] = useState<RoleDto[]>([]);
+  const [grantedRolesByGroup, setGrantedRolesByGroup] = useState<UserRoleDto[]>([]);
+  const [grantedRolesByUser, setGrantedRolesByUser] = useState<UserRoleDto[]>([]);
+  const [initialGrantedRolesByUser, setInitialGrantedRolesByUser] = useState<UserRoleDto[]>([]);
+  const [selectedLeft, setSelectedLeft] = useState<number[]>([]);
+  const [selectedRight, setSelectedRight] = useState<number[]>([]);
+  const [searchLeft, setSearchLeft] = useState("");
+  const [searchRight, setSearchRight] = useState("");
 
-  async function loadRoles() {
+  async function loadData() {
     setLoading(true);
     try {
-      const data = await reactUsersApi.getUserRoles(userId);
-      setRoles(Array.isArray(data) ? data : []);
+      const [rolesResponse, groupRoles, userRoles] = await Promise.all([
+        reactUsersApi.getAvailableRoles(),
+        reactUsersApi.getUserGroupRoles(userId),
+        reactUsersApi.getUserDirectRoles(userId),
+      ]);
+      const roles = (rolesResponse.content ?? []).slice().sort(byName);
+      const directRoles = (Array.isArray(userRoles) ? userRoles : []).slice().sort(byName);
+      const inheritedRoles = (Array.isArray(groupRoles) ? groupRoles : []).slice().sort(byName);
+      setAllRoles(roles);
+      setGrantedRolesByGroup(inheritedRoles);
+      setGrantedRolesByUser(directRoles);
+      setInitialGrantedRolesByUser(directRoles);
+      setSelectedLeft([]);
+      setSelectedRight([]);
+      setSearchLeft("");
+      setSearchRight("");
     } catch {
-      toast.error("역할 목록 로딩 실패");
+      toast.error("역할 목록 로딩에 실패했습니다.");
     } finally {
       setLoading(false);
     }
   }
 
   useEffect(() => {
-    if (open) { setRoleIdInput(""); loadRoles(); }
+    if (!open) return;
+    void loadData();
   }, [open, userId]);
 
-  async function handleAdd() {
-    const roleId = parseInt(roleIdInput, 10);
-    if (!roleId) return;
-    try {
-      await reactUsersApi.addUserRole(userId, roleId);
-      toast.success("역할이 부여되었습니다.");
-      setRoleIdInput("");
-      loadRoles();
-    } catch {
-      toast.error("역할 부여에 실패했습니다.");
-    }
+  const inheritedRoleIds = useMemo(
+    () => new Set(grantedRolesByGroup.map((role) => role.roleId)),
+    [grantedRolesByGroup]
+  );
+  const directRoleIds = useMemo(
+    () => new Set(grantedRolesByUser.map((role) => role.roleId)),
+    [grantedRolesByUser]
+  );
+
+  const availableRoles = useMemo(
+    () =>
+      allRoles
+        .filter((role) => !inheritedRoleIds.has(role.roleId) && !directRoleIds.has(role.roleId))
+        .filter((role) => {
+          const keyword = searchLeft.trim().toLowerCase();
+          if (!keyword) return true;
+          return (
+            role.name.toLowerCase().includes(keyword) ||
+            String(role.roleId).includes(keyword) ||
+            (role.description ?? "").toLowerCase().includes(keyword)
+          );
+        }),
+    [allRoles, inheritedRoleIds, directRoleIds, searchLeft]
+  );
+
+  const filteredGrantedRolesByUser = useMemo(
+    () =>
+      grantedRolesByUser.filter((role) => {
+        const keyword = searchRight.trim().toLowerCase();
+        if (!keyword) return true;
+        return (
+          role.name.toLowerCase().includes(keyword) ||
+          String(role.roleId).includes(keyword) ||
+          (role.description ?? "").toLowerCase().includes(keyword)
+        );
+      }),
+    [grantedRolesByUser, searchRight]
+  );
+
+  function toggleSelected(
+    selected: number[],
+    setter: (value: number[]) => void,
+    roleId: number
+  ) {
+    setter(
+      selected.includes(roleId)
+        ? selected.filter((value) => value !== roleId)
+        : [...selected, roleId]
+    );
   }
 
-  async function handleRemove(roleId: number) {
+  function moveToGranted() {
+    const nextRoles = allRoles
+      .filter((role) => selectedLeft.includes(role.roleId))
+      .map((role) => ({
+        roleId: role.roleId,
+        name: role.name,
+        description: role.description,
+      }));
+
+    setGrantedRolesByUser((current) =>
+      [...current, ...nextRoles]
+        .filter(
+          (role, index, roles) =>
+            roles.findIndex((candidate) => candidate.roleId === role.roleId) === index
+        )
+        .sort(byName)
+    );
+    setSelectedLeft([]);
+  }
+
+  function moveToAvailable() {
+    setGrantedRolesByUser((current) =>
+      current.filter((role) => !selectedRight.includes(role.roleId))
+    );
+    setSelectedRight([]);
+  }
+
+  async function handleSave() {
+    const initialIds = new Set(initialGrantedRolesByUser.map((role) => role.roleId));
+    const currentIds = new Set(grantedRolesByUser.map((role) => role.roleId));
+
+    const toAdd = grantedRolesByUser.filter((role) => !initialIds.has(role.roleId));
+    const toRemove = initialGrantedRolesByUser.filter((role) => !currentIds.has(role.roleId));
+
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      toast.info("변경된 역할이 없습니다.");
+      onClose();
+      return;
+    }
+
+    const ok = await confirm({
+      title: "역할 변경 저장",
+      message: `역할 ${toAdd.length}개 추가, ${toRemove.length}개 제거를 저장하시겠습니까?`,
+      okText: "저장",
+      cancelText: "취소",
+    });
+    if (!ok) return;
+
+    setSaving(true);
     try {
-      await reactUsersApi.removeUserRole(userId, roleId);
-      toast.success("역할이 제거되었습니다.");
-      loadRoles();
+      await Promise.all([
+        ...toAdd.map((role) => reactUsersApi.addUserRole(userId, role.roleId)),
+        ...toRemove.map((role) => reactUsersApi.removeUserRole(userId, role.roleId)),
+      ]);
+      toast.success("사용자 역할이 저장되었습니다.");
+      onClose();
     } catch {
-      toast.error("역할 제거에 실패했습니다.");
+      toast.error("사용자 역할 저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
     }
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth>
       <DialogTitle>역할 관리 — {username}</DialogTitle>
       <DialogContent>
-        <Stack spacing={1} sx={{ mt: 1 }}>
-          <Stack direction="row" spacing={1}>
-            <TextField label="역할 ID" size="small" value={roleIdInput}
-              onChange={e => setRoleIdInput(e.target.value)}
-              onKeyDown={e => e.key === "Enter" && handleAdd()} />
-            <Button startIcon={<AddOutlined />} variant="outlined" onClick={handleAdd} disabled={!roleIdInput}>추가</Button>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Alert severity="info">
+            그룹에서 상속된 역할은 읽기 전용입니다. 여기서는 사용자에게 직접 부여한 역할만 추가하거나 제거할 수 있습니다.
+          </Alert>
+
+          <Card variant="outlined">
+            <CardContent>
+              <Stack spacing={1}>
+                <Typography variant="subtitle2">그룹에서 부여된 역할</Typography>
+                {loading ? (
+                  <CircularProgress size={24} />
+                ) : grantedRolesByGroup.length === 0 ? (
+                  <Typography color="text.secondary" variant="body2">
+                    그룹 상속 역할 없음
+                  </Typography>
+                ) : (
+                  <List dense>
+                    {grantedRolesByGroup.map((role) => (
+                      <ListItemButton key={role.roleId} disabled>
+                        <ListItemText
+                          primary={role.name}
+                          secondary={`ID: ${role.roleId}`}
+                        />
+                      </ListItemButton>
+                    ))}
+                  </List>
+                )}
+              </Stack>
+            </CardContent>
+          </Card>
+
+          <Stack direction={{ xs: "column", md: "row" }} spacing={2} alignItems="stretch">
+            <Card variant="outlined" sx={{ flex: 1, minWidth: 0 }}>
+              <CardContent>
+                <Stack spacing={1}>
+                  <Typography variant="subtitle2">부여 가능한 역할</Typography>
+                  <TextField
+                    label="역할 검색"
+                    size="small"
+                    value={searchLeft}
+                    onChange={(event) => setSearchLeft(event.target.value)}
+                    fullWidth
+                  />
+                  <Divider />
+                  {loading ? (
+                    <CircularProgress size={24} />
+                  ) : availableRoles.length === 0 ? (
+                    <Typography color="text.secondary" variant="body2">
+                      선택 가능한 역할 없음
+                    </Typography>
+                  ) : (
+                    <List dense sx={{ maxHeight: 280, overflowY: "auto" }}>
+                      {availableRoles.map((role) => (
+                        <ListItemButton
+                          key={role.roleId}
+                          selected={selectedLeft.includes(role.roleId)}
+                          onClick={() =>
+                            toggleSelected(selectedLeft, setSelectedLeft, role.roleId)
+                          }
+                        >
+                          <ListItemText
+                            primary={role.name}
+                            secondary={`ID: ${role.roleId}${role.description ? ` · ${role.description}` : ""}`}
+                          />
+                        </ListItemButton>
+                      ))}
+                    </List>
+                  )}
+                </Stack>
+              </CardContent>
+            </Card>
+
+            <Stack
+              direction={{ xs: "row", md: "column" }}
+              spacing={1}
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Button
+                variant="outlined"
+                startIcon={<ArrowForwardOutlined />}
+                onClick={moveToGranted}
+                disabled={selectedLeft.length === 0}
+              >
+                추가
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<ArrowBackOutlined />}
+                onClick={moveToAvailable}
+                disabled={selectedRight.length === 0}
+              >
+                제거
+              </Button>
+            </Stack>
+
+            <Card variant="outlined" sx={{ flex: 1, minWidth: 0 }}>
+              <CardContent>
+                <Stack spacing={1}>
+                  <Typography variant="subtitle2">사용자에게 직접 부여한 역할</Typography>
+                  <TextField
+                    label="역할 검색"
+                    size="small"
+                    value={searchRight}
+                    onChange={(event) => setSearchRight(event.target.value)}
+                    fullWidth
+                  />
+                  <Divider />
+                  {loading ? (
+                    <CircularProgress size={24} />
+                  ) : filteredGrantedRolesByUser.length === 0 ? (
+                    <Typography color="text.secondary" variant="body2">
+                      직접 부여 역할 없음
+                    </Typography>
+                  ) : (
+                    <List dense sx={{ maxHeight: 280, overflowY: "auto" }}>
+                      {filteredGrantedRolesByUser.map((role) => (
+                        <ListItemButton
+                          key={role.roleId}
+                          selected={selectedRight.includes(role.roleId)}
+                          onClick={() =>
+                            toggleSelected(selectedRight, setSelectedRight, role.roleId)
+                          }
+                        >
+                          <ListItemText
+                            primary={role.name}
+                            secondary={`ID: ${role.roleId}${role.description ? ` · ${role.description}` : ""}`}
+                          />
+                        </ListItemButton>
+                      ))}
+                    </List>
+                  )}
+                </Stack>
+              </CardContent>
+            </Card>
           </Stack>
-          <Divider />
-          {loading ? <CircularProgress size={24} /> : (
-            <List dense>
-              {roles.length === 0 && <Typography color="text.secondary" variant="body2">부여된 역할 없음</Typography>}
-              {roles.map(r => (
-                <ListItem key={r.roleId} secondaryAction={
-                  <IconButton size="small" color="error" onClick={() => handleRemove(r.roleId)}><DeleteOutlined fontSize="small" /></IconButton>
-                }>
-                  <ListItemText primary={r.name} secondary={`ID: ${r.roleId}`} />
-                </ListItem>
-              ))}
-            </List>
-          )}
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>닫기</Button>
+        <Button onClick={onClose} disabled={saving}>
+          취소
+        </Button>
+        <Button variant="contained" onClick={() => void handleSave()} disabled={saving}>
+          {saving ? <CircularProgress size={20} /> : "저장"}
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/react/pages/admin/users/api.ts
+++ b/src/react/pages/admin/users/api.ts
@@ -1,4 +1,5 @@
 import { apiRequest } from "@/react/query/fetcher";
+import type { RoleDto } from "@/react/pages/admin/datasource";
 import type { UserDto, PasswordPolicyDto, ResetPasswordRequest } from "@/types/studio/user";
 
 export interface UserRoleDto { roleId: number; name: string; description?: string | null; }
@@ -17,6 +18,22 @@ export const reactUsersApi = {
     apiRequest<UserDto>("put", `/api/mgmt/users/${userId}`, { data: payload }),
   getUserRoles: (userId: number) =>
     apiRequest<UserRoleDto[]>("get", `/api/mgmt/users/${userId}/roles`),
+  getUserDirectRoles: (userId: number) =>
+    apiRequest<UserRoleDto[]>("get", `/api/mgmt/users/${userId}/roles`, {
+      params: { by: "user" },
+    }),
+  getUserGroupRoles: (userId: number) =>
+    apiRequest<UserRoleDto[]>("get", `/api/mgmt/users/${userId}/roles`, {
+      params: { by: "group" },
+    }),
+  getAvailableRoles: (params?: { page?: number; size?: number; sort?: string }) =>
+    apiRequest<{ content: RoleDto[]; totalElements: number }>("get", "/api/mgmt/roles", {
+      params: {
+        page: params?.page ?? 0,
+        size: params?.size ?? 200,
+        sort: params?.sort ?? "name,asc",
+      },
+    }),
   addUserRole: (userId: number, roleId: number) =>
     apiRequest<void>("post", `/api/mgmt/users/${userId}/roles`, { data: { roleId } }),
   removeUserRole: (userId: number, roleId: number) =>


### PR DESCRIPTION
## Why
- Closes #77
- 현재 React `UserRolesDialog`는 역할 ID 직접 입력 방식이라 부여 실수 가능성이 높고, 기존 Vue 구현의 핵심 의도였던 그룹 상속 역할과 사용자 직접 부여 역할의 구분이 충분히 드러나지 않았습니다.
- 역할 부여/회수는 권한 변경 작업이므로 상세 본문과 분리된 모달 문맥을 유지하되, 더 명확하고 안전한 부여 UX가 필요합니다.

## What
- `UserRolesDialog`는 모달로 유지했습니다.
- 그룹 상속 역할을 읽기 전용 섹션으로 분리했습니다.
- 사용자 직접 부여 역할은 Transfer List 스타일의 좌측 후보 / 우측 직접 부여 역할 구조로 변경했습니다.
- 역할 ID 직접 입력 대신 역할 목록에서 선택하도록 바꿨습니다.
- 저장 시 초기 직접 부여 역할과 현재 직접 부여 역할의 diff를 계산해 add/remove API만 호출하도록 변경했습니다.
- `reactUsersApi`에 다음 helper를 추가했습니다.
  - `getUserDirectRoles(userId)`
  - `getUserGroupRoles(userId)`
  - `getAvailableRoles()`
- `CHANGELOG.md`에 issue #77 변경과 검증 기록을 추가했습니다.

## Related Issues
- Closes #77

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 권한 변경은 민감 작업이므로 오동작 시 잘못된 권한 부여/회수가 발생할 수 있습니다.
- Mitigation: 그룹 상속 역할은 읽기 전용으로 분리하고, 저장 전에 변경 요약 confirm을 거치며, diff 기반 add/remove 호출만 수행합니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - `npm run typecheck`: 통과
  - `npm run lint`: 통과, 기존 warning 15개 유지
  - `npm run build`: 통과, 기존 Vite large chunk warning 유지
- Additional checks:
  - 기존 Vue `UserRolesDialog.vue`와 `user.roles.store.ts`의 의도(상속 역할/직접 부여 역할 분리)를 대조했습니다.
  - 브라우저 smoke test는 현재 환경에서 수행하지 못했습니다. 머지 전 `/admin/users/:userId` 역할 관리 모달에서 상속 역할 읽기 전용, 직접 부여 역할 추가/제거, 저장 반영을 수동 확인해야 합니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 사용자 상세 표준화 이후 역할 관리 UX를 별도 개선한 작업입니다.
- Rollback plan: PR revert 시 UserRolesDialog가 기존 역할 ID 직접 입력 방식으로 돌아갑니다.
- Post-deploy checks: `/admin/users/:userId`에서 역할 관리 모달 open, 상속 역할 읽기 전용 표시, 직접 부여 역할 이동, 저장 후 재오픈 시 최신 상태 반영을 확인합니다.