### PR TITLE
[ai-assisted] refactor(dialog): standardize dialog shells and actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@
 
 ### Changed
 
+- Issue `#85` standardized dialog shell rounding and footer action button variants across create/edit and admin management dialogs.
 - Issue `#83` aligned React group member deletion with the server contract by sending `DELETE /api/mgmt/groups/{id}/members` requests with `{ userIds: [...] }` bodies for both single and multiple deletion.
 - Neutral outlined close/cancel button styling is now provided by the MUI theme instead of per-dialog overrides.
 
 ### Verification
 
+- Issue `#85`: `npm run typecheck`
+- Issue `#85`: `npm run lint`
+- Issue `#85`: `npm run build`
+- Issue `#85`: manual check - create/edit and admin management dialog shell/action consistency reviewed in code
 - Issue `#83`: `npm run typecheck`
 - Issue `#83`: `npm run lint`
 - Issue `#83`: `npm run build`

--- a/src/react/pages/acl/CreateClassDialog.tsx
+++ b/src/react/pages/acl/CreateClassDialog.tsx
@@ -47,7 +47,7 @@ export function CreateClassDialog({ open, onClose, onCreated }: Props) {
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>ACL 클래스 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
@@ -73,11 +73,11 @@ export function CreateClassDialog({ open, onClose, onCreated }: Props) {
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={loading}>
+        <Button variant="outlined" onClick={onClose} disabled={loading}>
           취소
         </Button>
         <Button
-          variant="contained"
+          variant="outlined"
           onClick={() => void handleCreate()}
           disabled={loading || !className.trim()}
         >

--- a/src/react/pages/acl/CreateEntryDialog.tsx
+++ b/src/react/pages/acl/CreateEntryDialog.tsx
@@ -81,7 +81,7 @@ export function CreateEntryDialog({
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>ACL 엔트리 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
@@ -171,11 +171,11 @@ export function CreateEntryDialog({
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={loading}>
+        <Button variant="outlined" onClick={onClose} disabled={loading}>
           취소
         </Button>
         <Button
-          variant="contained"
+          variant="outlined"
           onClick={() => void handleCreate()}
           disabled={loading || !objectIdentityId || !sidId || !mask}
         >

--- a/src/react/pages/acl/CreateObjectDialog.tsx
+++ b/src/react/pages/acl/CreateObjectDialog.tsx
@@ -65,7 +65,7 @@ export function CreateObjectDialog({
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>오브젝트 아이덴티티 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
@@ -124,11 +124,11 @@ export function CreateObjectDialog({
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={loading}>
+        <Button variant="outlined" onClick={onClose} disabled={loading}>
           취소
         </Button>
         <Button
-          variant="contained"
+          variant="outlined"
           onClick={() => void handleCreate()}
           disabled={loading || !classId || !objectIdIdentity.trim()}
         >

--- a/src/react/pages/acl/CreateSidDialog.tsx
+++ b/src/react/pages/acl/CreateSidDialog.tsx
@@ -46,7 +46,7 @@ export function CreateSidDialog({ open, onClose, onCreated }: Props) {
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>ACL SID 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
@@ -73,11 +73,11 @@ export function CreateSidDialog({ open, onClose, onCreated }: Props) {
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={loading}>
+        <Button variant="outlined" onClick={onClose} disabled={loading}>
           취소
         </Button>
         <Button
-          variant="contained"
+          variant="outlined"
           onClick={() => void handleCreate()}
           disabled={loading || !sid.trim()}
         >

--- a/src/react/pages/admin/groups/GroupMembershipDialog.tsx
+++ b/src/react/pages/admin/groups/GroupMembershipDialog.tsx
@@ -258,7 +258,7 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
 
   return (
     <>
-      <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth>
+      <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
         <DialogTitle>멤버 관리 — {groupName}</DialogTitle>
         <DialogContent
           sx={{

--- a/src/react/pages/admin/groups/GroupRolesDialog.tsx
+++ b/src/react/pages/admin/groups/GroupRolesDialog.tsx
@@ -209,7 +209,7 @@ export function GroupRolesDialog({ open, onClose, groupId, groupName }: Props) {
   }
 
   return (
-    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth>
+    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>역할 관리 — {groupName}</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>

--- a/src/react/pages/admin/roles/RoleDialog.tsx
+++ b/src/react/pages/admin/roles/RoleDialog.tsx
@@ -34,7 +34,7 @@ export function RoleDialog({ open, onClose, onCreated }: Props) {
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>역할 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
@@ -43,8 +43,8 @@ export function RoleDialog({ open, onClose, onCreated }: Props) {
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={loading}>취소</Button>
-        <Button variant="contained" onClick={handleCreate} disabled={loading || !name.trim()}>
+        <Button variant="outlined" onClick={onClose} disabled={loading}>취소</Button>
+        <Button variant="outlined" onClick={handleCreate} disabled={loading || !name.trim()}>
           {loading ? <CircularProgress size={20} /> : "생성"}
         </Button>
       </DialogActions>

--- a/src/react/pages/admin/roles/RoleGrantedGroupsDialog.tsx
+++ b/src/react/pages/admin/roles/RoleGrantedGroupsDialog.tsx
@@ -57,7 +57,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>그룹 부여 — {roleName}</DialogTitle>
       <DialogContent>
         <Stack spacing={1} sx={{ mt: 1 }}>
@@ -83,7 +83,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>닫기</Button>
+        <Button variant="outlined" onClick={onClose}>닫기</Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/react/pages/admin/roles/RoleGrantedUsersDialog.tsx
+++ b/src/react/pages/admin/roles/RoleGrantedUsersDialog.tsx
@@ -58,7 +58,7 @@ export function RoleGrantedUsersDialog({ open, onClose, roleId, roleName }: Prop
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
         <DialogTitle>사용자 부여 — {roleName}</DialogTitle>
         <DialogContent>
           <Stack spacing={1} sx={{ mt: 1 }}>
@@ -78,7 +78,7 @@ export function RoleGrantedUsersDialog({ open, onClose, roleId, roleName }: Prop
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose}>닫기</Button>
+          <Button variant="outlined" onClick={onClose}>닫기</Button>
         </DialogActions>
       </Dialog>
       <UserSearchDialog open={userSearchOpen} onClose={() => setUserSearchOpen(false)} onSelect={handleAdd} />

--- a/src/react/pages/admin/users/PasswordResetDialog.tsx
+++ b/src/react/pages/admin/users/PasswordResetDialog.tsx
@@ -79,7 +79,7 @@ export function PasswordResetDialog({ open, onClose, userId, username }: Props) 
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>비밀번호 재설정 — {username}</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
@@ -96,8 +96,8 @@ export function PasswordResetDialog({ open, onClose, userId, username }: Props) 
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={loading}>취소</Button>
-        <Button variant="contained" onClick={handleSubmit} disabled={loading || !newPassword}>
+        <Button variant="outlined" onClick={onClose} disabled={loading}>취소</Button>
+        <Button variant="outlined" onClick={handleSubmit} disabled={loading || !newPassword}>
           {loading ? <CircularProgress size={20} /> : "재설정"}
         </Button>
       </DialogActions>

--- a/src/react/pages/admin/users/UserRolesDialog.tsx
+++ b/src/react/pages/admin/users/UserRolesDialog.tsx
@@ -227,7 +227,7 @@ export function UserRolesDialog({ open, onClose, userId, username }: Props) {
   }
 
   return (
-    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth>
+    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>역할 관리 — {username}</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>

--- a/src/react/pages/audit/LoginFailureLogPage.tsx
+++ b/src/react/pages/audit/LoginFailureLogPage.tsx
@@ -134,7 +134,7 @@ export function LoginFailureLogPage() {
           sx={{
             border: 1,
             borderColor: "divider",
-            borderRadius: 1,
+            borderRadius: 0,
             px: 1,
             py: 1,
           }}

--- a/src/react/pages/audit/LoginFailureLogPage.tsx
+++ b/src/react/pages/audit/LoginFailureLogPage.tsx
@@ -134,7 +134,7 @@ export function LoginFailureLogPage() {
           sx={{
             border: 1,
             borderColor: "divider",
-            borderRadius: 0,
+            borderRadius: 0.5,
             px: 1,
             py: 1,
           }}

--- a/src/react/pages/audit/LoginFailureLogPage.tsx
+++ b/src/react/pages/audit/LoginFailureLogPage.tsx
@@ -133,10 +133,10 @@ export function LoginFailureLogPage() {
         <Box
           sx={{
             border: 1,
-            borderColor: "divider",
-            borderRadius: 0.5,
-            px: 1,
-            py: 1,
+            borderColor: "rgba(148, 163, 184, 0.45)",
+            borderRadius: 2,
+            px: 1.5,
+            py: 1.5,
           }}
         >
           <Stack spacing={1}>

--- a/src/react/pages/audit/LoginFailureLogPage.tsx
+++ b/src/react/pages/audit/LoginFailureLogPage.tsx
@@ -133,7 +133,7 @@ export function LoginFailureLogPage() {
         <Box
           sx={{
             border: 1,
-            borderColor: "rgba(148, 163, 184, 0.45)",
+            borderColor: "rgb(191 191 191)",
             borderRadius: 2,
             px: 1.5,
             py: 1.5,

--- a/src/react/pages/documents/CreateDocumentDialog.tsx
+++ b/src/react/pages/documents/CreateDocumentDialog.tsx
@@ -41,7 +41,7 @@ export function CreateDocumentDialog({ open, onClose, onCreated }: Props) {
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>문서 생성</DialogTitle>
       <DialogContent>
         <TextField
@@ -55,11 +55,11 @@ export function CreateDocumentDialog({ open, onClose, onCreated }: Props) {
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={loading}>
+        <Button variant="outlined" onClick={onClose} disabled={loading}>
           취소
         </Button>
         <Button
-          variant="contained"
+          variant="outlined"
           onClick={() => void handleCreate()}
           disabled={loading || !title.trim()}
         >

--- a/src/react/pages/forums/admin/ForumCategoryDialog.tsx
+++ b/src/react/pages/forums/admin/ForumCategoryDialog.tsx
@@ -118,7 +118,7 @@ export function ForumCategoryDialog({ open, forumSlug, onClose }: Props) {
   }
 
   return (
-    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth>
+    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>카테고리 관리</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
@@ -199,7 +199,7 @@ export function ForumCategoryDialog({ open, forumSlug, onClose }: Props) {
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={saving}>
+        <Button variant="outlined" onClick={onClose} disabled={saving}>
           닫기
         </Button>
       </DialogActions>

--- a/src/react/pages/forums/admin/ForumCreateDialog.tsx
+++ b/src/react/pages/forums/admin/ForumCreateDialog.tsx
@@ -122,7 +122,7 @@ export function ForumCreateDialog({ open, onClose, onCreated }: Props) {
   }
 
   return (
-    <Dialog open={open} onClose={loading ? undefined : onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={loading ? undefined : onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>새 게시판</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
@@ -210,10 +210,10 @@ export function ForumCreateDialog({ open, onClose, onCreated }: Props) {
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={loading}>
+        <Button variant="outlined" onClick={onClose} disabled={loading}>
           취소
         </Button>
-        <Button variant="contained" onClick={handleSubmit} disabled={loading || !canSubmit}>
+        <Button variant="outlined" onClick={handleSubmit} disabled={loading || !canSubmit}>
           생성
         </Button>
       </DialogActions>

--- a/src/react/pages/forums/admin/ForumMembershipDialog.tsx
+++ b/src/react/pages/forums/admin/ForumMembershipDialog.tsx
@@ -152,7 +152,7 @@ export function ForumMembershipDialog({ open, forumSlug, onClose }: Props) {
 
   return (
     <>
-      <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth>
+      <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
         <DialogTitle>멤버 관리</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>

--- a/src/react/pages/objecttype/CreateObjectTypeDialog.tsx
+++ b/src/react/pages/objecttype/CreateObjectTypeDialog.tsx
@@ -94,7 +94,7 @@ export function CreateObjectTypeDialog({ open, onClose, onCreated }: Props) {
   }
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>오브젝트 타입 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
@@ -161,11 +161,11 @@ export function CreateObjectTypeDialog({ open, onClose, onCreated }: Props) {
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose} disabled={saving}>
+        <Button variant="outlined" onClick={handleClose} disabled={saving}>
           취소
         </Button>
         <Button
-          variant="contained"
+          variant="outlined"
           onClick={() => void handleCreate()}
           disabled={saving || !canSubmit}
         >

--- a/src/react/pages/templates/CreateTemplateDialog.tsx
+++ b/src/react/pages/templates/CreateTemplateDialog.tsx
@@ -52,7 +52,7 @@ export function CreateTemplateDialog({ open, onClose, onCreated }: Props) {
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
       <DialogTitle>템플릿 생성</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
@@ -92,11 +92,11 @@ export function CreateTemplateDialog({ open, onClose, onCreated }: Props) {
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={loading}>
+        <Button variant="outlined" onClick={onClose} disabled={loading}>
           취소
         </Button>
         <Button
-          variant="contained"
+          variant="outlined"
           onClick={() => void handleCreate()}
           disabled={loading || !name.trim()}
         >


### PR DESCRIPTION
## Why
- 관리형 생성/편집 및 일반 관리 다이얼로그의 쉘과 액션 버튼 규칙이 제각각이라 일관성이 부족했습니다.
- `GroupDialog` 기준의 라운드와 `DialogActions` 버튼 규칙을 공통 기준으로 삼아 관리형 다이얼로그 UX를 정리할 필요가 있었습니다.

## What
- 생성/편집/관리형 일반 다이얼로그의 `Dialog` paper radius를 `GroupDialog` 기준으로 통일했습니다.
- `DialogActions`의 닫기/취소 버튼을 default outlined로 맞췄습니다.
- `DialogActions`의 생성/저장/재설정 버튼을 default outlined로 맞췄습니다.
- 삭제 성격의 버튼은 기존 error outlined 규칙을 유지했습니다.
- 검색/미리보기/fullScreen 계열 다이얼로그는 이번 범위에서 제외했습니다.
- `CHANGELOG.md`에 `#85` 변경/검증 기록을 추가했습니다.

## Related Issues
- Closes #85
- Related #74

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: UI shell과 버튼 스타일만 정리하는 작업이라 기능 리스크는 낮습니다.
- Mitigation: 다이얼로그 본문 로직은 건드리지 않고, shell/action 영역만 최소 변경했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - 모두 통과
  - `lint`는 기존 warning 16개 유지
  - `build`는 기존 Vite chunk warning 유지
- Additional checks:
  - 검색/미리보기/fullScreen 다이얼로그는 제외되고, 대상 다이얼로그의 shell/action 규칙만 바뀌는지 코드 기준으로 검토했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks:
- Ownership (files/modules/tasks):
- Main author post-integration validation:

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert 또는 대상 다이얼로그의 shell/action 변경만 되돌리면 됩니다.
- Post-deploy checks: 생성/편집/관리 다이얼로그에서 라운드와 하단 액션 버튼 variant가 일관되게 보이는지 확인합니다.
