### PR TITLE
[ai-assisted] refactor(group): improve member and role dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Issue `#81` updates group member and role dialogs with batch member selection and transfer-list role editing.
 - Issue `#79` stabilizes the user roles dialog loading layout with section skeletons and fixed content heights.
 - User roles management dialog now distinguishes group-inherited roles from directly granted roles and uses a transfer-list style editor for direct assignments.
 - Managed detail pages for groups, roles, object types, and templates now follow the user detail page layout standard.
@@ -19,6 +20,10 @@
 
 ### Verification
 
+- Issue `#81`: `npm run typecheck`
+- Issue `#81`: `npm run lint`
+- Issue `#81`: `npm run build`
+- Issue `#81`: manual check - group member and role dialog flows reviewed in code
 - Issue `#79`: `npm run typecheck`
 - Issue `#79`: `npm run lint`
 - Issue `#79`: `npm run build`

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -22,6 +22,7 @@ import { PageableGridContent } from "@/react/components/ag-grid";
 import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
 import { UsersDataSource } from "@/react/pages/admin/datasource";
 import type { UserDto } from "@/types/studio/user";
+import { useConfirm } from "@/react/feedback";
 import { API_BASE_URL } from "@/config/backend";
 import NO_AVATAR from "@/assets/images/users/no-avatar.png";
 
@@ -32,6 +33,7 @@ interface Props {
   selectionMode?: "single" | "multiple";
   onConfirmSelection?: (users: UserDto[]) => void | Promise<void>;
   confirmLabel?: string;
+  confirmMessage?: string;
 }
 
 export function UserSearchDialog({
@@ -41,9 +43,11 @@ export function UserSearchDialog({
   selectionMode = "single",
   onConfirmSelection,
   confirmLabel = "추가",
+  confirmMessage = "선택한 사용자를 추가하시겠습니까? 이 작업은 즉시 반영됩니다.",
 }: Props) {
   const gridRef = useRef<PageableGridContentHandle<UserDto>>(null);
   const dataSource = useMemo(() => new UsersDataSource(), []);
+  const confirm = useConfirm();
   const isMultiple = selectionMode === "multiple";
   const [selectedCount, setSelectedCount] = useState(0);
   const [displayedCount, setDisplayedCount] = useState(0);
@@ -149,6 +153,17 @@ export function UserSearchDialog({
     if (users.length === 0) {
       return;
     }
+
+    const ok = await confirm({
+      title: "확인",
+      message: confirmMessage,
+      okText: "확인",
+      cancelText: "취소",
+    });
+    if (!ok) {
+      return;
+    }
+
     setConfirming(true);
     try {
       await onConfirmSelection?.(users);

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -29,7 +29,7 @@ export function UserSearchDialog({
 }: Props) {
   const gridRef = useRef<PageableGridContentHandle<UserDto>>(null);
   const dataSource = useMemo(() => new UsersDataSource(), []);
-  const isMultiple = selectionMode === "multiple";
+const isMultiple = selectionMode === "multiple";
   const [selectedCount, setSelectedCount] = useState(0);
   const [confirming, setConfirming] = useState(false);
 
@@ -102,12 +102,13 @@ export function UserSearchDialog({
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
       <DialogTitle>사용자 검색</DialogTitle>
-      <DialogContent sx={{ height: 400 }}>
+      <DialogContent sx={{ height: 420 }}>
         <PageableGridContent<UserDto>
           ref={gridRef}
           datasource={dataSource}
           columns={columnDefs}
           events={gridEvents}
+          height={340}
           rowSelection={isMultiple ? "multiple" : undefined}
         />
       </DialogContent>

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -215,8 +215,14 @@ export function UserSearchDialog({
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
       <DialogTitle>사용자 검색</DialogTitle>
-      <DialogContent sx={{ height: 420 }}>
-        <Stack spacing={1} sx={{ mt: 1 }}>
+      <DialogContent
+        sx={{
+          height: "min(70vh, 640px)",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <Stack spacing={1} sx={{ mt: 1, minHeight: 0, flex: 1 }}>
           <TextField
             label="이름, 아이디, 이메일 검색"
             size="small"
@@ -248,7 +254,6 @@ export function UserSearchDialog({
             datasource={dataSource}
             columns={columnDefs}
             events={gridEvents}
-            height={320}
             rowSelection={isMultiple ? "multiple" : undefined}
           />
         </Stack>

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -5,12 +5,14 @@ import {
   DialogContent,
   DialogActions,
   Button,
+  Typography,
   Stack,
   TextField,
 } from "@mui/material";
 import type {
   ColDef,
   ICellRendererParams,
+  PaginationChangedEvent,
   SelectionChangedEvent,
 } from "ag-grid-community";
 import { SearchOutlined } from "@mui/icons-material";
@@ -40,6 +42,7 @@ export function UserSearchDialog({
   const dataSource = useMemo(() => new UsersDataSource(), []);
   const isMultiple = selectionMode === "multiple";
   const [selectedCount, setSelectedCount] = useState(0);
+  const [displayedCount, setDisplayedCount] = useState(0);
   const [confirming, setConfirming] = useState(false);
   const [query, setQuery] = useState("");
 
@@ -98,6 +101,11 @@ export function UserSearchDialog({
               listener: (event: SelectionChangedEvent<UserDto>) =>
                 setSelectedCount(event.api.getSelectedRows().length ?? 0),
             },
+            {
+              type: "paginationChanged",
+              listener: (event: PaginationChangedEvent<UserDto>) =>
+                setDisplayedCount(event.api.getDisplayedRowCount() ?? 0),
+            },
           ]
         : undefined,
     [isMultiple]
@@ -105,6 +113,7 @@ export function UserSearchDialog({
 
   const handleClose = useCallback(() => {
     setSelectedCount(0);
+    setDisplayedCount(0);
     setConfirming(false);
     setQuery("");
     dataSource.setSearch("");
@@ -115,7 +124,20 @@ export function UserSearchDialog({
     dataSource.setSearch(query);
     gridRef.current?.refresh();
     setSelectedCount(0);
+    setDisplayedCount(0);
   }, [dataSource, query]);
+
+  const allDisplayedSelected = displayedCount > 0 && selectedCount === displayedCount;
+
+  const handleToggleSelectAll = useCallback(() => {
+    if (allDisplayedSelected) {
+      gridRef.current?.deselectAll();
+      setSelectedCount(0);
+      return;
+    }
+    gridRef.current?.selectAll();
+    setSelectedCount(gridRef.current?.selectedRows().length ?? 0);
+  }, [allDisplayedSelected]);
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
@@ -159,6 +181,18 @@ export function UserSearchDialog({
         </Stack>
       </DialogContent>
       <DialogActions>
+        {isMultiple ? (
+          <Button
+            variant="outlined"
+            onClick={handleToggleSelectAll}
+            disabled={displayedCount === 0 || confirming}
+          >
+            {allDisplayedSelected ? "전체 해제" : "전체 선택"}
+            <Typography component="span" sx={{ ml: 0.5 }}>
+              ({selectedCount})
+            </Typography>
+          </Button>
+        ) : null}
         <Button variant="outlined" onClick={handleClose}>닫기</Button>
         {isMultiple ? (
           <Button

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -36,20 +36,7 @@ export function UserSearchDialog({
     ];
 
     if (isMultiple) {
-      return [
-        {
-          colId: "select",
-          headerName: "",
-          width: 56,
-          maxWidth: 56,
-          checkboxSelection: true,
-          sortable: false,
-          filter: false,
-          resizable: false,
-          pinned: "left",
-        },
-        ...baseColumns,
-      ];
+      return baseColumns;
     }
 
     return [

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from "@mui/material";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
 import { PageableGridContent } from "@/react/components/ag-grid";
@@ -9,33 +9,120 @@ import type { UserDto } from "@/types/studio/user";
 interface Props {
   open: boolean;
   onClose: () => void;
-  onSelect: (user: UserDto) => void;
+  onSelect?: (user: UserDto) => void;
+  selectionMode?: "single" | "multiple";
+  onConfirmSelection?: (users: UserDto[]) => void;
+  confirmLabel?: string;
 }
 
-export function UserSearchDialog({ open, onClose, onSelect }: Props) {
+export function UserSearchDialog({
+  open,
+  onClose,
+  onSelect,
+  selectionMode = "single",
+  onConfirmSelection,
+  confirmLabel = "추가",
+}: Props) {
   const gridRef = useRef<PageableGridContentHandle<UserDto>>(null);
   const dataSource = useMemo(() => new UsersDataSource(), []);
+  const isMultiple = selectionMode === "multiple";
+  const [selectedCount, setSelectedCount] = useState(0);
 
-  const columnDefs = useMemo<ColDef<UserDto>[]>(() => [
-    { field: "username", headerName: "아이디", flex: 1 },
-    { field: "name", headerName: "이름", flex: 1 },
-    { field: "email", headerName: "이메일", flex: 1.5 },
-    {
-      colId: "select", headerName: "", flex: 0.5,
-      cellRenderer: (params: ICellRendererParams<UserDto>) => (
-        <Button size="small" onClick={() => { onSelect(params.data!); onClose(); }}>선택</Button>
-      ),
-    },
-  ], [onClose, onSelect]);
+  const columnDefs = useMemo<ColDef<UserDto>[]>(() => {
+    const baseColumns: ColDef<UserDto>[] = [
+      { field: "username", headerName: "아이디", flex: 1 },
+      { field: "name", headerName: "이름", flex: 1 },
+      { field: "email", headerName: "이메일", flex: 1.5 },
+    ];
+
+    if (isMultiple) {
+      return [
+        {
+          colId: "select",
+          headerName: "",
+          width: 56,
+          maxWidth: 56,
+          checkboxSelection: true,
+          sortable: false,
+          filter: false,
+          resizable: false,
+          pinned: "left",
+        },
+        ...baseColumns,
+      ];
+    }
+
+    return [
+      ...baseColumns,
+      {
+        colId: "select",
+        headerName: "",
+        flex: 0.5,
+        cellRenderer: (params: ICellRendererParams<UserDto>) => (
+          <Button
+            size="small"
+            onClick={() => {
+              onSelect?.(params.data!);
+              onClose();
+            }}
+          >
+            선택
+          </Button>
+        ),
+      },
+    ];
+  }, [isMultiple, onClose, onSelect]);
+
+  function handleConfirmSelection() {
+    const users = gridRef.current?.selectedRows() ?? [];
+    if (users.length === 0) {
+      return;
+    }
+    onConfirmSelection?.(users);
+    handleClose();
+  }
+
+  const gridEvents = useMemo(
+    () =>
+      isMultiple
+        ? [
+            {
+              type: "selectionChanged",
+              listener: () => setSelectedCount(gridRef.current?.selectedRows().length ?? 0),
+            },
+          ]
+        : undefined,
+    [isMultiple]
+  );
+
+  const handleClose = useCallback(() => {
+    setSelectedCount(0);
+    onClose();
+  }, [onClose]);
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
       <DialogTitle>사용자 검색</DialogTitle>
       <DialogContent sx={{ height: 400 }}>
-        <PageableGridContent<UserDto> ref={gridRef} datasource={dataSource} columns={columnDefs} />
+        <PageableGridContent<UserDto>
+          ref={gridRef}
+          datasource={dataSource}
+          columns={columnDefs}
+          events={gridEvents}
+          rowSelection={isMultiple ? "multiple" : undefined}
+        />
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>닫기</Button>
+        <Button variant="outlined" onClick={handleClose}>닫기</Button>
+        {isMultiple ? (
+          <Button
+            variant="outlined"
+            onClick={handleConfirmSelection}
+            disabled={selectedCount === 0}
+          >
+            {confirmLabel}
+          </Button>
+        ) : null}
       </DialogActions>
     </Dialog>
   );

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -194,12 +194,15 @@ export function UserSearchDialog({
     setAllSelected(false);
     setConfirming(false);
     setQuery("");
-    dataSource.setSearch("");
+    dataSource.applyFilter({});
     onClose();
   }, [dataSource, onClose]);
 
   const handleSearch = useCallback(() => {
-    dataSource.setSearch(query);
+    const trimmed = query.trim();
+    dataSource.applyFilter(
+      trimmed ? { q: trimmed, in: "username,name,email" } : {}
+    );
     gridRef.current?.refresh();
     setSelectedCount(0);
     setDisplayedCount(0);

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -43,6 +43,7 @@ export function UserSearchDialog({
   const isMultiple = selectionMode === "multiple";
   const [selectedCount, setSelectedCount] = useState(0);
   const [displayedCount, setDisplayedCount] = useState(0);
+  const [allSelected, setAllSelected] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const [query, setQuery] = useState("");
 
@@ -98,13 +99,23 @@ export function UserSearchDialog({
         ? [
             {
               type: "selectionChanged",
-              listener: (event: SelectionChangedEvent<UserDto>) =>
-                setSelectedCount(event.api.getSelectedRows().length ?? 0),
+              listener: (event: SelectionChangedEvent<UserDto>) => {
+                const nextSelectedCount = event.api.getSelectedRows().length ?? 0;
+                const nextDisplayedCount = event.api.getDisplayedRowCount() ?? 0;
+                setSelectedCount(nextSelectedCount);
+                setAllSelected(
+                  nextDisplayedCount > 0 && nextSelectedCount === nextDisplayedCount
+                );
+              },
             },
             {
               type: "paginationChanged",
-              listener: (event: PaginationChangedEvent<UserDto>) =>
-                setDisplayedCount(event.api.getDisplayedRowCount() ?? 0),
+              listener: (event: PaginationChangedEvent<UserDto>) => {
+                const nextDisplayedCount = event.api.getDisplayedRowCount() ?? 0;
+                const nextSelectedCount = event.api.getSelectedRows().length ?? 0;
+                setDisplayedCount(nextDisplayedCount);
+                setAllSelected(nextDisplayedCount > 0 && nextSelectedCount === nextDisplayedCount);
+              },
             },
           ]
         : undefined,
@@ -114,6 +125,7 @@ export function UserSearchDialog({
   const handleClose = useCallback(() => {
     setSelectedCount(0);
     setDisplayedCount(0);
+    setAllSelected(false);
     setConfirming(false);
     setQuery("");
     dataSource.setSearch("");
@@ -125,19 +137,20 @@ export function UserSearchDialog({
     gridRef.current?.refresh();
     setSelectedCount(0);
     setDisplayedCount(0);
+    setAllSelected(false);
   }, [dataSource, query]);
 
-  const allDisplayedSelected = displayedCount > 0 && selectedCount === displayedCount;
-
   const handleToggleSelectAll = useCallback(() => {
-    if (allDisplayedSelected) {
+    if (allSelected) {
       gridRef.current?.deselectAll();
       setSelectedCount(0);
+      setAllSelected(false);
       return;
     }
     gridRef.current?.selectAll();
     setSelectedCount(gridRef.current?.selectedRows().length ?? 0);
-  }, [allDisplayedSelected]);
+    setAllSelected(true);
+  }, [allSelected]);
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
@@ -187,7 +200,7 @@ export function UserSearchDialog({
             onClick={handleToggleSelectAll}
             disabled={displayedCount === 0 || confirming}
           >
-            {allDisplayedSelected ? "전체 해제" : "전체 선택"}
+            {allSelected ? "전체 해제" : "전체 선택"}
             <Typography component="span" sx={{ ml: 0.5 }}>
               ({selectedCount})
             </Typography>

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from "@mui/material";
-import type { ColDef, ICellRendererParams } from "ag-grid-community";
+import type {
+  ColDef,
+  ICellRendererParams,
+  SelectionChangedEvent,
+} from "ag-grid-community";
 import { PageableGridContent } from "@/react/components/ag-grid";
 import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
 import { UsersDataSource } from "@/react/pages/admin/datasource";
@@ -75,7 +79,8 @@ export function UserSearchDialog({
         ? [
             {
               type: "selectionChanged",
-              listener: () => setSelectedCount(gridRef.current?.selectedRows().length ?? 0),
+              listener: (event: SelectionChangedEvent<UserDto>) =>
+                setSelectedCount(event.api.getSelectedRows().length ?? 0),
             },
           ]
         : undefined,

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
+  Avatar,
+  Chip,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -20,6 +22,8 @@ import { PageableGridContent } from "@/react/components/ag-grid";
 import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
 import { UsersDataSource } from "@/react/pages/admin/datasource";
 import type { UserDto } from "@/types/studio/user";
+import { API_BASE_URL } from "@/config/backend";
+import NO_AVATAR from "@/assets/images/users/no-avatar.png";
 
 interface Props {
   open: boolean;
@@ -49,9 +53,71 @@ export function UserSearchDialog({
 
   const columnDefs = useMemo<ColDef<UserDto>[]>(() => {
     const baseColumns: ColDef<UserDto>[] = [
-      { field: "username", headerName: "아이디", flex: 1, filter: false },
+      {
+        field: "username",
+        headerName: "아이디",
+        flex: 1,
+        filter: false,
+        cellRenderer: (params: ICellRendererParams<UserDto>) => (
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Avatar
+              alt={String(params.value ?? "")}
+              src={
+                params.value
+                  ? `${API_BASE_URL}/api/profile/${encodeURIComponent(String(params.value))}/avatar`
+                  : NO_AVATAR
+              }
+              imgProps={{
+                onError: (event) => {
+                  event.currentTarget.src = NO_AVATAR;
+                },
+              }}
+              sx={{ width: 24, height: 24, bgcolor: "grey.200" }}
+            />
+            <span>{String(params.value ?? "")}</span>
+          </Stack>
+        ),
+      },
       { field: "name", headerName: "이름", flex: 1, filter: false },
       { field: "email", headerName: "이메일", flex: 1.5, filter: false },
+      {
+        field: "enabled",
+        headerName: "활성화",
+        width: 96,
+        maxWidth: 96,
+        filter: false,
+        sortable: true,
+        cellRenderer: (params: ICellRendererParams<UserDto>) => (
+          <Chip
+            size="small"
+            label={params.value ? "활성" : "비활성"}
+            variant={params.value ? "filled" : "outlined"}
+            sx={{
+              height: 22,
+              fontSize: 11,
+              ...(params.value
+                ? {
+                    bgcolor: "#2563eb",
+                    color: "#ffffff",
+                    borderColor: "#1d4ed8",
+                  }
+                : {}),
+            }}
+          />
+        ),
+        cellStyle: { textAlign: "center" },
+      },
+      {
+        colId: "status",
+        headerName: "상태",
+        width: 100,
+        maxWidth: 100,
+        filter: false,
+        sortable: true,
+        valueGetter: (params) =>
+          (params.data as UserDto & { status?: string | null } | undefined)?.status ?? "",
+        cellStyle: { textAlign: "center" },
+      },
     ];
 
     if (isMultiple) {

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -47,7 +47,6 @@ export function UserSearchDialog({
   const isMultiple = selectionMode === "multiple";
   const [selectedCount, setSelectedCount] = useState(0);
   const [displayedCount, setDisplayedCount] = useState(0);
-  const [allSelected, setAllSelected] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const [query, setQuery] = useState("");
 
@@ -167,20 +166,14 @@ export function UserSearchDialog({
               type: "selectionChanged",
               listener: (event: SelectionChangedEvent<UserDto>) => {
                 const nextSelectedCount = event.api.getSelectedRows().length ?? 0;
-                const nextDisplayedCount = event.api.getDisplayedRowCount() ?? 0;
                 setSelectedCount(nextSelectedCount);
-                setAllSelected(
-                  nextDisplayedCount > 0 && nextSelectedCount === nextDisplayedCount
-                );
               },
             },
             {
               type: "paginationChanged",
               listener: (event: PaginationChangedEvent<UserDto>) => {
                 const nextDisplayedCount = event.api.getDisplayedRowCount() ?? 0;
-                const nextSelectedCount = event.api.getSelectedRows().length ?? 0;
                 setDisplayedCount(nextDisplayedCount);
-                setAllSelected(nextDisplayedCount > 0 && nextSelectedCount === nextDisplayedCount);
               },
             },
           ]
@@ -191,7 +184,6 @@ export function UserSearchDialog({
   const handleClose = useCallback(() => {
     setSelectedCount(0);
     setDisplayedCount(0);
-    setAllSelected(false);
     setConfirming(false);
     setQuery("");
     dataSource.applyFilter({});
@@ -206,20 +198,19 @@ export function UserSearchDialog({
     gridRef.current?.refresh();
     setSelectedCount(0);
     setDisplayedCount(0);
-    setAllSelected(false);
   }, [dataSource, query]);
 
+  const hasSelection = selectedCount > 0;
+
   const handleToggleSelectAll = useCallback(() => {
-    if (allSelected) {
+    if (hasSelection) {
       gridRef.current?.deselectAll();
       setSelectedCount(0);
-      setAllSelected(false);
       return;
     }
     gridRef.current?.selectAll();
     setSelectedCount(gridRef.current?.selectedRows().length ?? 0);
-    setAllSelected(true);
-  }, [allSelected]);
+  }, [hasSelection]);
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
@@ -269,7 +260,7 @@ export function UserSearchDialog({
             onClick={handleToggleSelectAll}
             disabled={displayedCount === 0 || confirming}
           >
-            {allSelected ? "전체 해제" : "전체 선택"}
+            {hasSelection ? "전체 해제" : "전체 선택"}
             <Typography component="span" sx={{ ml: 0.5 }}>
               ({selectedCount})
             </Typography>

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -1,10 +1,19 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from "@mui/material";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Stack,
+  TextField,
+} from "@mui/material";
 import type {
   ColDef,
   ICellRendererParams,
   SelectionChangedEvent,
 } from "ag-grid-community";
+import { SearchOutlined } from "@mui/icons-material";
 import { PageableGridContent } from "@/react/components/ag-grid";
 import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
 import { UsersDataSource } from "@/react/pages/admin/datasource";
@@ -29,9 +38,10 @@ export function UserSearchDialog({
 }: Props) {
   const gridRef = useRef<PageableGridContentHandle<UserDto>>(null);
   const dataSource = useMemo(() => new UsersDataSource(), []);
-const isMultiple = selectionMode === "multiple";
+  const isMultiple = selectionMode === "multiple";
   const [selectedCount, setSelectedCount] = useState(0);
   const [confirming, setConfirming] = useState(false);
+  const [query, setQuery] = useState("");
 
   const columnDefs = useMemo<ColDef<UserDto>[]>(() => {
     const baseColumns: ColDef<UserDto>[] = [
@@ -96,21 +106,57 @@ const isMultiple = selectionMode === "multiple";
   const handleClose = useCallback(() => {
     setSelectedCount(0);
     setConfirming(false);
+    setQuery("");
+    dataSource.setSearch("");
     onClose();
-  }, [onClose]);
+  }, [dataSource, onClose]);
+
+  const handleSearch = useCallback(() => {
+    dataSource.setSearch(query);
+    gridRef.current?.refresh();
+    setSelectedCount(0);
+  }, [dataSource, query]);
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
       <DialogTitle>사용자 검색</DialogTitle>
       <DialogContent sx={{ height: 420 }}>
-        <PageableGridContent<UserDto>
-          ref={gridRef}
-          datasource={dataSource}
-          columns={columnDefs}
-          events={gridEvents}
-          height={340}
-          rowSelection={isMultiple ? "multiple" : undefined}
-        />
+        <Stack spacing={1} sx={{ mt: 1 }}>
+          <TextField
+            label="이름, 아이디, 이메일 검색"
+            size="small"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                handleSearch();
+              }
+            }}
+            fullWidth
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <Button
+                    size="small"
+                    variant="text"
+                    startIcon={<SearchOutlined />}
+                    onClick={handleSearch}
+                  >
+                    검색
+                  </Button>
+                ),
+              },
+            }}
+          />
+          <PageableGridContent<UserDto>
+            ref={gridRef}
+            datasource={dataSource}
+            columns={columnDefs}
+            events={gridEvents}
+            height={320}
+            rowSelection={isMultiple ? "multiple" : undefined}
+          />
+        </Stack>
       </DialogContent>
       <DialogActions>
         <Button variant="outlined" onClick={handleClose}>닫기</Button>

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -53,6 +53,7 @@ export function UserSearchDialog({
   const [displayedCount, setDisplayedCount] = useState(0);
   const [confirming, setConfirming] = useState(false);
   const [query, setQuery] = useState("");
+  const [hasSearched, setHasSearched] = useState(false);
 
   const columnDefs = useMemo<ColDef<UserDto>[]>(() => {
     const baseColumns: ColDef<UserDto>[] = [
@@ -201,18 +202,25 @@ export function UserSearchDialog({
     setDisplayedCount(0);
     setConfirming(false);
     setQuery("");
+    setHasSearched(false);
     dataSource.applyFilter({});
     onClose();
   }, [dataSource, onClose]);
 
   const handleSearch = useCallback(() => {
     const trimmed = query.trim();
-    dataSource.applyFilter(
-      trimmed ? { q: trimmed, in: "username,name,email" } : {}
-    );
+    if (!trimmed) {
+      dataSource.applyFilter({});
+      setHasSearched(false);
+      setSelectedCount(0);
+      setDisplayedCount(0);
+      return;
+    }
+    dataSource.applyFilter({ q: trimmed, in: "username,name,email" });
     gridRef.current?.refresh();
     setSelectedCount(0);
     setDisplayedCount(0);
+    setHasSearched(true);
   }, [dataSource, query]);
 
   const hasSelection = selectedCount > 0;
@@ -264,13 +272,29 @@ export function UserSearchDialog({
               },
             }}
           />
-          <PageableGridContent<UserDto>
-            ref={gridRef}
-            datasource={dataSource}
-            columns={columnDefs}
-            events={gridEvents}
-            rowSelection={isMultiple ? "multiple" : undefined}
-          />
+          {hasSearched ? (
+            <PageableGridContent<UserDto>
+              ref={gridRef}
+              datasource={dataSource}
+              columns={columnDefs}
+              events={gridEvents}
+              rowSelection={isMultiple ? "multiple" : undefined}
+            />
+          ) : (
+            <Stack
+              alignItems="center"
+              justifyContent="center"
+              sx={{
+                flex: 1,
+                minHeight: 0,
+                color: "text.secondary",
+              }}
+            >
+              <Typography variant="body2">
+                검색어를 입력한 뒤 검색을 실행하면 결과가 표시됩니다.
+              </Typography>
+            </Stack>
+          )}
         </Stack>
       </DialogContent>
       <DialogActions>
@@ -278,7 +302,7 @@ export function UserSearchDialog({
           <Button
             variant="outlined"
             onClick={handleToggleSelectAll}
-            disabled={displayedCount === 0 || confirming}
+            disabled={!hasSearched || displayedCount === 0 || confirming}
           >
             {hasSelection ? "전체 해제" : "전체 선택"}
             <Typography component="span" sx={{ ml: 0.5 }}>

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -15,7 +15,7 @@ interface Props {
   onClose: () => void;
   onSelect?: (user: UserDto) => void;
   selectionMode?: "single" | "multiple";
-  onConfirmSelection?: (users: UserDto[]) => void;
+  onConfirmSelection?: (users: UserDto[]) => void | Promise<void>;
   confirmLabel?: string;
 }
 
@@ -31,6 +31,7 @@ export function UserSearchDialog({
   const dataSource = useMemo(() => new UsersDataSource(), []);
   const isMultiple = selectionMode === "multiple";
   const [selectedCount, setSelectedCount] = useState(0);
+  const [confirming, setConfirming] = useState(false);
 
   const columnDefs = useMemo<ColDef<UserDto>[]>(() => {
     const baseColumns: ColDef<UserDto>[] = [
@@ -64,13 +65,18 @@ export function UserSearchDialog({
     ];
   }, [isMultiple, onClose, onSelect]);
 
-  function handleConfirmSelection() {
+  async function handleConfirmSelection() {
     const users = gridRef.current?.selectedRows() ?? [];
     if (users.length === 0) {
       return;
     }
-    onConfirmSelection?.(users);
-    handleClose();
+    setConfirming(true);
+    try {
+      await onConfirmSelection?.(users);
+      handleClose();
+    } finally {
+      setConfirming(false);
+    }
   }
 
   const gridEvents = useMemo(
@@ -89,6 +95,7 @@ export function UserSearchDialog({
 
   const handleClose = useCallback(() => {
     setSelectedCount(0);
+    setConfirming(false);
     onClose();
   }, [onClose]);
 
@@ -109,10 +116,10 @@ export function UserSearchDialog({
         {isMultiple ? (
           <Button
             variant="outlined"
-            onClick={handleConfirmSelection}
-            disabled={selectedCount === 0}
+            onClick={() => void handleConfirmSelection()}
+            disabled={selectedCount === 0 || confirming}
           >
-            {confirmLabel}
+            {confirming ? "추가 중..." : confirmLabel}
           </Button>
         ) : null}
       </DialogActions>

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -45,9 +45,9 @@ export function UserSearchDialog({
 
   const columnDefs = useMemo<ColDef<UserDto>[]>(() => {
     const baseColumns: ColDef<UserDto>[] = [
-      { field: "username", headerName: "아이디", flex: 1 },
-      { field: "name", headerName: "이름", flex: 1 },
-      { field: "email", headerName: "이메일", flex: 1.5 },
+      { field: "username", headerName: "아이디", flex: 1, filter: false },
+      { field: "name", headerName: "이름", flex: 1, filter: false },
+      { field: "email", headerName: "이메일", flex: 1.5, filter: false },
     ];
 
     if (isMultiple) {

--- a/src/react/pages/admin/groups/GroupMembershipDialog.tsx
+++ b/src/react/pages/admin/groups/GroupMembershipDialog.tsx
@@ -1,9 +1,19 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
-  Dialog, DialogTitle, DialogContent, DialogActions,
-  Button, List, ListItem, ListItemText, IconButton, Stack, CircularProgress, Typography,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
 } from "@mui/material";
-import { DeleteOutlined } from "@mui/icons-material";
+import { DeleteOutlined, GroupAddOutlined } from "@mui/icons-material";
 import { useToast } from "@/react/feedback";
 import { reactGroupsApi, type GroupMemberDto } from "./api";
 import { UserSearchDialog } from "@/react/pages/admin/UserSearchDialog";
@@ -20,7 +30,10 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
   const toast = useToast();
   const [members, setMembers] = useState<GroupMemberDto[]>([]);
   const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [userSearchOpen, setUserSearchOpen] = useState(false);
+
+  const memberIds = useMemo(() => new Set(members.map((member) => member.userId)), [members]);
 
   async function loadMembers() {
     setLoading(true);
@@ -34,15 +47,41 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
     }
   }
 
-  useEffect(() => { if (open) loadMembers(); }, [open, groupId]);
+  useEffect(() => {
+    if (open) {
+      void loadMembers();
+    }
+  }, [open, groupId]);
 
-  async function handleAdd(user: UserDto) {
+  async function handleAdd(selectedUsers: UserDto[]) {
+    const usersToAdd = selectedUsers.filter((user) => !memberIds.has(user.userId));
+
+    if (usersToAdd.length === 0) {
+      toast.info("추가할 멤버가 없습니다.");
+      return;
+    }
+
+    setSaving(true);
     try {
-      await reactGroupsApi.addMember(groupId, user.userId);
-      toast.success("멤버가 추가되었습니다.");
-      loadMembers();
-    } catch {
-      toast.error("멤버 추가에 실패했습니다.");
+      const results = await Promise.allSettled(
+        usersToAdd.map((user) => reactGroupsApi.addMember(groupId, user.userId))
+      );
+      const successCount = results.filter((result) => result.status === "fulfilled").length;
+      const failureCount = results.length - successCount;
+
+      if (successCount > 0) {
+        await loadMembers();
+      }
+
+      if (successCount > 0 && failureCount > 0) {
+        toast.warning(`${successCount}명 추가, ${failureCount}명 실패`);
+      } else if (successCount > 0) {
+        toast.success(`${successCount}명의 멤버가 추가되었습니다.`);
+      } else {
+        toast.error("멤버 추가에 실패했습니다.");
+      }
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -50,7 +89,7 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
     try {
       await reactGroupsApi.removeMember(groupId, userId);
       toast.success("멤버가 제거되었습니다.");
-      loadMembers();
+      await loadMembers();
     } catch {
       toast.error("멤버 제거에 실패했습니다.");
     }
@@ -58,30 +97,65 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="sm" fullWidth>
         <DialogTitle>멤버 관리 — {groupName}</DialogTitle>
         <DialogContent>
           <Stack spacing={1} sx={{ mt: 1 }}>
-            <Button variant="outlined" size="small" onClick={() => setUserSearchOpen(true)} sx={{ alignSelf: "flex-start" }}>멤버 추가</Button>
-            {loading ? <CircularProgress size={24} /> : (
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<GroupAddOutlined />}
+              onClick={() => setUserSearchOpen(true)}
+              sx={{ alignSelf: "flex-start" }}
+            >
+              멤버 추가
+            </Button>
+            {loading ? (
+              <CircularProgress size={24} />
+            ) : (
               <List dense>
-                {members.length === 0 && <Typography color="text.secondary" variant="body2">멤버 없음</Typography>}
-                {members.map(m => (
-                  <ListItem key={m.userId} secondaryAction={
-                    <IconButton size="small" color="error" onClick={() => handleRemove(m.userId)}><DeleteOutlined fontSize="small" /></IconButton>
-                  }>
-                    <ListItemText primary={m.name} secondary={`@${m.username}`} />
-                  </ListItem>
-                ))}
+                {members.length === 0 ? (
+                  <Typography color="text.secondary" variant="body2">
+                    멤버 없음
+                  </Typography>
+                ) : (
+                  members.map((member) => (
+                    <ListItem
+                      key={member.userId}
+                      secondaryAction={
+                        <IconButton
+                          size="small"
+                          color="error"
+                          onClick={() => void handleRemove(member.userId)}
+                        >
+                          <DeleteOutlined fontSize="small" />
+                        </IconButton>
+                      }
+                    >
+                      <ListItemText
+                        primary={member.name}
+                        secondary={`@${member.username}`}
+                      />
+                    </ListItem>
+                  ))
+                )}
               </List>
             )}
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose}>닫기</Button>
+          <Button variant="outlined" onClick={onClose} disabled={saving}>
+            닫기
+          </Button>
         </DialogActions>
       </Dialog>
-      <UserSearchDialog open={userSearchOpen} onClose={() => setUserSearchOpen(false)} onSelect={handleAdd} />
+      <UserSearchDialog
+        open={userSearchOpen}
+        onClose={() => setUserSearchOpen(false)}
+        selectionMode="multiple"
+        confirmLabel={saving ? "추가 중..." : "추가"}
+        onConfirmSelection={(users) => void handleAdd(users)}
+      />
     </>
   );
 }

--- a/src/react/pages/admin/groups/GroupMembershipDialog.tsx
+++ b/src/react/pages/admin/groups/GroupMembershipDialog.tsx
@@ -63,23 +63,14 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
 
     setSaving(true);
     try {
-      const results = await Promise.allSettled(
-        usersToAdd.map((user) => reactGroupsApi.addMember(groupId, user.userId))
+      await reactGroupsApi.addMembers(
+        groupId,
+        usersToAdd.map((user) => user.userId)
       );
-      const successCount = results.filter((result) => result.status === "fulfilled").length;
-      const failureCount = results.length - successCount;
-
-      if (successCount > 0) {
-        await loadMembers();
-      }
-
-      if (successCount > 0 && failureCount > 0) {
-        toast.warning(`${successCount}명 추가, ${failureCount}명 실패`);
-      } else if (successCount > 0) {
-        toast.success(`${successCount}명의 멤버가 추가되었습니다.`);
-      } else {
-        toast.error("멤버 추가에 실패했습니다.");
-      }
+      await loadMembers();
+      toast.success(`${usersToAdd.length}명의 멤버가 추가되었습니다.`);
+    } catch {
+      toast.error("멤버 추가에 실패했습니다.");
     } finally {
       setSaving(false);
     }

--- a/src/react/pages/admin/groups/GroupRolesDialog.tsx
+++ b/src/react/pages/admin/groups/GroupRolesDialog.tsx
@@ -1,11 +1,27 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
-  Dialog, DialogTitle, DialogContent, DialogActions,
-  Button, List, ListItem, ListItemText, IconButton, Stack, TextField, CircularProgress, Typography, Divider,
+  Alert,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  List,
+  ListItemButton,
+  ListItemText,
+  Skeleton,
+  Stack,
+  TextField,
+  Typography,
 } from "@mui/material";
-import { DeleteOutlined, AddOutlined } from "@mui/icons-material";
-import { useToast } from "@/react/feedback";
+import { ArrowBackOutlined, ArrowForwardOutlined } from "@mui/icons-material";
+import { useConfirm, useToast } from "@/react/feedback";
 import { reactGroupsApi } from "./api";
+import type { RoleDto } from "@/react/pages/admin/datasource";
 
 interface Props {
   open: boolean;
@@ -14,17 +30,64 @@ interface Props {
   groupName: string;
 }
 
+const TRANSFER_SECTION_MIN_HEIGHT = 300;
+const ROLE_LIST_MAX_HEIGHT = 220;
+
+function byName(left: { name: string }, right: { name: string }) {
+  return left.name.localeCompare(right.name);
+}
+
+function RolesListSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <Stack spacing={1}>
+      <Skeleton variant="rounded" height={40} />
+      <Divider />
+      <Stack spacing={0.75}>
+        {Array.from({ length: rows }).map((_, index) => (
+          <Skeleton key={index} variant="rounded" height={48} />
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+type GrantedRole = { roleId: number; name: string; description?: string | null };
+
 export function GroupRolesDialog({ open, onClose, groupId, groupName }: Props) {
   const toast = useToast();
-  const [roles, setRoles] = useState<{ roleId: number; name: string }[]>([]);
+  const confirm = useConfirm();
   const [loading, setLoading] = useState(false);
-  const [roleIdInput, setRoleIdInput] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [allRoles, setAllRoles] = useState<RoleDto[]>([]);
+  const [grantedRoles, setGrantedRoles] = useState<GrantedRole[]>([]);
+  const [initialGrantedRoles, setInitialGrantedRoles] = useState<GrantedRole[]>([]);
+  const [selectedLeft, setSelectedLeft] = useState<number[]>([]);
+  const [selectedRight, setSelectedRight] = useState<number[]>([]);
+  const [searchLeft, setSearchLeft] = useState("");
+  const [searchRight, setSearchRight] = useState("");
 
-  async function loadRoles() {
+  async function loadData() {
     setLoading(true);
     try {
-      const data = await reactGroupsApi.getGroupRoles(groupId);
-      setRoles(Array.isArray(data) ? data : []);
+      const [rolesResponse, groupRoles] = await Promise.all([
+        reactGroupsApi.getAvailableRoles(),
+        reactGroupsApi.getGroupRoles(groupId),
+      ]);
+      const roles = (rolesResponse.content ?? []).slice().sort(byName);
+      const currentRoles = (Array.isArray(groupRoles) ? groupRoles : [])
+        .map((role) => ({
+          roleId: role.roleId,
+          name: role.name,
+          description: roles.find((candidate) => candidate.roleId === role.roleId)?.description,
+        }))
+        .sort(byName);
+      setAllRoles(roles);
+      setGrantedRoles(currentRoles);
+      setInitialGrantedRoles(currentRoles);
+      setSelectedLeft([]);
+      setSelectedRight([]);
+      setSearchLeft("");
+      setSearchRight("");
     } catch {
       toast.error("역할 목록 로딩 실패");
     } finally {
@@ -32,58 +95,268 @@ export function GroupRolesDialog({ open, onClose, groupId, groupName }: Props) {
     }
   }
 
-  useEffect(() => { if (open) { setRoleIdInput(""); loadRoles(); } }, [open, groupId]);
-
-  async function handleAdd() {
-    const roleId = parseInt(roleIdInput, 10);
-    if (!roleId) return;
-    try {
-      await reactGroupsApi.addGroupRole(groupId, roleId);
-      toast.success("역할이 부여되었습니다.");
-      setRoleIdInput(""); loadRoles();
-    } catch {
-      toast.error("역할 부여에 실패했습니다.");
+  useEffect(() => {
+    if (open) {
+      void loadData();
     }
+  }, [open, groupId]);
+
+  const grantedRoleIds = useMemo(
+    () => new Set(grantedRoles.map((role) => role.roleId)),
+    [grantedRoles]
+  );
+
+  const availableRoles = useMemo(
+    () =>
+      allRoles
+        .filter((role) => !grantedRoleIds.has(role.roleId))
+        .filter((role) => {
+          const keyword = searchLeft.trim().toLowerCase();
+          if (!keyword) return true;
+          return (
+            role.name.toLowerCase().includes(keyword) ||
+            String(role.roleId).includes(keyword) ||
+            (role.description ?? "").toLowerCase().includes(keyword)
+          );
+        }),
+    [allRoles, grantedRoleIds, searchLeft]
+  );
+
+  const filteredGrantedRoles = useMemo(
+    () =>
+      grantedRoles.filter((role) => {
+        const keyword = searchRight.trim().toLowerCase();
+        if (!keyword) return true;
+        return (
+          role.name.toLowerCase().includes(keyword) ||
+          String(role.roleId).includes(keyword) ||
+          (role.description ?? "").toLowerCase().includes(keyword)
+        );
+      }),
+    [grantedRoles, searchRight]
+  );
+
+  function toggleSelected(
+    selected: number[],
+    setter: (value: number[]) => void,
+    roleId: number
+  ) {
+    setter(
+      selected.includes(roleId)
+        ? selected.filter((value) => value !== roleId)
+        : [...selected, roleId]
+    );
   }
 
-  async function handleRemove(roleId: number) {
+  function moveToGranted() {
+    const nextRoles = allRoles
+      .filter((role) => selectedLeft.includes(role.roleId))
+      .map((role) => ({
+        roleId: role.roleId,
+        name: role.name,
+        description: role.description,
+      }));
+
+    setGrantedRoles((current) =>
+      [...current, ...nextRoles]
+        .filter(
+          (role, index, roles) =>
+            roles.findIndex((candidate) => candidate.roleId === role.roleId) === index
+        )
+        .sort(byName)
+    );
+    setSelectedLeft([]);
+  }
+
+  function moveToAvailable() {
+    setGrantedRoles((current) =>
+      current.filter((role) => !selectedRight.includes(role.roleId))
+    );
+    setSelectedRight([]);
+  }
+
+  async function handleSave() {
+    const initialIds = new Set(initialGrantedRoles.map((role) => role.roleId));
+    const currentIds = new Set(grantedRoles.map((role) => role.roleId));
+    const toAdd = grantedRoles.filter((role) => !initialIds.has(role.roleId));
+    const toRemove = initialGrantedRoles.filter((role) => !currentIds.has(role.roleId));
+
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      toast.info("변경된 역할이 없습니다.");
+      onClose();
+      return;
+    }
+
+    const ok = await confirm({
+      title: "역할 변경 저장",
+      message: `역할 ${toAdd.length}개 추가, ${toRemove.length}개 제거를 저장하시겠습니까?`,
+      okText: "저장",
+      cancelText: "취소",
+    });
+    if (!ok) return;
+
+    setSaving(true);
     try {
-      await reactGroupsApi.removeGroupRole(groupId, roleId);
-      toast.success("역할이 제거되었습니다.");
-      loadRoles();
+      await Promise.all([
+        ...toAdd.map((role) => reactGroupsApi.addGroupRole(groupId, role.roleId)),
+        ...toRemove.map((role) => reactGroupsApi.removeGroupRole(groupId, role.roleId)),
+      ]);
+      toast.success("그룹 역할이 저장되었습니다.");
+      onClose();
     } catch {
-      toast.error("역할 제거에 실패했습니다.");
+      toast.error("그룹 역할 저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
     }
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth>
       <DialogTitle>역할 관리 — {groupName}</DialogTitle>
       <DialogContent>
-        <Stack spacing={1} sx={{ mt: 1 }}>
-          <Stack direction="row" spacing={1}>
-            <TextField label="역할 ID" size="small" value={roleIdInput}
-              onChange={e => setRoleIdInput(e.target.value)}
-              onKeyDown={e => e.key === "Enter" && handleAdd()} />
-            <Button startIcon={<AddOutlined />} variant="outlined" onClick={handleAdd} disabled={!roleIdInput}>추가</Button>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Alert severity="info">
+            그룹에 직접 부여할 역할만 추가하거나 제거할 수 있습니다. 변경 내용은 저장 시점에 반영됩니다.
+          </Alert>
+
+          <Stack direction={{ xs: "column", md: "row" }} spacing={2} alignItems="stretch">
+            <Card variant="outlined" sx={{ flex: 1, minWidth: 0 }}>
+              <CardContent>
+                <Stack spacing={1} sx={{ minHeight: TRANSFER_SECTION_MIN_HEIGHT }}>
+                  <Typography variant="subtitle2">부여 가능한 역할</Typography>
+                  {loading ? (
+                    <RolesListSkeleton />
+                  ) : availableRoles.length === 0 ? (
+                    <>
+                      <TextField
+                        label="역할 검색"
+                        size="small"
+                        value={searchLeft}
+                        onChange={(event) => setSearchLeft(event.target.value)}
+                        fullWidth
+                      />
+                      <Divider />
+                      <Typography color="text.secondary" variant="body2">
+                        선택 가능한 역할 없음
+                      </Typography>
+                    </>
+                  ) : (
+                    <>
+                      <TextField
+                        label="역할 검색"
+                        size="small"
+                        value={searchLeft}
+                        onChange={(event) => setSearchLeft(event.target.value)}
+                        fullWidth
+                      />
+                      <Divider />
+                      <List dense sx={{ maxHeight: ROLE_LIST_MAX_HEIGHT, overflowY: "auto" }}>
+                        {availableRoles.map((role) => (
+                          <ListItemButton
+                            key={role.roleId}
+                            selected={selectedLeft.includes(role.roleId)}
+                            onClick={() =>
+                              toggleSelected(selectedLeft, setSelectedLeft, role.roleId)
+                            }
+                          >
+                            <ListItemText
+                              primary={role.name}
+                              secondary={`ID: ${role.roleId}${role.description ? ` · ${role.description}` : ""}`}
+                            />
+                          </ListItemButton>
+                        ))}
+                      </List>
+                    </>
+                  )}
+                </Stack>
+              </CardContent>
+            </Card>
+
+            <Stack
+              direction={{ xs: "row", md: "column" }}
+              spacing={1}
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Button
+                variant="outlined"
+                startIcon={<ArrowForwardOutlined />}
+                onClick={moveToGranted}
+                disabled={loading || selectedLeft.length === 0}
+              >
+                추가
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<ArrowBackOutlined />}
+                onClick={moveToAvailable}
+                disabled={loading || selectedRight.length === 0}
+              >
+                제거
+              </Button>
+            </Stack>
+
+            <Card variant="outlined" sx={{ flex: 1, minWidth: 0 }}>
+              <CardContent>
+                <Stack spacing={1} sx={{ minHeight: TRANSFER_SECTION_MIN_HEIGHT }}>
+                  <Typography variant="subtitle2">그룹에 직접 부여한 역할</Typography>
+                  {loading ? (
+                    <RolesListSkeleton />
+                  ) : filteredGrantedRoles.length === 0 ? (
+                    <>
+                      <TextField
+                        label="역할 검색"
+                        size="small"
+                        value={searchRight}
+                        onChange={(event) => setSearchRight(event.target.value)}
+                        fullWidth
+                      />
+                      <Divider />
+                      <Typography color="text.secondary" variant="body2">
+                        직접 부여 역할 없음
+                      </Typography>
+                    </>
+                  ) : (
+                    <>
+                      <TextField
+                        label="역할 검색"
+                        size="small"
+                        value={searchRight}
+                        onChange={(event) => setSearchRight(event.target.value)}
+                        fullWidth
+                      />
+                      <Divider />
+                      <List dense sx={{ maxHeight: ROLE_LIST_MAX_HEIGHT, overflowY: "auto" }}>
+                        {filteredGrantedRoles.map((role) => (
+                          <ListItemButton
+                            key={role.roleId}
+                            selected={selectedRight.includes(role.roleId)}
+                            onClick={() =>
+                              toggleSelected(selectedRight, setSelectedRight, role.roleId)
+                            }
+                          >
+                            <ListItemText
+                              primary={role.name}
+                              secondary={`ID: ${role.roleId}${role.description ? ` · ${role.description}` : ""}`}
+                            />
+                          </ListItemButton>
+                        ))}
+                      </List>
+                    </>
+                  )}
+                </Stack>
+              </CardContent>
+            </Card>
           </Stack>
-          <Divider />
-          {loading ? <CircularProgress size={24} /> : (
-            <List dense>
-              {roles.length === 0 && <Typography color="text.secondary" variant="body2">부여된 역할 없음</Typography>}
-              {roles.map(r => (
-                <ListItem key={r.roleId} secondaryAction={
-                  <IconButton size="small" color="error" onClick={() => handleRemove(r.roleId)}><DeleteOutlined fontSize="small" /></IconButton>
-                }>
-                  <ListItemText primary={r.name} secondary={`ID: ${r.roleId}`} />
-                </ListItem>
-              ))}
-            </List>
-          )}
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>닫기</Button>
+        <Button variant="outlined" onClick={onClose} disabled={saving}>
+          취소
+        </Button>
+        <Button variant="outlined" onClick={() => void handleSave()} disabled={saving}>
+          {saving ? <CircularProgress size={20} /> : "저장"}
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/react/pages/admin/groups/GroupRolesDialog.tsx
+++ b/src/react/pages/admin/groups/GroupRolesDialog.tsx
@@ -176,12 +176,13 @@ export function GroupRolesDialog({ open, onClose, groupId, groupName }: Props) {
   }
 
   async function handleSave() {
-    const initialIds = new Set(initialGrantedRoles.map((role) => role.roleId));
-    const currentIds = new Set(grantedRoles.map((role) => role.roleId));
-    const toAdd = grantedRoles.filter((role) => !initialIds.has(role.roleId));
-    const toRemove = initialGrantedRoles.filter((role) => !currentIds.has(role.roleId));
+    const initialIds = initialGrantedRoles.map((role) => role.roleId).sort((a, b) => a - b);
+    const currentIds = grantedRoles.map((role) => role.roleId).sort((a, b) => a - b);
+    const changed =
+      initialIds.length !== currentIds.length ||
+      initialIds.some((roleId, index) => roleId !== currentIds[index]);
 
-    if (toAdd.length === 0 && toRemove.length === 0) {
+    if (!changed) {
       toast.info("변경된 역할이 없습니다.");
       onClose();
       return;
@@ -189,7 +190,7 @@ export function GroupRolesDialog({ open, onClose, groupId, groupName }: Props) {
 
     const ok = await confirm({
       title: "역할 변경 저장",
-      message: `역할 ${toAdd.length}개 추가, ${toRemove.length}개 제거를 저장하시겠습니까?`,
+      message: `그룹 역할을 ${currentIds.length}개로 저장하시겠습니까? 기존 역할 구성은 전체 교체됩니다.`,
       okText: "저장",
       cancelText: "취소",
     });
@@ -197,10 +198,7 @@ export function GroupRolesDialog({ open, onClose, groupId, groupName }: Props) {
 
     setSaving(true);
     try {
-      await Promise.all([
-        ...toAdd.map((role) => reactGroupsApi.addGroupRole(groupId, role.roleId)),
-        ...toRemove.map((role) => reactGroupsApi.removeGroupRole(groupId, role.roleId)),
-      ]);
+      await reactGroupsApi.setGroupRoles(groupId, currentIds);
       toast.success("그룹 역할이 저장되었습니다.");
       onClose();
     } catch {

--- a/src/react/pages/admin/groups/api.ts
+++ b/src/react/pages/admin/groups/api.ts
@@ -26,8 +26,10 @@ export const reactGroupsApi = {
         sort: params?.sort ?? "name,asc",
       },
     }),
-  addGroupRole: (groupId: number, roleId: number) =>
-    apiRequest<void>("post", `/api/mgmt/groups/${groupId}/roles`, { data: { roleId } }),
+  setGroupRoles: (groupId: number, roleIds: number[]) =>
+    apiRequest<void>("post", `/api/mgmt/groups/${groupId}/roles`, {
+      data: { roleIds },
+    }),
   removeGroupRole: (groupId: number, roleId: number) =>
     apiRequest<void>("delete", `/api/mgmt/groups/${groupId}/roles/${roleId}`),
 };

--- a/src/react/pages/admin/groups/api.ts
+++ b/src/react/pages/admin/groups/api.ts
@@ -1,5 +1,5 @@
 import { apiRequest } from "@/react/query/fetcher";
-import type { GroupDto } from "@/react/pages/admin/datasource";
+import type { GroupDto, RoleDto } from "@/react/pages/admin/datasource";
 
 export interface GroupMemberDto { userId: number; username: string; name: string; role?: string; joinedAt?: string; }
 
@@ -18,6 +18,14 @@ export const reactGroupsApi = {
     apiRequest<void>("delete", `/api/mgmt/groups/${groupId}/members/${userId}`),
   getGroupRoles: (groupId: number) =>
     apiRequest<{ roleId: number; name: string }[]>("get", `/api/mgmt/groups/${groupId}/roles`),
+  getAvailableRoles: (params?: { page?: number; size?: number; sort?: string }) =>
+    apiRequest<{ content: RoleDto[]; totalElements: number }>("get", "/api/mgmt/roles", {
+      params: {
+        page: params?.page ?? 0,
+        size: params?.size ?? 200,
+        sort: params?.sort ?? "name,asc",
+      },
+    }),
   addGroupRole: (groupId: number, roleId: number) =>
     apiRequest<void>("post", `/api/mgmt/groups/${groupId}/roles`, { data: { roleId } }),
   removeGroupRole: (groupId: number, roleId: number) =>

--- a/src/react/pages/admin/groups/api.ts
+++ b/src/react/pages/admin/groups/api.ts
@@ -12,8 +12,8 @@ export const reactGroupsApi = {
     apiRequest<GroupDto>("post", "/api/mgmt/groups", { data: payload }),
   getMembers: (groupId: number) =>
     apiRequest<GroupMemberDto[]>("get", `/api/mgmt/groups/${groupId}/members`),
-  addMember: (groupId: number, userId: number) =>
-    apiRequest<void>("post", `/api/mgmt/groups/${groupId}/members`, { data: { userId } }),
+  addMembers: (groupId: number, userIds: number[]) =>
+    apiRequest<void>("post", `/api/mgmt/groups/${groupId}/members`, { data: { userIds } }),
   removeMember: (groupId: number, userId: number) =>
     apiRequest<void>("delete", `/api/mgmt/groups/${groupId}/members/${userId}`),
   getGroupRoles: (groupId: number) =>

--- a/src/react/pages/admin/users/UserRolesDialog.tsx
+++ b/src/react/pages/admin/users/UserRolesDialog.tsx
@@ -190,13 +190,17 @@ export function UserRolesDialog({ open, onClose, userId, username }: Props) {
   }
 
   async function handleSave() {
-    const initialIds = new Set(initialGrantedRolesByUser.map((role) => role.roleId));
-    const currentIds = new Set(grantedRolesByUser.map((role) => role.roleId));
+    const initialIds = initialGrantedRolesByUser
+      .map((role) => role.roleId)
+      .sort((a, b) => a - b);
+    const currentIds = grantedRolesByUser
+      .map((role) => role.roleId)
+      .sort((a, b) => a - b);
+    const changed =
+      initialIds.length !== currentIds.length ||
+      initialIds.some((roleId, index) => roleId !== currentIds[index]);
 
-    const toAdd = grantedRolesByUser.filter((role) => !initialIds.has(role.roleId));
-    const toRemove = initialGrantedRolesByUser.filter((role) => !currentIds.has(role.roleId));
-
-    if (toAdd.length === 0 && toRemove.length === 0) {
+    if (!changed) {
       toast.info("변경된 역할이 없습니다.");
       onClose();
       return;
@@ -204,7 +208,7 @@ export function UserRolesDialog({ open, onClose, userId, username }: Props) {
 
     const ok = await confirm({
       title: "역할 변경 저장",
-      message: `역할 ${toAdd.length}개 추가, ${toRemove.length}개 제거를 저장하시겠습니까?`,
+      message: `사용자 직접 부여 역할을 ${currentIds.length}개로 저장하시겠습니까? 기존 직접 부여 역할 구성은 전체 교체됩니다.`,
       okText: "저장",
       cancelText: "취소",
     });
@@ -212,10 +216,7 @@ export function UserRolesDialog({ open, onClose, userId, username }: Props) {
 
     setSaving(true);
     try {
-      await Promise.all([
-        ...toAdd.map((role) => reactUsersApi.addUserRole(userId, role.roleId)),
-        ...toRemove.map((role) => reactUsersApi.removeUserRole(userId, role.roleId)),
-      ]);
+      await reactUsersApi.setUserRoles(userId, currentIds);
       toast.success("사용자 역할이 저장되었습니다.");
       onClose();
     } catch {

--- a/src/react/pages/admin/users/api.ts
+++ b/src/react/pages/admin/users/api.ts
@@ -34,8 +34,8 @@ export const reactUsersApi = {
         sort: params?.sort ?? "name,asc",
       },
     }),
-  addUserRole: (userId: number, roleId: number) =>
-    apiRequest<void>("post", `/api/mgmt/users/${userId}/roles`, { data: { roleId } }),
+  setUserRoles: (userId: number, roleIds: number[]) =>
+    apiRequest<void>("post", `/api/mgmt/users/${userId}/roles`, { data: { roleIds } }),
   removeUserRole: (userId: number, roleId: number) =>
     apiRequest<void>("delete", `/api/mgmt/users/${userId}/roles/${roleId}`),
   getPasswordPolicy: () =>


### PR DESCRIPTION
## Why
- 그룹 상세의 멤버 관리와 역할 관리 다이얼로그가 사용자 상세 수준의 UX와 일관되지 않았습니다.
- 멤버 추가는 단건 선택 기반이라 반복 작업이 많았고, 역할 관리는 역할 ID 직접 입력 방식이라 오류 가능성이 높았습니다.

## What
- `GroupMembershipDialog`에서 멤버 추가를 다중 선택 일괄 추가 방식으로 변경했습니다.
- 공용 `UserSearchDialog`에 단건/다건 선택 모드를 추가했습니다.
- `GroupRolesDialog`를 transfer list + 검색 + 저장 diff 패턴으로 재구성했습니다.
- `reactGroupsApi`에 역할 후보 조회 helper를 추가했습니다.
- `CHANGELOG.md`에 `#81` 변경/검증 기록을 추가했습니다.

## Related Issues
- Closes #81
- Related #77

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 그룹 멤버/역할 부여 UI 흐름이 바뀌며 다건 추가와 diff 저장 로직이 새로 들어갑니다.
- Mitigation: 기존 add/remove endpoint는 그대로 유지하고, 타입체크/lint/build로 검증했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - 모두 통과
  - `lint`는 기존 warning 15개 유지
  - `build`는 기존 Vite chunk warning 유지
- Additional checks:
  - 그룹 멤버/역할 다이얼로그 흐름을 코드 기준으로 검토했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks:
- Ownership (files/modules/tasks):
- Main author post-integration validation:

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert 또는 그룹 멤버/역할 다이얼로그와 `UserSearchDialog` 확장 변경만 되돌리면 됩니다.
- Post-deploy checks: `/admin/groups/:groupId`에서 멤버 다중 선택 추가, 개별 제거, 역할 transfer list 저장 흐름을 확인합니다.