### PR TITLE
[ai-assisted] refactor(user): add properties accordion editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Issue `#89` restores user detail properties editing with a reusable accordion-based key/value editor.
+- Issue `#89` restores user detail properties editing with a reusable accordion-based AG Grid editor backed by the dedicated user properties API.
 - Issue `#87` improves role detail user/group assignment dialogs with search-driven multi-select assign/revoke flows and current assignment grids.
 - Issue `#85` standardized dialog shell rounding and footer action button variants across create/edit and admin management dialogs.
 - Issue `#83` aligned React group member deletion with the server contract by sending `DELETE /api/mgmt/groups/{id}/members` requests with `{ userIds: [...] }` bodies for both single and multiple deletion.
@@ -15,7 +15,7 @@
 - Issue `#89`: `npm run typecheck`
 - Issue `#89`: `npm run lint`
 - Issue `#89`: `npm run build`
-- Issue `#89`: manual check - user detail properties accordion and save flow reviewed in code
+- Issue `#89`: manual check - user detail properties accordion, separate properties save flow, and key validation reviewed in code
 - Issue `#87`: `npm run typecheck`
 - Issue `#87`: `npm run lint`
 - Issue `#87`: `npm run build`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Issue `#89` restores user detail properties editing with a reusable accordion-based key/value editor.
 - Issue `#87` improves role detail user/group assignment dialogs with search-driven multi-select assign/revoke flows and current assignment grids.
 - Issue `#85` standardized dialog shell rounding and footer action button variants across create/edit and admin management dialogs.
 - Issue `#83` aligned React group member deletion with the server contract by sending `DELETE /api/mgmt/groups/{id}/members` requests with `{ userIds: [...] }` bodies for both single and multiple deletion.
@@ -11,6 +12,10 @@
 
 ### Verification
 
+- Issue `#89`: `npm run typecheck`
+- Issue `#89`: `npm run lint`
+- Issue `#89`: `npm run build`
+- Issue `#89`: manual check - user detail properties accordion and save flow reviewed in code
 - Issue `#87`: `npm run typecheck`
 - Issue `#87`: `npm run lint`
 - Issue `#87`: `npm run build`

--- a/src/react/api/properties.ts
+++ b/src/react/api/properties.ts
@@ -1,0 +1,41 @@
+import { apiRequest } from "@/react/query/fetcher";
+
+export type PropertyOwnerType = "users" | "groups";
+
+export interface PropertyEntryDto {
+  key: string;
+  value: string;
+}
+
+export function getProperties(type: PropertyOwnerType, id: number) {
+  return apiRequest<Record<string, string>>("get", `/api/mgmt/${type}/${id}/properties`);
+}
+
+export function replaceProperties(
+  type: PropertyOwnerType,
+  id: number,
+  properties: Record<string, string>
+) {
+  return apiRequest<Record<string, string>, Record<string, string>>(
+    "put",
+    `/api/mgmt/${type}/${id}/properties`,
+    { data: properties }
+  );
+}
+
+export function setProperty(
+  type: PropertyOwnerType,
+  id: number,
+  key: string,
+  value: string
+) {
+  return apiRequest<PropertyEntryDto, PropertyEntryDto>(
+    "put",
+    `/api/mgmt/${type}/${id}/properties/${encodeURIComponent(key)}`,
+    { data: { key, value } }
+  );
+}
+
+export function deleteProperty(type: PropertyOwnerType, id: number, key: string) {
+  return apiRequest<void>("delete", `/api/mgmt/${type}/${id}/properties/${encodeURIComponent(key)}`);
+}

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -4,24 +4,27 @@ import {
   useImperativeHandle,
   useMemo,
   useState,
+  type ForwardedRef,
 } from "react";
 import { IconButton, Stack, Typography } from "@mui/material";
 import { DeleteOutlined } from "@mui/icons-material";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
+import type { PropertyOwnerType } from "@/react/api/properties";
 import { GridContent } from "@/react/components/ag-grid/GridContent";
+import { validatePropertyKey } from "@/react/utils/propertyKeys";
 
 type PropertyRow = {
   id: string;
   key: string;
   value: string;
-  keyError?: "required" | "duplicate" | null;
+  keyError?: "required" | "duplicate" | "pattern" | "reserved" | null;
 };
 
 interface Props {
   value: Record<string, string>;
   onChange: (next: Record<string, string>) => void;
   disabled?: boolean;
-  hideDefaultAddAction?: boolean;
+  type?: PropertyOwnerType;
   resetKey?: string | number;
 }
 
@@ -31,7 +34,7 @@ export interface PropertiesEditorHandle {
   getValue: () => Record<string, string>;
 }
 
-function toRows(value: Record<string, string>): PropertyRow[] {
+function toRows(value: Record<string, string>) {
   return Object.entries(value).map(([key, rowValue], index) => ({
     id: `row-${index}`,
     key,
@@ -52,7 +55,7 @@ function toMap(rows: PropertyRow[]) {
   return next;
 }
 
-function validateRows(rows: PropertyRow[]) {
+function validateRows(rows: PropertyRow[], type: PropertyOwnerType) {
   const counts = new Map<string, number>();
 
   rows.forEach((row) => {
@@ -65,9 +68,11 @@ function validateRows(rows: PropertyRow[]) {
 
   return rows.map((row) => {
     const normalizedKey = row.key.trim();
-    if (!normalizedKey) {
-      return { ...row, keyError: "required" as const };
+    const keyError = validatePropertyKey(normalizedKey, type);
+    if (keyError) {
+      return { ...row, keyError };
     }
+
     return {
       ...row,
       keyError: (counts.get(normalizedKey) ?? 0) > 1 ? ("duplicate" as const) : null,
@@ -106,37 +111,36 @@ function ActionsCell({
 }
 
 function PropertiesEditorInner(
-  { value, onChange, disabled = false, resetKey }: Props,
-  ref: React.ForwardedRef<PropertiesEditorHandle>
+  { value, onChange, disabled = false, type = "users", resetKey }: Props,
+  ref: ForwardedRef<PropertiesEditorHandle>
 ) {
-  const [rows, setRows] = useState<PropertyRow[]>(() => validateRows(toRows(value)));
+  const [rows, setRows] = useState<PropertyRow[]>(() => validateRows(toRows(value), type));
 
   useEffect(() => {
-    const nextRows = validateRows(
-      Object.entries(value).map(([key, rowValue], index) => ({
-        id: `row-${index}`,
-        key,
-        value: rowValue,
-        keyError: null,
-      }))
-    );
-    setRows(nextRows);
-  }, [resetKey]);
+    setRows(validateRows(toRows(value), type));
+  }, [resetKey, type]);
 
-  function updateRows(nextRows: PropertyRow[]) {
-    const validated = validateRows(nextRows);
-    setRows(validated);
-    const nextValue = toMap(validated);
-    onChange(nextValue);
+  function updateRows(
+    nextRowsOrUpdater: PropertyRow[] | ((currentRows: PropertyRow[]) => PropertyRow[])
+  ) {
+    setRows((currentRows) => {
+      const nextRows =
+        typeof nextRowsOrUpdater === "function"
+          ? nextRowsOrUpdater(currentRows)
+          : nextRowsOrUpdater;
+      const validated = validateRows(nextRows, type);
+      onChange(toMap(validated));
+      return validated;
+    });
   }
 
   function handleDelete(rowId: string) {
-    updateRows(rows.filter((row) => row.id !== rowId));
+    updateRows((currentRows) => currentRows.filter((row) => row.id !== rowId));
   }
 
   function handleCellValueChanged(rowId: string, field: "key" | "value", nextValue: string) {
-    updateRows(
-      rows.map((row) => (row.id === rowId ? { ...row, [field]: nextValue } : row))
+    updateRows((currentRows) =>
+      currentRows.map((row) => (row.id === rowId ? { ...row, [field]: nextValue } : row))
     );
   }
 
@@ -167,9 +171,9 @@ function PropertiesEditorInner(
         headerName: "",
         width: 64,
         maxWidth: 64,
+        editable: false,
         sortable: false,
         filter: false,
-        editable: false,
         cellRenderer: (params: ICellRendererParams<PropertyRow>) =>
           params.data ? (
             <ActionsCell
@@ -180,19 +184,19 @@ function PropertiesEditorInner(
           ) : null,
       },
     ],
-    [disabled, rows]
+    [disabled]
   );
 
   useImperativeHandle(
     ref,
     () => ({
       addRow: () => {
-        updateRows([...rows, createEmptyRow(rows.length)]);
+        updateRows((currentRows) => [...currentRows, createEmptyRow(currentRows.length)]);
       },
       hasErrors: () => rows.some((row) => row.keyError != null),
-      getValue: () => toMap(validateRows(rows)),
+      getValue: () => toMap(validateRows(rows, type)),
     }),
-    [rows]
+    [rows, type]
   );
 
   return (
@@ -217,7 +221,7 @@ function PropertiesEditorInner(
       />
       {rows.some((row) => row.keyError != null) ? (
         <Typography variant="caption" color="error">
-          빈 키 또는 중복 키는 저장에서 제외됩니다.
+          빈 키, 중복 키, 형식 오류, 예약 prefix 키는 저장에서 제외됩니다.
         </Typography>
       ) : null}
     </Stack>

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -27,6 +27,7 @@ interface Props {
   disabled?: boolean;
   actions?: React.ReactNode;
   onAdd?: () => void;
+  hideDefaultAddAction?: boolean;
 }
 
 function toRows(value: Record<string, string>): PropertyRow[] {
@@ -88,6 +89,7 @@ export function PropertiesEditor({
   disabled = false,
   actions,
   onAdd,
+  hideDefaultAddAction = false,
 }: Props) {
   const [rows, setRows] = useState<PropertyRow[]>(() => validateRows(toRows(value)));
 
@@ -135,7 +137,7 @@ export function PropertiesEditor({
     <Stack spacing={1}>
       <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <Box />
-        {actions ?? (
+        {actions ?? (hideDefaultAddAction ? null : (
           <Button
             size="small"
             variant="outlined"
@@ -145,7 +147,7 @@ export function PropertiesEditor({
           >
             행 추가
           </Button>
-        )}
+        ))}
       </Box>
       <Table size="small">
         <TableHead>

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -25,6 +25,8 @@ interface Props {
   value: Record<string, string>;
   onChange: (next: Record<string, string>) => void;
   disabled?: boolean;
+  actions?: React.ReactNode;
+  onAdd?: () => void;
 }
 
 function toRows(value: Record<string, string>): PropertyRow[] {
@@ -80,7 +82,13 @@ function createEmptyRow() {
   };
 }
 
-export function PropertiesEditor({ value, onChange, disabled = false }: Props) {
+export function PropertiesEditor({
+  value,
+  onChange,
+  disabled = false,
+  actions,
+  onAdd,
+}: Props) {
   const [rows, setRows] = useState<PropertyRow[]>(() => validateRows(toRows(value)));
 
   useEffect(() => {
@@ -127,15 +135,17 @@ export function PropertiesEditor({ value, onChange, disabled = false }: Props) {
     <Stack spacing={1}>
       <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <Box />
-        <Button
-          size="small"
-          variant="outlined"
-          startIcon={<AddOutlined />}
-          onClick={handleAddRow}
-          disabled={disabled}
-        >
-          행 추가
-        </Button>
+        {actions ?? (
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<AddOutlined />}
+            onClick={onAdd ?? handleAddRow}
+            disabled={disabled}
+          >
+            행 추가
+          </Button>
+        )}
       </Box>
       <Table size="small">
         <TableHead>

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -126,7 +126,7 @@ export function PropertiesEditor({ value, onChange, disabled = false }: Props) {
   return (
     <Stack spacing={1}>
       <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <Typography variant="subtitle2">프로퍼티 목록</Typography>
+        <Box />
         <Button
           size="small"
           variant="outlined"

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -95,11 +95,10 @@ export function PropertiesEditor({ value, onChange, disabled = false }: Props) {
   function updateRows(nextRows: PropertyRow[]) {
     const validated = validateRows(nextRows);
     setRows(validated);
-    if (!validated.some((row) => row.keyError != null)) {
-      onChange(toMap(validated));
+    if (validated.some((row) => row.keyError != null)) {
       return;
     }
-    onChange(toMap(validated.filter((row) => row.keyError == null)));
+    onChange(toMap(validated));
   }
 
   function handleRowChange(id: string, field: "key" | "value", nextValue: string) {

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -100,6 +100,7 @@ function ActionsCell({
   return (
     <Button
       size="small"
+      variant="outlined"
       color="error"
       onClick={() => onDelete(data.id)}
       disabled={disabled}

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -128,6 +128,7 @@ export function PropertiesEditor({ value, onChange, disabled = false }: Props) {
       <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <Typography variant="subtitle2">프로퍼티 목록</Typography>
         <Button
+          size="small"
           variant="outlined"
           startIcon={<AddOutlined />}
           onClick={handleAddRow}

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -3,7 +3,6 @@ import {
   useEffect,
   useImperativeHandle,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import { IconButton, Stack, Typography } from "@mui/material";
@@ -23,6 +22,7 @@ interface Props {
   onChange: (next: Record<string, string>) => void;
   disabled?: boolean;
   hideDefaultAddAction?: boolean;
+  resetKey?: string | number;
 }
 
 export interface PropertiesEditorHandle {
@@ -83,19 +83,6 @@ function createEmptyRow(index: number): PropertyRow {
   };
 }
 
-function sameMap(left: Record<string, string>, right: Record<string, string>) {
-  const leftEntries = Object.entries(left).sort(([a], [b]) => a.localeCompare(b));
-  const rightEntries = Object.entries(right).sort(([a], [b]) => a.localeCompare(b));
-
-  return (
-    leftEntries.length === rightEntries.length &&
-    leftEntries.every(
-      ([leftKey, leftValue], index) =>
-        leftKey === rightEntries[index]?.[0] && leftValue === rightEntries[index]?.[1]
-    )
-  );
-}
-
 function ActionsCell({
   data,
   disabled,
@@ -118,36 +105,27 @@ function ActionsCell({
 }
 
 function PropertiesEditorInner(
-  { value, onChange, disabled = false }: Props,
+  { value, onChange, disabled = false, resetKey }: Props,
   ref: React.ForwardedRef<PropertiesEditorHandle>
 ) {
   const [rows, setRows] = useState<PropertyRow[]>(() => validateRows(toRows(value)));
-  const lastEmittedValueRef = useRef<Record<string, string>>(value);
 
   useEffect(() => {
-    if (sameMap(lastEmittedValueRef.current, value)) {
-      return;
-    }
-
     const nextRows = validateRows(
       Object.entries(value).map(([key, rowValue], index) => ({
-        id: rows[index]?.id ?? `row-${index}`,
+        id: `row-${index}`,
         key,
         value: rowValue,
         keyError: null,
       }))
     );
-
-    if (!sameMap(toMap(rows), value)) {
-      setRows(nextRows);
-    }
-  }, [value]);
+    setRows(nextRows);
+  }, [resetKey]);
 
   function updateRows(nextRows: PropertyRow[]) {
     const validated = validateRows(nextRows);
     setRows(validated);
     const nextValue = toMap(validated);
-    lastEmittedValueRef.current = nextValue;
     onChange(nextValue);
   }
 

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -17,7 +17,7 @@ type PropertyRow = {
   id: string;
   key: string;
   value: string;
-  keyError?: "required" | "duplicate" | "pattern" | "reserved" | null;
+  keyError?: string | null;
 };
 
 interface Props {
@@ -85,7 +85,7 @@ function createEmptyRow(index: number): PropertyRow {
     id: `new-${Date.now()}-${index}`,
     key: "",
     value: "",
-    keyError: "required",
+    keyError: "키를 입력해 주세요.",
   };
 }
 
@@ -153,9 +153,14 @@ function PropertiesEditorInner(
         editable: !disabled,
         sortable: false,
         filter: false,
+        tooltipValueGetter: (params) => params.data?.keyError ?? "",
         cellStyle: (params) =>
           params.data?.keyError
-            ? { border: "1px solid #d32f2f", borderRadius: 4 }
+            ? {
+                border: "1px solid #d32f2f",
+                borderRadius: 4,
+                backgroundColor: "rgba(211, 47, 47, 0.06)",
+              }
             : undefined,
       },
       {

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -6,8 +6,7 @@ import {
   useState,
   type ForwardedRef,
 } from "react";
-import { IconButton, Stack, Typography } from "@mui/material";
-import { DeleteOutlined } from "@mui/icons-material";
+import { Button, Stack, Typography } from "@mui/material";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
 import type { PropertyOwnerType } from "@/react/api/properties";
 import { GridContent } from "@/react/components/ag-grid/GridContent";
@@ -99,14 +98,14 @@ function ActionsCell({
   onDelete: (rowId: string) => void;
 }) {
   return (
-    <IconButton
+    <Button
       size="small"
       color="error"
       onClick={() => onDelete(data.id)}
       disabled={disabled}
     >
-      <DeleteOutlined fontSize="small" />
-    </IconButton>
+      삭제
+    </Button>
   );
 }
 

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -29,7 +29,7 @@ interface Props {
 
 function toRows(value: Record<string, string>): PropertyRow[] {
   return Object.entries(value).map(([key, rowValue], index) => ({
-    id: `${key}-${index}`,
+    id: `row-${index}`,
     key,
     value: rowValue,
     keyError: null,
@@ -84,7 +84,15 @@ export function PropertiesEditor({ value, onChange, disabled = false }: Props) {
   const [rows, setRows] = useState<PropertyRow[]>(() => validateRows(toRows(value)));
 
   useEffect(() => {
-    setRows(validateRows(toRows(value)));
+    setRows((currentRows) => {
+      const nextRows = Object.entries(value).map(([key, rowValue], index) => ({
+        id: currentRows[index]?.id ?? `row-${index}`,
+        key,
+        value: rowValue,
+        keyError: null,
+      }));
+      return validateRows(nextRows);
+    });
   }, [value]);
 
   const hasErrors = useMemo(

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -163,13 +163,6 @@ export function PropertiesEditor({ value, onChange, disabled = false }: Props) {
                     value={row.key}
                     onChange={(event) => handleRowChange(row.id, "key", event.target.value)}
                     error={row.keyError != null}
-                    helperText={
-                      row.keyError === "required"
-                        ? "키를 입력하세요."
-                        : row.keyError === "duplicate"
-                          ? "중복된 키입니다."
-                          : undefined
-                    }
                     disabled={disabled}
                   />
                 </TableCell>

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -28,6 +28,7 @@ interface Props {
 export interface PropertiesEditorHandle {
   addRow: () => void;
   hasErrors: () => boolean;
+  getValue: () => Record<string, string>;
 }
 
 function toRows(value: Record<string, string>): PropertyRow[] {
@@ -189,6 +190,7 @@ function PropertiesEditorInner(
         updateRows([...rows, createEmptyRow(rows.length)]);
       },
       hasErrors: () => rows.some((row) => row.keyError != null),
+      getValue: () => toMap(validateRows(rows)),
     }),
     [rows]
   );

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { IconButton, Stack, Typography } from "@mui/material";
@@ -121,8 +122,13 @@ function PropertiesEditorInner(
   ref: React.ForwardedRef<PropertiesEditorHandle>
 ) {
   const [rows, setRows] = useState<PropertyRow[]>(() => validateRows(toRows(value)));
+  const lastEmittedValueRef = useRef<Record<string, string>>(value);
 
   useEffect(() => {
+    if (sameMap(lastEmittedValueRef.current, value)) {
+      return;
+    }
+
     const nextRows = validateRows(
       Object.entries(value).map(([key, rowValue], index) => ({
         id: rows[index]?.id ?? `row-${index}`,
@@ -140,7 +146,9 @@ function PropertiesEditorInner(
   function updateRows(nextRows: PropertyRow[]) {
     const validated = validateRows(nextRows);
     setRows(validated);
-    onChange(toMap(validated));
+    const nextValue = toMap(validated);
+    lastEmittedValueRef.current = nextValue;
+    onChange(nextValue);
   }
 
   function handleDelete(rowId: string) {

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -174,8 +174,8 @@ function PropertiesEditorInner(
       {
         colId: "actions",
         headerName: "",
-        width: 64,
-        maxWidth: 64,
+        width: 96,
+        maxWidth: 96,
         editable: false,
         sortable: false,
         filter: false,

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  IconButton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { AddOutlined, DeleteOutlined } from "@mui/icons-material";
+
+type PropertyRow = {
+  id: string;
+  key: string;
+  value: string;
+  keyError?: "required" | "duplicate" | null;
+};
+
+interface Props {
+  value: Record<string, string>;
+  onChange: (next: Record<string, string>) => void;
+  disabled?: boolean;
+}
+
+function toRows(value: Record<string, string>): PropertyRow[] {
+  return Object.entries(value).map(([key, rowValue], index) => ({
+    id: `${key}-${index}`,
+    key,
+    value: rowValue,
+    keyError: null,
+  }));
+}
+
+function toMap(rows: PropertyRow[]) {
+  const next: Record<string, string> = {};
+  rows.forEach((row) => {
+    const normalizedKey = row.key.trim();
+    if (!normalizedKey) {
+      return;
+    }
+    next[normalizedKey] = row.value;
+  });
+  return next;
+}
+
+function validateRows(rows: PropertyRow[]) {
+  const counts = new Map<string, number>();
+
+  rows.forEach((row) => {
+    const normalizedKey = row.key.trim();
+    if (!normalizedKey) {
+      return;
+    }
+    counts.set(normalizedKey, (counts.get(normalizedKey) ?? 0) + 1);
+  });
+
+  return rows.map((row) => {
+    const normalizedKey = row.key.trim();
+    if (!normalizedKey) {
+      return { ...row, keyError: "required" as const };
+    }
+    return {
+      ...row,
+      keyError: (counts.get(normalizedKey) ?? 0) > 1 ? ("duplicate" as const) : null,
+    };
+  });
+}
+
+function createEmptyRow() {
+  return {
+    id: `${Date.now()}-${Math.random()}`,
+    key: "",
+    value: "",
+    keyError: "required" as const,
+  };
+}
+
+export function PropertiesEditor({ value, onChange, disabled = false }: Props) {
+  const [rows, setRows] = useState<PropertyRow[]>(() => validateRows(toRows(value)));
+
+  useEffect(() => {
+    setRows(validateRows(toRows(value)));
+  }, [value]);
+
+  const hasErrors = useMemo(
+    () => rows.some((row) => row.keyError != null),
+    [rows]
+  );
+
+  function updateRows(nextRows: PropertyRow[]) {
+    const validated = validateRows(nextRows);
+    setRows(validated);
+    if (!validated.some((row) => row.keyError != null)) {
+      onChange(toMap(validated));
+      return;
+    }
+    onChange(toMap(validated.filter((row) => row.keyError == null)));
+  }
+
+  function handleRowChange(id: string, field: "key" | "value", nextValue: string) {
+    updateRows(
+      rows.map((row) => (row.id === id ? { ...row, [field]: nextValue } : row))
+    );
+  }
+
+  function handleAddRow() {
+    updateRows([...rows, createEmptyRow()]);
+  }
+
+  function handleDeleteRow(id: string) {
+    updateRows(rows.filter((row) => row.id !== id));
+  }
+
+  return (
+    <Stack spacing={1}>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography variant="subtitle2">프로퍼티 목록</Typography>
+        <Button
+          variant="outlined"
+          startIcon={<AddOutlined />}
+          onClick={handleAddRow}
+          disabled={disabled}
+        >
+          행 추가
+        </Button>
+      </Box>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ width: "35%" }}>키</TableCell>
+            <TableCell>값</TableCell>
+            <TableCell align="right" sx={{ width: 64 }}>작업</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={3} align="center">
+                <Typography variant="body2" color="text.secondary">
+                  등록된 프로퍼티가 없습니다.
+                </Typography>
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell>
+                  <TextField
+                    size="small"
+                    fullWidth
+                    value={row.key}
+                    onChange={(event) => handleRowChange(row.id, "key", event.target.value)}
+                    error={row.keyError != null}
+                    helperText={
+                      row.keyError === "required"
+                        ? "키를 입력하세요."
+                        : row.keyError === "duplicate"
+                          ? "중복된 키입니다."
+                          : undefined
+                    }
+                    disabled={disabled}
+                  />
+                </TableCell>
+                <TableCell>
+                  <TextField
+                    size="small"
+                    fullWidth
+                    value={row.value}
+                    onChange={(event) => handleRowChange(row.id, "value", event.target.value)}
+                    disabled={disabled}
+                  />
+                </TableCell>
+                <TableCell align="right">
+                  <IconButton
+                    size="small"
+                    color="error"
+                    onClick={() => handleDeleteRow(row.id)}
+                    disabled={disabled}
+                  >
+                    <DeleteOutlined fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+      {hasErrors ? (
+        <Typography variant="caption" color="error">
+          빈 키 또는 중복 키가 있으면 저장 시 제외됩니다.
+        </Typography>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/react/components/properties/PropertiesEditor.tsx
+++ b/src/react/components/properties/PropertiesEditor.tsx
@@ -1,18 +1,14 @@
-import { useEffect, useMemo, useState } from "react";
 import {
-  Box,
-  Button,
-  IconButton,
-  Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  TextField,
-  Typography,
-} from "@mui/material";
-import { AddOutlined, DeleteOutlined } from "@mui/icons-material";
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from "react";
+import { IconButton, Stack, Typography } from "@mui/material";
+import { DeleteOutlined } from "@mui/icons-material";
+import type { ColDef, ICellRendererParams } from "ag-grid-community";
+import { GridContent } from "@/react/components/ag-grid/GridContent";
 
 type PropertyRow = {
   id: string;
@@ -25,9 +21,12 @@ interface Props {
   value: Record<string, string>;
   onChange: (next: Record<string, string>) => void;
   disabled?: boolean;
-  actions?: React.ReactNode;
-  onAdd?: () => void;
   hideDefaultAddAction?: boolean;
+}
+
+export interface PropertiesEditorHandle {
+  addRow: () => void;
+  hasErrors: () => boolean;
 }
 
 function toRows(value: Record<string, string>): PropertyRow[] {
@@ -43,7 +42,7 @@ function toMap(rows: PropertyRow[]) {
   const next: Record<string, string> = {};
   rows.forEach((row) => {
     const normalizedKey = row.key.trim();
-    if (!normalizedKey) {
+    if (!normalizedKey || row.keyError) {
       return;
     }
     next[normalizedKey] = row.value;
@@ -74,140 +73,167 @@ function validateRows(rows: PropertyRow[]) {
   });
 }
 
-function createEmptyRow() {
+function createEmptyRow(index: number): PropertyRow {
   return {
-    id: `${Date.now()}-${Math.random()}`,
+    id: `new-${Date.now()}-${index}`,
     key: "",
     value: "",
-    keyError: "required" as const,
+    keyError: "required",
   };
 }
 
-export function PropertiesEditor({
-  value,
-  onChange,
-  disabled = false,
-  actions,
-  onAdd,
-  hideDefaultAddAction = false,
-}: Props) {
+function sameMap(left: Record<string, string>, right: Record<string, string>) {
+  const leftEntries = Object.entries(left).sort(([a], [b]) => a.localeCompare(b));
+  const rightEntries = Object.entries(right).sort(([a], [b]) => a.localeCompare(b));
+
+  return (
+    leftEntries.length === rightEntries.length &&
+    leftEntries.every(
+      ([leftKey, leftValue], index) =>
+        leftKey === rightEntries[index]?.[0] && leftValue === rightEntries[index]?.[1]
+    )
+  );
+}
+
+function ActionsCell({
+  data,
+  disabled,
+  onDelete,
+}: {
+  data: PropertyRow;
+  disabled: boolean;
+  onDelete: (rowId: string) => void;
+}) {
+  return (
+    <IconButton
+      size="small"
+      color="error"
+      onClick={() => onDelete(data.id)}
+      disabled={disabled}
+    >
+      <DeleteOutlined fontSize="small" />
+    </IconButton>
+  );
+}
+
+function PropertiesEditorInner(
+  { value, onChange, disabled = false }: Props,
+  ref: React.ForwardedRef<PropertiesEditorHandle>
+) {
   const [rows, setRows] = useState<PropertyRow[]>(() => validateRows(toRows(value)));
 
   useEffect(() => {
-    setRows((currentRows) => {
-      const nextRows = Object.entries(value).map(([key, rowValue], index) => ({
-        id: currentRows[index]?.id ?? `row-${index}`,
+    const nextRows = validateRows(
+      Object.entries(value).map(([key, rowValue], index) => ({
+        id: rows[index]?.id ?? `row-${index}`,
         key,
         value: rowValue,
         keyError: null,
-      }));
-      return validateRows(nextRows);
-    });
-  }, [value]);
+      }))
+    );
 
-  const hasErrors = useMemo(
-    () => rows.some((row) => row.keyError != null),
-    [rows]
-  );
+    if (!sameMap(toMap(rows), value)) {
+      setRows(nextRows);
+    }
+  }, [value]);
 
   function updateRows(nextRows: PropertyRow[]) {
     const validated = validateRows(nextRows);
     setRows(validated);
-    if (validated.some((row) => row.keyError != null)) {
-      return;
-    }
     onChange(toMap(validated));
   }
 
-  function handleRowChange(id: string, field: "key" | "value", nextValue: string) {
+  function handleDelete(rowId: string) {
+    updateRows(rows.filter((row) => row.id !== rowId));
+  }
+
+  function handleCellValueChanged(rowId: string, field: "key" | "value", nextValue: string) {
     updateRows(
-      rows.map((row) => (row.id === id ? { ...row, [field]: nextValue } : row))
+      rows.map((row) => (row.id === rowId ? { ...row, [field]: nextValue } : row))
     );
   }
 
-  function handleAddRow() {
-    updateRows([...rows, createEmptyRow()]);
-  }
+  const columnDefs = useMemo<ColDef<PropertyRow>[]>(
+    () => [
+      {
+        field: "key",
+        headerName: "키",
+        flex: 1,
+        editable: !disabled,
+        sortable: false,
+        filter: false,
+        cellStyle: (params) =>
+          params.data?.keyError
+            ? { border: "1px solid #d32f2f", borderRadius: 4 }
+            : undefined,
+      },
+      {
+        field: "value",
+        headerName: "값",
+        flex: 1.4,
+        editable: !disabled,
+        sortable: false,
+        filter: false,
+      },
+      {
+        colId: "actions",
+        headerName: "",
+        width: 64,
+        maxWidth: 64,
+        sortable: false,
+        filter: false,
+        editable: false,
+        cellRenderer: (params: ICellRendererParams<PropertyRow>) =>
+          params.data ? (
+            <ActionsCell
+              data={params.data}
+              disabled={disabled}
+              onDelete={handleDelete}
+            />
+          ) : null,
+      },
+    ],
+    [disabled, rows]
+  );
 
-  function handleDeleteRow(id: string) {
-    updateRows(rows.filter((row) => row.id !== id));
-  }
+  useImperativeHandle(
+    ref,
+    () => ({
+      addRow: () => {
+        updateRows([...rows, createEmptyRow(rows.length)]);
+      },
+      hasErrors: () => rows.some((row) => row.keyError != null),
+    }),
+    [rows]
+  );
 
   return (
     <Stack spacing={1}>
-      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <Box />
-        {actions ?? (hideDefaultAddAction ? null : (
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<AddOutlined />}
-            onClick={onAdd ?? handleAddRow}
-            disabled={disabled}
-          >
-            행 추가
-          </Button>
-        ))}
-      </Box>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell sx={{ width: "35%" }}>키</TableCell>
-            <TableCell>값</TableCell>
-            <TableCell align="right" sx={{ width: 64 }}>작업</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rows.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={3} align="center">
-                <Typography variant="body2" color="text.secondary">
-                  등록된 프로퍼티가 없습니다.
-                </Typography>
-              </TableCell>
-            </TableRow>
-          ) : (
-            rows.map((row) => (
-              <TableRow key={row.id}>
-                <TableCell>
-                  <TextField
-                    size="small"
-                    fullWidth
-                    value={row.key}
-                    onChange={(event) => handleRowChange(row.id, "key", event.target.value)}
-                    error={row.keyError != null}
-                    disabled={disabled}
-                  />
-                </TableCell>
-                <TableCell>
-                  <TextField
-                    size="small"
-                    fullWidth
-                    value={row.value}
-                    onChange={(event) => handleRowChange(row.id, "value", event.target.value)}
-                    disabled={disabled}
-                  />
-                </TableCell>
-                <TableCell align="right">
-                  <IconButton
-                    size="small"
-                    color="error"
-                    onClick={() => handleDeleteRow(row.id)}
-                    disabled={disabled}
-                  >
-                    <DeleteOutlined fontSize="small" />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
-      {hasErrors ? (
+      <GridContent<PropertyRow>
+        rowData={rows}
+        columns={columnDefs}
+        height={220}
+        options={{
+          stopEditingWhenCellsLoseFocus: true,
+          suppressCellFocus: false,
+          singleClickEdit: true,
+          getRowId: (params) => params.data.id,
+          onCellValueChanged: (event) => {
+            const field = event.colDef.field as "key" | "value" | undefined;
+            if (!field || !event.data) {
+              return;
+            }
+            handleCellValueChanged(event.data.id, field, String(event.newValue ?? ""));
+          },
+        }}
+      />
+      {rows.some((row) => row.keyError != null) ? (
         <Typography variant="caption" color="error">
-          빈 키 또는 중복 키가 있으면 저장 시 제외됩니다.
+          빈 키 또는 중복 키는 저장에서 제외됩니다.
         </Typography>
       ) : null}
     </Stack>
   );
 }
+
+export const PropertiesEditor = forwardRef(PropertiesEditorInner);

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Avatar,
   Box,
   Stack,
@@ -15,6 +18,7 @@ import {
 } from "@mui/material";
 import {
   DeleteOutlined,
+  ExpandMoreOutlined,
   KeyOutlined,
   ManageAccountsOutlined,
   SaveOutlined,
@@ -28,6 +32,7 @@ import type { UserDto } from "@/types/studio/user";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
 import { API_BASE_URL } from "@/config/backend";
 import NO_AVATAR from "@/assets/images/users/no-avatar.png";
+import { PropertiesEditor } from "@/react/components/properties/PropertiesEditor";
 
 export function UserDetailPage() {
   const { userId } = useParams<{ userId: string }>();
@@ -49,6 +54,7 @@ export function UserDetailPage() {
     nameVisible: true,
     enabled: true,
   });
+  const [properties, setProperties] = useState<Record<string, string>>({});
 
   const loadUser = useCallback(() => {
     if (!userId) return;
@@ -64,6 +70,14 @@ export function UserDetailPage() {
           nameVisible: u.nameVisible,
           enabled: u.enabled,
         });
+        setProperties(
+          Object.fromEntries(
+            Object.entries(u.properties ?? {}).map(([key, value]) => [
+              key,
+              value == null ? "" : String(value),
+            ])
+          )
+        );
         const presence = await reactUsersApi
           .checkAvatarPresence(Number(userId))
           .catch(() => null);
@@ -83,7 +97,10 @@ export function UserDetailPage() {
     if (!userId) return;
     setSaving(true);
     try {
-      await reactUsersApi.updateUser(Number(userId), form);
+      await reactUsersApi.updateUser(Number(userId), {
+        ...form,
+        properties,
+      });
       toast.success("저장되었습니다.");
     } catch {
       toast.error("저장에 실패했습니다.");
@@ -291,6 +308,20 @@ export function UserDetailPage() {
             </Stack>
           </Grid>
         </Grid>
+      </Container>
+      <Container maxWidth="md" disableGutters>
+        <Accordion disableGutters>
+          <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
+            프로퍼티
+          </AccordionSummary>
+          <AccordionDetails>
+            <PropertiesEditor
+              value={properties}
+              onChange={setProperties}
+              disabled={saving}
+            />
+          </AccordionDetails>
+        </Accordion>
       </Container>
       <UserRolesDialog
         open={rolesOpen}

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
   Accordion,
@@ -15,7 +15,6 @@ import {
   CircularProgress,
   Alert,
   Container,
-  Typography,
 } from "@mui/material";
 import {
   AddOutlined,
@@ -34,7 +33,10 @@ import type { UserDto } from "@/types/studio/user";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
 import { API_BASE_URL } from "@/config/backend";
 import NO_AVATAR from "@/assets/images/users/no-avatar.png";
-import { PropertiesEditor } from "@/react/components/properties/PropertiesEditor";
+import {
+  PropertiesEditor,
+  type PropertiesEditorHandle,
+} from "@/react/components/properties/PropertiesEditor";
 
 export function UserDetailPage() {
   const { userId } = useParams<{ userId: string }>();
@@ -49,6 +51,7 @@ export function UserDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [rolesOpen, setRolesOpen] = useState(false);
   const [resetOpen, setResetOpen] = useState(false);
+  const propertiesEditorRef = useRef<PropertiesEditorHandle | null>(null);
   const [form, setForm] = useState({
     name: "",
     email: "",
@@ -148,23 +151,6 @@ export function UserDetailPage() {
       setSaving(false);
     }
   }
-
-  const handleAddPropertyRow = useCallback(() => {
-    setProperties((current) => {
-      const nextKey = `new_property_${Object.keys(current).length + 1}`;
-      if (!(nextKey in current)) {
-        return { ...current, [nextKey]: "" };
-      }
-
-      let index = 1;
-      let candidate = `${nextKey}_${index}`;
-      while (candidate in current) {
-        index += 1;
-        candidate = `${nextKey}_${index}`;
-      }
-      return { ...current, [candidate]: "" };
-    });
-  }, []);
 
   if (loading)
     return (
@@ -342,7 +328,7 @@ export function UserDetailPage() {
                   size="small"
                   variant="outlined"
                   startIcon={<AddOutlined />}
-                  onClick={handleAddPropertyRow}
+                  onClick={() => propertiesEditorRef.current?.addRow()}
                   disabled={saving}
                 >
                   행 추가
@@ -350,10 +336,10 @@ export function UserDetailPage() {
               }
             />
             <PropertiesEditor
+              ref={propertiesEditorRef}
               value={properties}
               onChange={setProperties}
               disabled={saving}
-              hideDefaultAddAction
             />
           </AccordionDetails>
         </Accordion>

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -397,7 +397,7 @@ export function UserDetailPage() {
                     onClick={() => void handleSaveProperties()}
                     disabled={propertiesBusy || !propertiesChanged}
                   >
-                    {propertiesSaving ? <CircularProgress size={16} /> : "프로퍼티 저장"}
+                    {propertiesSaving ? <CircularProgress size={16} /> : "저장"}
                   </Button>
                 </Stack>
               }

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -119,6 +119,18 @@ export function UserDetailPage() {
     loadUser();
   }, [loadUser]);
 
+  useEffect(() => {
+    if (!propertiesExpanded) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      propertiesSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 120);
+
+    return () => window.clearTimeout(timer);
+  }, [propertiesExpanded]);
+
   async function handleSave() {
     if (!userId) return;
     setSaving(true);
@@ -194,15 +206,7 @@ export function UserDetailPage() {
   }
 
   const handleSectionChange = useCallback(() => {
-    setPropertiesExpanded((current) => {
-      const next = !current;
-      if (next) {
-        window.setTimeout(() => {
-          propertiesSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-        }, 0);
-      }
-      return next;
-    });
+    setPropertiesExpanded((current) => !current);
   }, []);
 
   if (loading) {

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -194,8 +194,13 @@ export function UserDetailPage() {
   }
 
   const handleSectionChange = useCallback(() => {
-    setPropertiesExpanded(true);
-    propertiesSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    setPropertiesExpanded((current) => {
+      const next = !current;
+      if (next) {
+        propertiesSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+      return next;
+    });
   }, []);
 
   if (loading) {

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -378,7 +378,13 @@ export function UserDetailPage() {
           </Grid>
         </Grid>
       </Container>
-      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", xl: "minmax(0, 1fr) 180px" }, gap: 3 }}>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", lg: "minmax(0, 1fr) 200px" },
+          gap: { xs: 0, lg: 3 },
+        }}
+      >
         <Container maxWidth="md" disableGutters>
         <Accordion
           disableGutters
@@ -431,7 +437,7 @@ export function UserDetailPage() {
         <Box
           component="aside"
           sx={{
-            display: { xs: "none", xl: "block" },
+            display: { xs: "none", lg: "block" },
             position: "sticky",
             top: 16,
             alignSelf: "start",
@@ -441,7 +447,7 @@ export function UserDetailPage() {
             py: 1,
           }}
         >
-          <Typography variant="caption" color="text.secondary" fontWeight={700}>
+          <Typography variant="caption" color="text.secondary" fontWeight={700} sx={{ letterSpacing: 0.2 }}>
             Contents
           </Typography>
           <Stack spacing={0.5} sx={{ mt: 1 }}>

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -18,6 +18,7 @@ import {
   Typography,
 } from "@mui/material";
 import {
+  AddOutlined,
   DeleteOutlined,
   ExpandMoreOutlined,
   KeyOutlined,
@@ -340,6 +341,7 @@ export function UserDetailPage() {
                 <Button
                   size="small"
                   variant="outlined"
+                  startIcon={<AddOutlined />}
                   onClick={handleAddPropertyRow}
                   disabled={saving}
                 >
@@ -351,7 +353,7 @@ export function UserDetailPage() {
               value={properties}
               onChange={setProperties}
               disabled={saving}
-              actions={null}
+              hideDefaultAddAction
             />
           </AccordionDetails>
         </Accordion>

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -52,6 +52,7 @@ export function UserDetailPage() {
   const [rolesOpen, setRolesOpen] = useState(false);
   const [resetOpen, setResetOpen] = useState(false);
   const propertiesEditorRef = useRef<PropertiesEditorHandle | null>(null);
+  const [propertiesResetKey, setPropertiesResetKey] = useState(0);
   const [form, setForm] = useState({
     name: "",
     email: "",
@@ -83,6 +84,7 @@ export function UserDetailPage() {
             ])
           )
         );
+        setPropertiesResetKey((current) => current + 1);
         const presence = await reactUsersApi
           .checkAvatarPresence(Number(userId))
           .catch(() => null);
@@ -340,6 +342,7 @@ export function UserDetailPage() {
               value={properties}
               onChange={setProperties}
               disabled={saving}
+              resetKey={propertiesResetKey}
             />
           </AccordionDetails>
         </Accordion>

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -226,158 +226,6 @@ export function UserDetailPage() {
         onPrevious={() => navigate("/admin/users")}
         onRefresh={loadUser}
       />
-      <Container maxWidth="md" disableGutters>
-        <Grid container spacing={1} alignItems="center">
-          <Grid size={12} sx={{ mb: 5 }}>
-            <Stack direction="row" spacing={2} alignItems="center">
-              <Avatar
-                alt={user.username}
-                src={avatarImageId ? avatarUrl : NO_AVATAR}
-                imgProps={{
-                  onError: (event) => {
-                    event.currentTarget.src = NO_AVATAR;
-                  },
-                }}
-                sx={{ width: 120, height: 120, bgcolor: "grey.200" }}
-              />
-              <Stack direction="row" spacing={1}>
-                <Button
-                  component="label"
-                  variant="outlined"
-                  startIcon={<UploadOutlined />}
-                  disabled={saving}
-                >
-                  아바타 업로드
-                  <input
-                    hidden
-                    accept="image/*"
-                    type="file"
-                    onChange={(event) => {
-                      const file = event.target.files?.[0];
-                      void handleAvatarUpload(file);
-                      event.currentTarget.value = "";
-                    }}
-                  />
-                </Button>
-                <Button
-                  variant="outlined"
-                  color="error"
-                  startIcon={<DeleteOutlined />}
-                  disabled={saving || !avatarImageId}
-                  onClick={() => void handleAvatarDelete()}
-                >
-                  아바타 삭제
-                </Button>
-              </Stack>
-            </Stack>
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <TextField
-              label="아이디"
-              value={user.username}
-              InputProps={{ readOnly: true }}
-              size="small"
-              fullWidth
-            />
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <TextField
-              label="이름"
-              value={form.name}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, name: event.target.value }))
-              }
-              size="small"
-              fullWidth
-            />
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <TextField
-              label="이메일"
-              value={form.email}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, email: event.target.value }))
-              }
-              size="small"
-              fullWidth
-            />
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={form.emailVisble}
-                  onChange={(event) =>
-                    setForm((current) => ({
-                      ...current,
-                      emailVisble: event.target.checked,
-                    }))
-                  }
-                />
-              }
-              label="이메일 공개"
-            />
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={form.nameVisible}
-                  onChange={(event) =>
-                    setForm((current) => ({
-                      ...current,
-                      nameVisible: event.target.checked,
-                    }))
-                  }
-                />
-              }
-              label="이름 공개"
-            />
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={form.enabled}
-                  onChange={(event) =>
-                    setForm((current) => ({
-                      ...current,
-                      enabled: event.target.checked,
-                    }))
-                  }
-                />
-              }
-              label="계정 활성화"
-            />
-          </Grid>
-          <Grid size={12} sx={{ mt: 10 }}>
-            <Stack direction="row" spacing={1} justifyContent="flex-end">
-              <Button
-                variant="outlined"
-                startIcon={<ManageAccountsOutlined />}
-                onClick={() => setRolesOpen(true)}
-              >
-                역할 관리
-              </Button>
-              <Button
-                variant="outlined"
-                startIcon={<KeyOutlined />}
-                onClick={() => setResetOpen(true)}
-              >
-                비밀번호 재설정
-              </Button>
-              <Button
-                variant="outlined"
-                startIcon={<SaveOutlined />}
-                onClick={handleSave}
-                disabled={saving}
-              >
-                {saving ? <CircularProgress size={20} /> : "저장"}
-              </Button>
-            </Stack>
-          </Grid>
-        </Grid>
-      </Container>
       <Box
         sx={{
           display: "grid",
@@ -385,55 +233,209 @@ export function UserDetailPage() {
           gap: { xs: 0, lg: 3 },
         }}
       >
-        <Container maxWidth="md" disableGutters>
-        <Accordion
-          disableGutters
-          expanded={propertiesExpanded}
-          onChange={(_, expanded) => setPropertiesExpanded(expanded)}
-          ref={propertiesSectionRef}
-          sx={{ scrollMarginTop: 56 }}
-        >
-          <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
-            프로퍼티
-          </AccordionSummary>
-          <AccordionDetails>
-            <PageToolbar
-              divider={false}
-              label="사용자에 대한 추가 속성을 관리합니다."
-              actions={
-                <Stack direction="row" spacing={1}>
+        <Stack spacing={2}>
+          <Container maxWidth="md" disableGutters>
+            <Grid container spacing={1} alignItems="center">
+              <Grid size={12} sx={{ mb: 5 }}>
+                <Stack direction="row" spacing={2} alignItems="center">
+                  <Avatar
+                    alt={user.username}
+                    src={avatarImageId ? avatarUrl : NO_AVATAR}
+                    imgProps={{
+                      onError: (event) => {
+                        event.currentTarget.src = NO_AVATAR;
+                      },
+                    }}
+                    sx={{ width: 120, height: 120, bgcolor: "grey.200" }}
+                  />
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      component="label"
+                      variant="outlined"
+                      startIcon={<UploadOutlined />}
+                      disabled={saving}
+                    >
+                      아바타 업로드
+                      <input
+                        hidden
+                        accept="image/*"
+                        type="file"
+                        onChange={(event) => {
+                          const file = event.target.files?.[0];
+                          void handleAvatarUpload(file);
+                          event.currentTarget.value = "";
+                        }}
+                      />
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      color="error"
+                      startIcon={<DeleteOutlined />}
+                      disabled={saving || !avatarImageId}
+                      onClick={() => void handleAvatarDelete()}
+                    >
+                      아바타 삭제
+                    </Button>
+                  </Stack>
+                </Stack>
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <TextField
+                  label="아이디"
+                  value={user.username}
+                  InputProps={{ readOnly: true }}
+                  size="small"
+                  fullWidth
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <TextField
+                  label="이름"
+                  value={form.name}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, name: event.target.value }))
+                  }
+                  size="small"
+                  fullWidth
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <TextField
+                  label="이메일"
+                  value={form.email}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, email: event.target.value }))
+                  }
+                  size="small"
+                  fullWidth
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={form.emailVisble}
+                      onChange={(event) =>
+                        setForm((current) => ({
+                          ...current,
+                          emailVisble: event.target.checked,
+                        }))
+                      }
+                    />
+                  }
+                  label="이메일 공개"
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={form.nameVisible}
+                      onChange={(event) =>
+                        setForm((current) => ({
+                          ...current,
+                          nameVisible: event.target.checked,
+                        }))
+                      }
+                    />
+                  }
+                  label="이름 공개"
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={form.enabled}
+                      onChange={(event) =>
+                        setForm((current) => ({
+                          ...current,
+                          enabled: event.target.checked,
+                        }))
+                      }
+                    />
+                  }
+                  label="계정 활성화"
+                />
+              </Grid>
+              <Grid size={12} sx={{ mt: 10 }}>
+                <Stack direction="row" spacing={1} justifyContent="flex-end">
                   <Button
-                    size="small"
                     variant="outlined"
-                    startIcon={<AddOutlined />}
-                    onClick={() => propertiesEditorRef.current?.addRow()}
-                    disabled={propertiesBusy}
+                    startIcon={<ManageAccountsOutlined />}
+                    onClick={() => setRolesOpen(true)}
                   >
-                    행 추가
+                    역할 관리
                   </Button>
                   <Button
-                    size="small"
+                    variant="outlined"
+                    startIcon={<KeyOutlined />}
+                    onClick={() => setResetOpen(true)}
+                  >
+                    비밀번호 재설정
+                  </Button>
+                  <Button
                     variant="outlined"
                     startIcon={<SaveOutlined />}
-                    onClick={() => void handleSaveProperties()}
-                    disabled={propertiesBusy || !propertiesChanged}
+                    onClick={handleSave}
+                    disabled={saving}
                   >
-                    {propertiesSaving ? <CircularProgress size={16} /> : "저장"}
+                    {saving ? <CircularProgress size={20} /> : "저장"}
                   </Button>
                 </Stack>
-              }
-            />
-            <PropertiesEditor
-              ref={propertiesEditorRef}
-              value={draftProperties}
-              onChange={setDraftProperties}
-              type="users"
-              disabled={propertiesBusy}
-              resetKey={propertiesResetKey}
-            />
-          </AccordionDetails>
-        </Accordion>
-      </Container>
+              </Grid>
+            </Grid>
+          </Container>
+          <Container maxWidth="md" disableGutters>
+            <Accordion
+              disableGutters
+              expanded={propertiesExpanded}
+              onChange={(_, expanded) => setPropertiesExpanded(expanded)}
+              ref={propertiesSectionRef}
+              sx={{ scrollMarginTop: 56 }}
+            >
+              <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
+                프로퍼티
+              </AccordionSummary>
+              <AccordionDetails>
+                <PageToolbar
+                  divider={false}
+                  label="사용자에 대한 추가 속성을 관리합니다."
+                  actions={
+                    <Stack direction="row" spacing={1}>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<AddOutlined />}
+                        onClick={() => propertiesEditorRef.current?.addRow()}
+                        disabled={propertiesBusy}
+                      >
+                        행 추가
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<SaveOutlined />}
+                        onClick={() => void handleSaveProperties()}
+                        disabled={propertiesBusy || !propertiesChanged}
+                      >
+                        {propertiesSaving ? <CircularProgress size={16} /> : "저장"}
+                      </Button>
+                    </Stack>
+                  }
+                />
+                <PropertiesEditor
+                  ref={propertiesEditorRef}
+                  value={draftProperties}
+                  onChange={setDraftProperties}
+                  type="users"
+                  disabled={propertiesBusy}
+                  resetKey={propertiesResetKey}
+                />
+              </AccordionDetails>
+            </Accordion>
+          </Container>
+        </Stack>
         <Box
           component="aside"
           sx={{

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -148,6 +148,23 @@ export function UserDetailPage() {
     }
   }
 
+  const handleAddPropertyRow = useCallback(() => {
+    setProperties((current) => {
+      const nextKey = `new_property_${Object.keys(current).length + 1}`;
+      if (!(nextKey in current)) {
+        return { ...current, [nextKey]: "" };
+      }
+
+      let index = 1;
+      let candidate = `${nextKey}_${index}`;
+      while (candidate in current) {
+        index += 1;
+        candidate = `${nextKey}_${index}`;
+      }
+      return { ...current, [candidate]: "" };
+    });
+  }, []);
+
   if (loading)
     return (
       <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
@@ -316,13 +333,25 @@ export function UserDetailPage() {
             프로퍼티
           </AccordionSummary>
           <AccordionDetails>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-              사용자에 대한 추가 속성을 관리합니다.
-            </Typography>
+            <PageToolbar
+              divider={false}
+              label="사용자에 대한 추가 속성을 관리합니다."
+              actions={
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={handleAddPropertyRow}
+                  disabled={saving}
+                >
+                  행 추가
+                </Button>
+              }
+            />
             <PropertiesEditor
               value={properties}
               onChange={setProperties}
               disabled={saving}
+              actions={null}
             />
           </AccordionDetails>
         </Accordion>

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   CircularProgress,
   Alert,
   Container,
+  Typography,
 } from "@mui/material";
 import {
   DeleteOutlined,
@@ -315,6 +316,9 @@ export function UserDetailPage() {
             프로퍼티
           </AccordionSummary>
           <AccordionDetails>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+              사용자에 대한 추가 속성을 관리합니다.
+            </Typography>
             <PropertiesEditor
               value={properties}
               onChange={setProperties}

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -102,12 +102,14 @@ export function UserDetailPage() {
 
   async function handleSave() {
     if (!userId) return;
+    const nextProperties = propertiesEditorRef.current?.getValue() ?? properties;
     setSaving(true);
     try {
       await reactUsersApi.updateUser(Number(userId), {
         ...form,
-        properties,
+        properties: nextProperties,
       });
+      setProperties(nextProperties);
       toast.success("저장되었습니다.");
     } catch {
       toast.error("저장에 실패했습니다.");
@@ -340,7 +342,7 @@ export function UserDetailPage() {
             <PropertiesEditor
               ref={propertiesEditorRef}
               value={properties}
-              onChange={setProperties}
+              onChange={() => {}}
               disabled={saving}
               resetKey={propertiesResetKey}
             />

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   Stack,
   Switch,
   TextField,
+  Typography,
 } from "@mui/material";
 import {
   AddOutlined,
@@ -55,7 +56,9 @@ export function UserDetailPage() {
   const [rolesOpen, setRolesOpen] = useState(false);
   const [resetOpen, setResetOpen] = useState(false);
   const propertiesEditorRef = useRef<PropertiesEditorHandle | null>(null);
+  const propertiesSectionRef = useRef<HTMLDivElement | null>(null);
   const [propertiesResetKey, setPropertiesResetKey] = useState(0);
+  const [propertiesExpanded, setPropertiesExpanded] = useState(false);
   const [form, setForm] = useState({
     name: "",
     email: "",
@@ -189,6 +192,11 @@ export function UserDetailPage() {
       setSaving(false);
     }
   }
+
+  const handleSectionChange = useCallback(() => {
+    setPropertiesExpanded(true);
+    propertiesSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
 
   if (loading) {
     return (
@@ -370,8 +378,15 @@ export function UserDetailPage() {
           </Grid>
         </Grid>
       </Container>
-      <Container maxWidth="md" disableGutters>
-        <Accordion disableGutters>
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", xl: "minmax(0, 1fr) 180px" }, gap: 3 }}>
+        <Container maxWidth="md" disableGutters>
+        <Accordion
+          disableGutters
+          expanded={propertiesExpanded}
+          onChange={(_, expanded) => setPropertiesExpanded(expanded)}
+          ref={propertiesSectionRef}
+          sx={{ scrollMarginTop: 56 }}
+        >
           <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
             프로퍼티
           </AccordionSummary>
@@ -413,6 +428,41 @@ export function UserDetailPage() {
           </AccordionDetails>
         </Accordion>
       </Container>
+        <Box
+          component="aside"
+          sx={{
+            display: { xs: "none", xl: "block" },
+            position: "sticky",
+            top: 16,
+            alignSelf: "start",
+            borderLeft: "1px solid",
+            borderColor: "divider",
+            pl: 2,
+            py: 1,
+          }}
+        >
+          <Typography variant="caption" color="text.secondary" fontWeight={700}>
+            Contents
+          </Typography>
+          <Stack spacing={0.5} sx={{ mt: 1 }}>
+            <Button
+              size="small"
+              variant="text"
+              sx={{
+                justifyContent: "flex-start",
+                color: propertiesExpanded ? "primary.main" : "text.secondary",
+                fontWeight: propertiesExpanded ? 700 : 400,
+                borderLeft: propertiesExpanded ? "2px solid" : "2px solid transparent",
+                borderColor: propertiesExpanded ? "primary.main" : "transparent",
+                pl: 1,
+              }}
+              onClick={handleSectionChange}
+            >
+              프로퍼티
+            </Button>
+          </Stack>
+        </Box>
+      </Box>
       <UserRolesDialog
         open={rolesOpen}
         onClose={() => setRolesOpen(false)}

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -394,53 +394,53 @@ export function UserDetailPage() {
             </Grid>
           </Container>
           <Container maxWidth="md" disableGutters>
-            <Accordion
-              disableGutters
-              expanded={propertiesExpanded}
-              onChange={(_, expanded) => setPropertiesExpanded(expanded)}
-              ref={propertiesSectionRef}
-              sx={{ scrollMarginTop: 56 }}
-            >
-              <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
-                프로퍼티
-              </AccordionSummary>
-              <AccordionDetails>
-                <PageToolbar
-                  divider={false}
-                  label="사용자에 대한 추가 속성을 관리합니다."
-                  actions={
-                    <Stack direction="row" spacing={1}>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        startIcon={<AddOutlined />}
-                        onClick={() => propertiesEditorRef.current?.addRow()}
-                        disabled={propertiesBusy}
-                      >
-                        행 추가
-                      </Button>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        startIcon={<SaveOutlined />}
-                        onClick={() => void handleSaveProperties()}
-                        disabled={propertiesBusy || !propertiesChanged}
-                      >
-                        {propertiesSaving ? <CircularProgress size={16} /> : "저장"}
-                      </Button>
-                    </Stack>
-                  }
-                />
-                <PropertiesEditor
-                  ref={propertiesEditorRef}
-                  value={draftProperties}
-                  onChange={setDraftProperties}
-                  type="users"
-                  disabled={propertiesBusy}
-                  resetKey={propertiesResetKey}
-                />
-              </AccordionDetails>
-            </Accordion>
+            <Box ref={propertiesSectionRef} sx={{ scrollMarginTop: 56 }}>
+              <Accordion
+                disableGutters
+                expanded={propertiesExpanded}
+                onChange={(_, expanded) => setPropertiesExpanded(expanded)}
+              >
+                <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
+                  프로퍼티
+                </AccordionSummary>
+                <AccordionDetails>
+                  <PageToolbar
+                    divider={false}
+                    label="사용자에 대한 추가 속성을 관리합니다."
+                    actions={
+                      <Stack direction="row" spacing={1}>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<AddOutlined />}
+                          onClick={() => propertiesEditorRef.current?.addRow()}
+                          disabled={propertiesBusy}
+                        >
+                          행 추가
+                        </Button>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<SaveOutlined />}
+                          onClick={() => void handleSaveProperties()}
+                          disabled={propertiesBusy || !propertiesChanged}
+                        >
+                          {propertiesSaving ? <CircularProgress size={16} /> : "저장"}
+                        </Button>
+                      </Stack>
+                    }
+                  />
+                  <PropertiesEditor
+                    ref={propertiesEditorRef}
+                    value={draftProperties}
+                    onChange={setDraftProperties}
+                    type="users"
+                    disabled={propertiesBusy}
+                    resetKey={propertiesResetKey}
+                  />
+                </AccordionDetails>
+              </Accordion>
+            </Box>
           </Container>
         </Stack>
         <Box

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -1,20 +1,20 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Alert,
   Avatar,
   Box,
-  Stack,
   Button,
-  Grid,
-  TextField,
-  FormControlLabel,
-  Switch,
   CircularProgress,
-  Alert,
   Container,
+  FormControlLabel,
+  Grid,
+  Stack,
+  Switch,
+  TextField,
 } from "@mui/material";
 import {
   AddOutlined,
@@ -25,18 +25,20 @@ import {
   SaveOutlined,
   UploadOutlined,
 } from "@mui/icons-material";
-import { useConfirm, useToast } from "@/react/feedback";
-import { reactUsersApi } from "./api";
-import { UserRolesDialog } from "./UserRolesDialog";
-import { PasswordResetDialog } from "./PasswordResetDialog";
-import type { UserDto } from "@/types/studio/user";
-import { PageToolbar } from "@/react/components/page/PageToolbar";
 import { API_BASE_URL } from "@/config/backend";
 import NO_AVATAR from "@/assets/images/users/no-avatar.png";
+import { getProperties, replaceProperties } from "@/react/api/properties";
+import { PageToolbar } from "@/react/components/page/PageToolbar";
 import {
   PropertiesEditor,
   type PropertiesEditorHandle,
 } from "@/react/components/properties/PropertiesEditor";
+import { useConfirm, useToast } from "@/react/feedback";
+import { diffProperties, normalizeProperties } from "@/react/utils/propertyKeys";
+import type { UserDto } from "@/types/studio/user";
+import { PasswordResetDialog } from "./PasswordResetDialog";
+import { reactUsersApi } from "./api";
+import { UserRolesDialog } from "./UserRolesDialog";
 
 export function UserDetailPage() {
   const { userId } = useParams<{ userId: string }>();
@@ -48,6 +50,7 @@ export function UserDetailPage() {
   const [avatarVersion, setAvatarVersion] = useState(0);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [propertiesSaving, setPropertiesSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [rolesOpen, setRolesOpen] = useState(false);
   const [resetOpen, setResetOpen] = useState(false);
@@ -60,31 +63,44 @@ export function UserDetailPage() {
     nameVisible: true,
     enabled: true,
   });
-  const [properties, setProperties] = useState<Record<string, string>>({});
+  const [initialProperties, setInitialProperties] = useState<Record<string, string>>({});
+  const [draftProperties, setDraftProperties] = useState<Record<string, string>>({});
 
   const loadUser = useCallback(() => {
     if (!userId) return;
     setLoading(true);
-    reactUsersApi
-      .getUser(Number(userId))
-      .then(async (u) => {
-        setUser(u);
+
+    Promise.allSettled([
+      reactUsersApi.getUser(Number(userId)),
+      getProperties("users", Number(userId)),
+    ])
+      .then(async ([userResult, propertiesResult]) => {
+        if (userResult.status !== "fulfilled") {
+          throw userResult.reason;
+        }
+
+        const nextUser = userResult.value;
+        setUser(nextUser);
         setForm({
-          name: u.name,
-          email: u.email ?? "",
-          emailVisble: u.emailVisble,
-          nameVisible: u.nameVisible,
-          enabled: u.enabled,
+          name: nextUser.name,
+          email: nextUser.email ?? "",
+          emailVisble: nextUser.emailVisble,
+          nameVisible: nextUser.nameVisible,
+          enabled: nextUser.enabled,
         });
-        setProperties(
-          Object.fromEntries(
-            Object.entries(u.properties ?? {}).map(([key, value]) => [
-              key,
-              value == null ? "" : String(value),
-            ])
-          )
-        );
+
+        const nextProperties =
+          propertiesResult.status === "fulfilled"
+            ? normalizeProperties(propertiesResult.value)
+            : {};
+        if (propertiesResult.status !== "fulfilled") {
+          toast.error("프로퍼티를 불러오지 못했습니다.");
+        }
+
+        setInitialProperties(nextProperties);
+        setDraftProperties(nextProperties);
         setPropertiesResetKey((current) => current + 1);
+
         const presence = await reactUsersApi
           .checkAvatarPresence(Number(userId))
           .catch(() => null);
@@ -94,7 +110,7 @@ export function UserDetailPage() {
       })
       .catch(() => setError("사용자를 불러오지 못했습니다."))
       .finally(() => setLoading(false));
-  }, [userId]);
+  }, [toast, userId]);
 
   useEffect(() => {
     loadUser();
@@ -102,19 +118,37 @@ export function UserDetailPage() {
 
   async function handleSave() {
     if (!userId) return;
-    const nextProperties = propertiesEditorRef.current?.getValue() ?? properties;
     setSaving(true);
     try {
-      await reactUsersApi.updateUser(Number(userId), {
-        ...form,
-        properties: nextProperties,
-      });
-      setProperties(nextProperties);
+      await reactUsersApi.updateUser(Number(userId), form);
       toast.success("저장되었습니다.");
     } catch {
       toast.error("저장에 실패했습니다.");
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleSaveProperties() {
+    if (!userId) return;
+    if (propertiesEditorRef.current?.hasErrors()) {
+      toast.error("프로퍼티 키 오류를 먼저 수정해 주세요.");
+      return;
+    }
+
+    setPropertiesSaving(true);
+    try {
+      const nextProperties = propertiesEditorRef.current?.getValue() ?? draftProperties;
+      const saved = await replaceProperties("users", Number(userId), nextProperties);
+      const normalized = normalizeProperties(saved);
+      setInitialProperties(normalized);
+      setDraftProperties(normalized);
+      setPropertiesResetKey((current) => current + 1);
+      toast.success("프로퍼티가 저장되었습니다.");
+    } catch {
+      toast.error("프로퍼티 저장에 실패했습니다.");
+    } finally {
+      setPropertiesSaving(false);
     }
   }
 
@@ -156,16 +190,23 @@ export function UserDetailPage() {
     }
   }
 
-  if (loading)
+  if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
         <CircularProgress />
       </Box>
     );
+  }
   if (error) return <Alert severity="error">{error}</Alert>;
   if (!user) return null;
 
   const avatarUrl = `${API_BASE_URL}/api/profile/${encodeURIComponent(user.username)}/avatar?v=${avatarVersion}`;
+  const propertiesDiff = diffProperties(initialProperties, draftProperties);
+  const propertiesChanged =
+    Object.keys(propertiesDiff.added).length > 0 ||
+    Object.keys(propertiesDiff.updated).length > 0 ||
+    propertiesDiff.removed.length > 0;
+  const propertiesBusy = saving || propertiesSaving;
 
   return (
     <Stack spacing={2}>
@@ -235,7 +276,9 @@ export function UserDetailPage() {
             <TextField
               label="이름"
               value={form.name}
-              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, name: event.target.value }))
+              }
               size="small"
               fullWidth
             />
@@ -244,8 +287,8 @@ export function UserDetailPage() {
             <TextField
               label="이메일"
               value={form.email}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, email: e.target.value }))
+              onChange={(event) =>
+                setForm((current) => ({ ...current, email: event.target.value }))
               }
               size="small"
               fullWidth
@@ -256,8 +299,11 @@ export function UserDetailPage() {
               control={
                 <Switch
                   checked={form.emailVisble}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, emailVisble: e.target.checked }))
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      emailVisble: event.target.checked,
+                    }))
                   }
                 />
               }
@@ -269,8 +315,11 @@ export function UserDetailPage() {
               control={
                 <Switch
                   checked={form.nameVisible}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, nameVisible: e.target.checked }))
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      nameVisible: event.target.checked,
+                    }))
                   }
                 />
               }
@@ -282,8 +331,11 @@ export function UserDetailPage() {
               control={
                 <Switch
                   checked={form.enabled}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, enabled: e.target.checked }))
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      enabled: event.target.checked,
+                    }))
                   }
                 />
               }
@@ -328,22 +380,34 @@ export function UserDetailPage() {
               divider={false}
               label="사용자에 대한 추가 속성을 관리합니다."
               actions={
-                <Button
-                  size="small"
-                  variant="outlined"
-                  startIcon={<AddOutlined />}
-                  onClick={() => propertiesEditorRef.current?.addRow()}
-                  disabled={saving}
-                >
-                  행 추가
-                </Button>
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={<AddOutlined />}
+                    onClick={() => propertiesEditorRef.current?.addRow()}
+                    disabled={propertiesBusy}
+                  >
+                    행 추가
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={<SaveOutlined />}
+                    onClick={() => void handleSaveProperties()}
+                    disabled={propertiesBusy || !propertiesChanged}
+                  >
+                    {propertiesSaving ? <CircularProgress size={16} /> : "프로퍼티 저장"}
+                  </Button>
+                </Stack>
               }
             />
             <PropertiesEditor
               ref={propertiesEditorRef}
-              value={properties}
-              onChange={() => {}}
-              disabled={saving}
+              value={draftProperties}
+              onChange={setDraftProperties}
+              type="users"
+              disabled={propertiesBusy}
               resetKey={propertiesResetKey}
             />
           </AccordionDetails>

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -197,7 +197,9 @@ export function UserDetailPage() {
     setPropertiesExpanded((current) => {
       const next = !current;
       if (next) {
-        propertiesSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+        window.setTimeout(() => {
+          propertiesSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+        }, 0);
       }
       return next;
     });

--- a/src/react/utils/propertyKeys.ts
+++ b/src/react/utils/propertyKeys.ts
@@ -1,0 +1,71 @@
+import type { PropertyOwnerType } from "@/react/api/properties";
+
+export const RESERVED_PREFIXES = [
+  "security.",
+  "auth.",
+  "role.",
+  "admin.",
+  "permission.",
+] as const;
+
+export const KEY_PATTERN = /^[A-Za-z0-9_.-]{1,100}$/;
+
+export function normalizeProperties(
+  value: Record<string, string | null | undefined> | null | undefined
+) {
+  return Object.fromEntries(
+    Object.entries(value ?? {}).map(([key, currentValue]) => [
+      key,
+      currentValue == null ? "" : String(currentValue),
+    ])
+  ) as Record<string, string>;
+}
+
+export function validatePropertyKey(
+  key: string,
+  type: PropertyOwnerType
+): string | null {
+  const normalizedKey = key.trim();
+
+  if (!normalizedKey) {
+    return "키를 입력해 주세요.";
+  }
+
+  if (!KEY_PATTERN.test(normalizedKey)) {
+    return "키는 영문자, 숫자, _, ., - 만 사용하고 100자 이하여야 합니다.";
+  }
+
+  if (type === "users" && RESERVED_PREFIXES.some((prefix) => normalizedKey.startsWith(prefix))) {
+    return `'${normalizedKey}'는 예약된 prefix를 사용할 수 없습니다.`;
+  }
+
+  return null;
+}
+
+export function diffProperties(
+  initial: Record<string, string>,
+  draft: Record<string, string>
+) {
+  const added: Record<string, string> = {};
+  const updated: Record<string, string> = {};
+  const removed: string[] = [];
+
+  Object.entries(draft).forEach(([key, value]) => {
+    if (!(key in initial)) {
+      added[key] = value;
+      return;
+    }
+
+    if (initial[key] !== value) {
+      updated[key] = value;
+    }
+  });
+
+  Object.keys(initial).forEach((key) => {
+    if (!(key in draft)) {
+      removed.push(key);
+    }
+  });
+
+  return { added, updated, removed };
+}


### PR DESCRIPTION
## Why
- 기존 Vue 사용자 상세에는 properties 편집 기능이 있었지만, 현재 React 사용자 상세에는 누락되어 있었습니다.
- 서버에 User/Group 전용 Properties API가 추가되어, 기본 정보 저장과 properties 저장을 분리하는 편이 구조적으로 맞게 되었습니다.
- 향후 그룹/권한 화면에서도 재사용할 수 있도록 공용 AG Grid 기반 properties 편집기가 필요했습니다.

## What
- 공용 AG Grid 기반 `PropertiesEditor`를 추가/재구성했습니다.
- 공용 properties API (`getProperties`, `replaceProperties`)와 key validation 유틸을 추가했습니다.
- `UserDetailPage`에 아코디언 기반 `프로퍼티` 섹션을 추가했습니다.
- 사용자 상세는 이제:
  - 기본 정보 저장: 기존 `reactUsersApi.updateUser(...)`
  - 프로퍼티 저장: `PUT /api/mgmt/users/{id}/properties`
  로 분리됩니다.
- 프로퍼티 편집은 key/value 행 추가, 수정, 삭제를 지원하고, 빈 key/중복 key/형식 오류/예약 prefix를 검증합니다.
- `CHANGELOG.md`에 `#89` 변경/검증 기록을 추가했습니다.

## Related Issues
- Closes #89
- Related #66

## Change Scope
- [x] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 프로퍼티 저장이 기본 정보 저장과 분리되고, 전용 API로 전환되므로 잘못 매핑하면 기존 값 손실 가능성이 있습니다.
- Mitigation: 조회/저장을 전용 Properties API로 명확히 분리하고, key 검증과 전체 교체 저장 흐름을 기준으로 구현했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - 모두 통과
  - `lint`는 기존 warning 16개 유지
  - `build`는 기존 Vite chunk warning 유지
- Additional checks:
  - 사용자 상세 properties 아코디언, AG Grid 편집, 전용 저장 흐름을 코드 기준으로 검토했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks:
- Ownership (files/modules/tasks):
- Main author post-integration validation:

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert 또는 `PropertiesEditor`, properties API wrapper, `UserDetailPage` 연결만 되돌리면 됩니다.
- Post-deploy checks: `/admin/users/:userId`에서 properties 조회, 행 추가/수정/삭제, key 검증, `프로퍼티 저장` 후 재조회 동작을 확인합니다.
