### PR TITLE
[ai-assisted] refactor(group): add properties accordion editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Issue `#91` restores group detail properties editing with the shared accordion-based AG Grid editor and dedicated group properties API.
 - Issue `#89` restores user detail properties editing with a reusable accordion-based AG Grid editor backed by the dedicated user properties API.
 - Issue `#87` improves role detail user/group assignment dialogs with search-driven multi-select assign/revoke flows and current assignment grids.
 - Issue `#85` standardized dialog shell rounding and footer action button variants across create/edit and admin management dialogs.
@@ -12,6 +13,10 @@
 
 ### Verification
 
+- Issue `#91`: `npm run typecheck`
+- Issue `#91`: `npm run lint`
+- Issue `#91`: `npm run build`
+- Issue `#91`: manual check - group detail properties accordion, save flow, and side nav reviewed in code
 - Issue `#89`: `npm run typecheck`
 - Issue `#89`: `npm run lint`
 - Issue `#89`: `npm run build`

--- a/src/react/pages/admin/groups/GroupDetailPage.tsx
+++ b/src/react/pages/admin/groups/GroupDetailPage.tsx
@@ -1,52 +1,106 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Alert,
   Box,
   Button,
   CircularProgress,
   Container,
   Grid,
-  TextField,
   Stack,
+  TextField,
+  Typography,
 } from "@mui/material";
-import { GroupAddOutlined, ManageAccountsOutlined, SaveOutlined } from "@mui/icons-material";
+import {
+  AddOutlined,
+  ExpandMoreOutlined,
+  GroupAddOutlined,
+  ManageAccountsOutlined,
+  SaveOutlined,
+} from "@mui/icons-material";
+import { getProperties, replaceProperties } from "@/react/api/properties";
 import { useToast } from "@/react/feedback";
+import { PageToolbar } from "@/react/components/page/PageToolbar";
+import {
+  PropertiesEditor,
+  type PropertiesEditorHandle,
+} from "@/react/components/properties/PropertiesEditor";
+import { diffProperties, normalizeProperties } from "@/react/utils/propertyKeys";
 import { reactGroupsApi } from "./api";
 import { GroupMembershipDialog } from "./GroupMembershipDialog";
 import { GroupRolesDialog } from "./GroupRolesDialog";
 import type { GroupDto } from "@/react/pages/admin/datasource";
-import { PageToolbar } from "@/react/components/page/PageToolbar";
 
 export function GroupDetailPage() {
   const { groupId } = useParams<{ groupId: string }>();
   const navigate = useNavigate();
   const toast = useToast();
+  const propertiesEditorRef = useRef<PropertiesEditorHandle | null>(null);
   const [group, setGroup] = useState<GroupDto | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [propertiesSaving, setPropertiesSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [membersOpen, setMembersOpen] = useState(false);
   const [rolesOpen, setRolesOpen] = useState(false);
+  const [propertiesExpanded, setPropertiesExpanded] = useState(false);
+  const [propertiesResetKey, setPropertiesResetKey] = useState(0);
+  const propertiesSectionRef = useRef<HTMLDivElement | null>(null);
   const [form, setForm] = useState({ name: "", description: "" });
+  const [initialProperties, setInitialProperties] = useState<Record<string, string>>({});
+  const [draftProperties, setDraftProperties] = useState<Record<string, string>>({});
 
   const loadGroup = useCallback(() => {
     if (!groupId) return;
     setLoading(true);
-    reactGroupsApi
-      .getGroup(Number(groupId))
-      .then((g) => {
-        setGroup(g);
-        setForm({ name: g.name, description: g.description ?? "" });
+    Promise.allSettled([
+      reactGroupsApi.getGroup(Number(groupId)),
+      getProperties("groups", Number(groupId)),
+    ])
+      .then(([groupResult, propertiesResult]) => {
+        if (groupResult.status !== "fulfilled") {
+          throw groupResult.reason;
+        }
+
+        const nextGroup = groupResult.value;
+        setGroup(nextGroup);
+        setForm({ name: nextGroup.name, description: nextGroup.description ?? "" });
+
+        const nextProperties =
+          propertiesResult.status === "fulfilled"
+            ? normalizeProperties(propertiesResult.value)
+            : {};
+        if (propertiesResult.status !== "fulfilled") {
+          toast.error("프로퍼티를 불러오지 못했습니다.");
+        }
+
+        setInitialProperties(nextProperties);
+        setDraftProperties(nextProperties);
+        setPropertiesResetKey((current) => current + 1);
         setError(null);
       })
       .catch(() => setError("그룹을 불러오지 못했습니다."))
       .finally(() => setLoading(false));
-  }, [groupId]);
+  }, [groupId, toast]);
 
   useEffect(() => {
     loadGroup();
   }, [loadGroup]);
+
+  useEffect(() => {
+    if (!propertiesExpanded || !propertiesSectionRef.current) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      propertiesSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 120);
+
+    return () => window.clearTimeout(timer);
+  }, [propertiesExpanded]);
 
   async function handleSave() {
     if (!groupId) return;
@@ -61,6 +115,33 @@ export function GroupDetailPage() {
     }
   }
 
+  async function handleSaveProperties() {
+    if (!groupId) return;
+    if (propertiesEditorRef.current?.hasErrors()) {
+      toast.error("프로퍼티 키 오류를 먼저 수정해 주세요.");
+      return;
+    }
+
+    setPropertiesSaving(true);
+    try {
+      const nextProperties = propertiesEditorRef.current?.getValue() ?? draftProperties;
+      const saved = await replaceProperties("groups", Number(groupId), nextProperties);
+      const normalized = normalizeProperties(saved);
+      setInitialProperties(normalized);
+      setDraftProperties(normalized);
+      setPropertiesResetKey((current) => current + 1);
+      toast.success("프로퍼티가 저장되었습니다.");
+    } catch {
+      toast.error("프로퍼티 저장에 실패했습니다.");
+    } finally {
+      setPropertiesSaving(false);
+    }
+  }
+
+  const handleSectionChange = useCallback(() => {
+    setPropertiesExpanded((current) => !current);
+  }, []);
+
   if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
@@ -70,6 +151,13 @@ export function GroupDetailPage() {
   }
   if (error) return <Alert severity="error">{error}</Alert>;
   if (!group) return null;
+
+  const propertiesDiff = diffProperties(initialProperties, draftProperties);
+  const propertiesChanged =
+    Object.keys(propertiesDiff.added).length > 0 ||
+    Object.keys(propertiesDiff.updated).length > 0 ||
+    propertiesDiff.removed.length > 0;
+  const propertiesBusy = saving || propertiesSaving;
 
   return (
     <Stack spacing={2}>
@@ -81,58 +169,151 @@ export function GroupDetailPage() {
         onPrevious={() => navigate("/admin/groups")}
         onRefresh={loadGroup}
       />
-      <Container maxWidth="md" disableGutters>
-        <Grid container spacing={1} alignItems="center">
-          <Grid size={{ xs: 12, md: 6 }}>
-            <TextField
-              label="그룹명"
-              value={form.name}
-              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", lg: "minmax(0, 1fr) 200px" },
+          gap: { xs: 0, lg: 3 },
+        }}
+      >
+        <Stack spacing={2}>
+          <Container maxWidth="md" disableGutters>
+            <Grid container spacing={1} alignItems="center">
+              <Grid size={{ xs: 12, md: 6 }}>
+                <TextField
+                  label="그룹명"
+                  value={form.name}
+                  onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+                  size="small"
+                  fullWidth
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <TextField
+                  label="설명"
+                  value={form.description}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, description: event.target.value }))
+                  }
+                  size="small"
+                  multiline
+                  rows={2}
+                  fullWidth
+                />
+              </Grid>
+              <Grid size={12} sx={{ mt: 2 }}>
+                <Stack direction="row" spacing={1} justifyContent="flex-end">
+                  <Button
+                    variant="outlined"
+                    startIcon={<GroupAddOutlined />}
+                    onClick={() => setMembersOpen(true)}
+                  >
+                    멤버 관리
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    startIcon={<ManageAccountsOutlined />}
+                    onClick={() => setRolesOpen(true)}
+                  >
+                    역할 관리
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    startIcon={<SaveOutlined />}
+                    onClick={handleSave}
+                    disabled={saving}
+                  >
+                    {saving ? <CircularProgress size={20} /> : "저장"}
+                  </Button>
+                </Stack>
+              </Grid>
+            </Grid>
+          </Container>
+          <Container maxWidth="md" disableGutters>
+            <Box ref={propertiesSectionRef} sx={{ scrollMarginTop: 56 }}>
+              <Accordion
+                disableGutters
+                expanded={propertiesExpanded}
+                onChange={(_, expanded) => setPropertiesExpanded(expanded)}
+              >
+                <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
+                  프로퍼티
+                </AccordionSummary>
+                <AccordionDetails>
+                  <PageToolbar
+                    divider={false}
+                    label="그룹에 대한 추가 속성을 관리합니다."
+                    actions={
+                      <Stack direction="row" spacing={1}>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<AddOutlined />}
+                          onClick={() => propertiesEditorRef.current?.addRow()}
+                          disabled={propertiesBusy}
+                        >
+                          행 추가
+                        </Button>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<SaveOutlined />}
+                          onClick={() => void handleSaveProperties()}
+                          disabled={propertiesBusy || !propertiesChanged}
+                        >
+                          {propertiesSaving ? <CircularProgress size={16} /> : "저장"}
+                        </Button>
+                      </Stack>
+                    }
+                  />
+                  <PropertiesEditor
+                    ref={propertiesEditorRef}
+                    value={draftProperties}
+                    onChange={setDraftProperties}
+                    type="groups"
+                    disabled={propertiesBusy}
+                    resetKey={propertiesResetKey}
+                  />
+                </AccordionDetails>
+              </Accordion>
+            </Box>
+          </Container>
+        </Stack>
+        <Box
+          component="aside"
+          sx={{
+            display: { xs: "none", lg: "block" },
+            position: "sticky",
+            top: 16,
+            alignSelf: "start",
+            borderLeft: "1px solid",
+            borderColor: "divider",
+            pl: 2,
+            py: 1,
+          }}
+        >
+          <Typography variant="caption" color="text.secondary" fontWeight={700}>
+            Contents
+          </Typography>
+          <Stack spacing={0.5} sx={{ mt: 1 }}>
+            <Button
               size="small"
-              fullWidth
-            />
-          </Grid>
-          <Grid size={{ xs: 12, md: 6 }}>
-            <TextField
-              label="설명"
-              value={form.description}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, description: event.target.value }))
-              }
-              size="small"
-              multiline
-              rows={2}
-              fullWidth
-            />
-          </Grid>
-          <Grid size={12} sx={{ mt: 2 }}>
-            <Stack direction="row" spacing={1} justifyContent="flex-end">
-              <Button
-                variant="outlined"
-                startIcon={<GroupAddOutlined />}
-                onClick={() => setMembersOpen(true)}
-              >
-                멤버 관리
-              </Button>
-              <Button
-                variant="outlined"
-                startIcon={<ManageAccountsOutlined />}
-                onClick={() => setRolesOpen(true)}
-              >
-                역할 관리
-              </Button>
-              <Button
-                variant="outlined"
-                startIcon={<SaveOutlined />}
-                onClick={handleSave}
-                disabled={saving}
-              >
-                {saving ? <CircularProgress size={20} /> : "저장"}
-              </Button>
-            </Stack>
-          </Grid>
-        </Grid>
-      </Container>
+              variant="text"
+              sx={{
+                justifyContent: "flex-start",
+                color: propertiesExpanded ? "primary.main" : "text.secondary",
+                fontWeight: propertiesExpanded ? 700 : 400,
+                borderLeft: propertiesExpanded ? "2px solid" : "2px solid transparent",
+                borderColor: propertiesExpanded ? "primary.main" : "transparent",
+                pl: 1,
+              }}
+              onClick={handleSectionChange}
+            >
+              프로퍼티
+            </Button>
+          </Stack>
+        </Box>
+      </Box>
       <GroupMembershipDialog
         open={membersOpen}
         onClose={() => setMembersOpen(false)}

--- a/src/react/pages/admin/groups/GroupDetailPage.tsx
+++ b/src/react/pages/admin/groups/GroupDetailPage.tsx
@@ -244,26 +244,15 @@ export function GroupDetailPage() {
                     divider={false}
                     label="그룹에 대한 추가 속성을 관리합니다."
                     actions={
-                      <Stack direction="row" spacing={1}>
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          startIcon={<AddOutlined />}
-                          onClick={() => propertiesEditorRef.current?.addRow()}
-                          disabled={propertiesBusy}
-                        >
-                          행 추가
-                        </Button>
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          startIcon={<SaveOutlined />}
-                          onClick={() => void handleSaveProperties()}
-                          disabled={propertiesBusy || !propertiesChanged}
-                        >
-                          {propertiesSaving ? <CircularProgress size={16} /> : "저장"}
-                        </Button>
-                      </Stack>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<AddOutlined />}
+                        onClick={() => propertiesEditorRef.current?.addRow()}
+                        disabled={propertiesBusy}
+                      >
+                        행 추가
+                      </Button>
                     }
                   />
                   <PropertiesEditor
@@ -274,6 +263,17 @@ export function GroupDetailPage() {
                     disabled={propertiesBusy}
                     resetKey={propertiesResetKey}
                   />
+                  <Stack direction="row" spacing={1} justifyContent="flex-end" sx={{ mt: 1.5 }}>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<SaveOutlined />}
+                      onClick={() => void handleSaveProperties()}
+                      disabled={propertiesBusy || !propertiesChanged}
+                    >
+                      {propertiesSaving ? <CircularProgress size={16} /> : "저장"}
+                    </Button>
+                  </Stack>
                 </AccordionDetails>
               </Accordion>
             </Box>

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -412,26 +412,15 @@ export function UserDetailPage() {
                     divider={false}
                     label="사용자에 대한 추가 속성을 관리합니다."
                     actions={
-                      <Stack direction="row" spacing={1}>
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          startIcon={<AddOutlined />}
-                          onClick={() => propertiesEditorRef.current?.addRow()}
-                          disabled={propertiesBusy}
-                        >
-                          행 추가
-                        </Button>
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          startIcon={<SaveOutlined />}
-                          onClick={() => void handleSaveProperties()}
-                          disabled={propertiesBusy || !propertiesChanged}
-                        >
-                          {propertiesSaving ? <CircularProgress size={16} /> : "저장"}
-                        </Button>
-                      </Stack>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<AddOutlined />}
+                        onClick={() => propertiesEditorRef.current?.addRow()}
+                        disabled={propertiesBusy}
+                      >
+                        행 추가
+                      </Button>
                     }
                   />
                   <PropertiesEditor
@@ -442,6 +431,17 @@ export function UserDetailPage() {
                     disabled={propertiesBusy}
                     resetKey={propertiesResetKey}
                   />
+                  <Stack direction="row" spacing={1} justifyContent="flex-end" sx={{ mt: 1.5 }}>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<SaveOutlined />}
+                      onClick={() => void handleSaveProperties()}
+                      disabled={propertiesBusy || !propertiesChanged}
+                    >
+                      {propertiesSaving ? <CircularProgress size={16} /> : "저장"}
+                    </Button>
+                  </Stack>
                 </AccordionDetails>
               </Accordion>
             </Box>


### PR DESCRIPTION
## Why
- 기존 Vue 그룹 상세에는 properties 편집 기능이 있었지만, 현재 React 그룹 상세에는 누락되어 있었습니다.
- 사용자 상세에서 이미 도입한 공용 AG Grid 기반 properties 편집기와 전용 Properties API 패턴을 그룹 상세에도 동일하게 적용할 필요가 있었습니다.

## What
- `GroupDetailPage`에 아코디언 기반 `프로퍼티` 섹션을 추가했습니다.
- 그룹 상세는 이제:
  - 기본 정보 저장: 기존 `reactGroupsApi.updateGroup(...)`
  - 프로퍼티 저장: `PUT /api/mgmt/groups/{id}/properties`
  로 분리됩니다.
- 사용자 상세에서 만든 공용 `PropertiesEditor`를 그룹 상세에 재사용했습니다.
- 그룹 프로퍼티 조회는 `GET /api/mgmt/groups/{id}/properties`로 연결했습니다.
- 우측 `Contents -> 프로퍼티` 메뉴를 추가해 클릭 시 아코디언이 토글되고, 펼칠 때 해당 위치로 이동하도록 했습니다.
- `CHANGELOG.md`에 `#91` 변경/검증 기록을 추가했습니다.

## Related Issues
- Closes #91
- Related #89

## Change Scope
- [x] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 그룹 기본 정보 저장과 프로퍼티 저장을 분리하면서 그룹 properties 조회/저장 경로가 새로 연결되므로, 잘못 매핑하면 값 손실 가능성이 있습니다.
- Mitigation: 사용자 상세에서 이미 검증한 공용 editor와 properties API 패턴을 재사용했고, typecheck/lint/build로 검증했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - 모두 통과
  - `lint`는 기존 warning 16개 유지
  - `build`는 기존 Vite chunk warning 유지
- Additional checks:
  - 그룹 상세 properties 아코디언, 별도 저장 흐름, 우측 메뉴 토글/이동 동작을 코드 기준으로 검토했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks:
- Ownership (files/modules/tasks):
- Main author post-integration validation:

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert 또는 `GroupDetailPage` 연결과 changelog 변경만 되돌리면 됩니다.
- Post-deploy checks: `/admin/groups/:groupId`에서 properties 조회, 행 추가/수정/삭제, `저장` 후 재조회, 우측 `프로퍼티` 메뉴 동작을 확인합니다.
