### PR TITLE
[ai-assisted] fix(group): align member delete payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
 # Changelog
 
-## 2026-04-07
+## 2026-04-10
 
 ### Changed
 
+- Issue `#83` aligned React group member deletion with the server contract by sending `DELETE /api/mgmt/groups/{id}/members` requests with `{ userIds: [...] }` bodies for both single and multiple deletion.
+
+### Verification
+
+- Issue `#83`: `npm run typecheck`
+- Issue `#83`: `npm run lint`
+- Issue `#83`: `npm run build`
+- Issue `#83`: manual check - group member delete flow keeps success toast, selection reset, and grid refresh behavior in code
+
+## 2026-04-07
+
+### Changed
 - React login failure audit page header now follows the user list PageToolbar layout pattern.
 - React login failure audit page now uses the server-aligned route and field mapping, with toolbar-aligned search controls and grid column filters disabled.
 - React login failure audit list now uses `/api/mgmt/audit/login-failure-log` to match the server route.
@@ -22,7 +34,6 @@
 - Issue `#50` added `docs/react-maintainability-improvement-plan.md` to define the post-migration React structure improvement direction for the `2.x` runtime.
 
 ### Verification
-
 - Login failure audit toolbar layout: `npm run typecheck`
 - Login failure audit page cleanup: `npm run typecheck`
 - Login failure audit route: `npm run typecheck`

--- a/src/react/pages/admin/groups/GroupMembershipDialog.tsx
+++ b/src/react/pages/admin/groups/GroupMembershipDialog.tsx
@@ -245,7 +245,7 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
 
     setSaving(true);
     try {
-      await Promise.all(userIds.map((userId) => reactGroupsApi.removeMember(groupId, userId)));
+      await reactGroupsApi.removeMembers(groupId, userIds);
       setSelectedCount(0);
       setGridKey((current) => current + 1);
       toast.success(`${userIds.length}명의 멤버가 제거되었습니다.`);

--- a/src/react/pages/admin/groups/api.ts
+++ b/src/react/pages/admin/groups/api.ts
@@ -14,6 +14,10 @@ export interface GroupMemberDto {
   enabled?: boolean;
 }
 
+type GroupMemberIdsPayload = {
+  userIds: number[];
+};
+
 function unwrapMemberList(payload: GroupMemberDto[] | PageResponse<GroupMemberDto>) {
   if (Array.isArray(payload)) {
     return payload;
@@ -53,9 +57,13 @@ export const reactGroupsApi = {
       )
     ),
   addMembers: (groupId: number, userIds: number[]) =>
-    apiRequest<void>("post", `/api/mgmt/groups/${groupId}/members`, { data: { userIds } }),
-  removeMember: (groupId: number, userId: number) =>
-    apiRequest<void>("delete", `/api/mgmt/groups/${groupId}/members/${userId}`),
+    apiRequest<void>("post", `/api/mgmt/groups/${groupId}/members`, {
+      data: { userIds } satisfies GroupMemberIdsPayload,
+    }),
+  removeMembers: (groupId: number, userIds: number[]) =>
+    apiRequest<void>("delete", `/api/mgmt/groups/${groupId}/members`, {
+      data: { userIds } satisfies GroupMemberIdsPayload,
+    }),
   getGroupRoles: (groupId: number) =>
     apiRequest<{ roleId: number; name: string }[]>("get", `/api/mgmt/groups/${groupId}/roles`),
   getAvailableRoles: (params?: { page?: number; size?: number; sort?: string }) =>


### PR DESCRIPTION
## Why
- 그룹 멤버 삭제 API 계약이 변경되어 클라이언트 삭제 요청 형식을 서버와 맞춰야 합니다.
- 기존 단건 경로 기반 삭제는 더 이상 서버가 받지 않습니다.

## What
- 그룹 멤버 삭제 helper를 `DELETE /api/mgmt/groups/{id}/members` + `{ userIds: [...] }` body 형식으로 변경했습니다.
- 그룹 멤버 관리 다이얼로그의 삭제 흐름을 개별 요청 반복에서 단일 batch delete 요청으로 변경했습니다.
- 멤버 추가 흐름은 그대로 유지했습니다.
- 삭제 후 목록 갱신, 선택 상태 초기화, 성공/실패 toast 흐름은 유지했습니다.
- `CHANGELOG.md`에 이 API 정렬과 검증 기록을 추가했습니다.

## Related Issues
- Closes #83
- Related #81

## Change Scope
- [x] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 그룹 멤버 삭제 요청 형식 변경으로 인해 삭제가 실패할 수 있습니다.
- Mitigation: 서버 계약에 맞춘 payload로 정렬했고, typecheck/lint/build로 기본 회귀를 확인했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - 모두 통과
  - lint는 기존 warning 16개 유지
  - build는 기존 Vite chunk warning 유지
- Additional checks:
  - 삭제 후 선택 상태 초기화와 grid refresh 흐름이 코드상 유지되는지 확인했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks:
  - 그룹 멤버 삭제 payload 형식 정렬 구현
- Ownership (files/modules/tasks):
  - `src/react/pages/admin/groups/api.ts`
  - `src/react/pages/admin/groups/GroupMembershipDialog.tsx`
- Main author post-integration validation:
  - `CHANGELOG.md` 갱신
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
  - PR/MR 템플릿 및 Gemini 리뷰 기록 정리

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert 또는 이전 delete helper 복구
- Post-deploy checks: 그룹 멤버 관리 다이얼로그에서 단건/다건 삭제 요청 body가 `{ userIds: [...] }` 형식인지 확인
