### PR TITLE
[ai-assisted] refactor(role): simplify group assignment dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Issue `#93` simplifies the role detail group assignment dialog to a transfer-list style flow for smaller group sets.
+- Issue `#93` prevents stale role group assignment state from remaining after load failures and disables transfer actions while loading or saving.
 - Issue `#91` restores group detail properties editing with the shared accordion-based AG Grid editor and dedicated group properties API.
 - Issue `#89` restores user detail properties editing with a reusable accordion-based AG Grid editor backed by the dedicated user properties API.
 - Issue `#87` improves role detail user/group assignment dialogs with search-driven multi-select assign/revoke flows and current assignment grids.
@@ -18,6 +19,8 @@
 - Issue `#93`: `npm run lint`
 - Issue `#93`: `npm run build`
 - Issue `#93`: manual check - role group assignment transfer-list flow reviewed in code
+- Issue `#93`: review fix - stale role group assignment state is cleared and save/transfer actions are guarded during load/save
+- Issue `#93` review fix: `npm run typecheck`
 - Issue `#91`: `npm run typecheck`
 - Issue `#91`: `npm run lint`
 - Issue `#91`: `npm run build`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Issue `#93` simplifies the role detail group assignment dialog to a transfer-list style flow for smaller group sets.
 - Issue `#91` restores group detail properties editing with the shared accordion-based AG Grid editor and dedicated group properties API.
 - Issue `#89` restores user detail properties editing with a reusable accordion-based AG Grid editor backed by the dedicated user properties API.
 - Issue `#87` improves role detail user/group assignment dialogs with search-driven multi-select assign/revoke flows and current assignment grids.
@@ -13,6 +14,10 @@
 
 ### Verification
 
+- Issue `#93`: `npm run typecheck`
+- Issue `#93`: `npm run lint`
+- Issue `#93`: `npm run build`
+- Issue `#93`: manual check - role group assignment transfer-list flow reviewed in code
 - Issue `#91`: `npm run typecheck`
 - Issue `#91`: `npm run lint`
 - Issue `#91`: `npm run build`

--- a/src/react/pages/admin/roles/RoleGrantedGroupsDialog.tsx
+++ b/src/react/pages/admin/roles/RoleGrantedGroupsDialog.tsx
@@ -1,25 +1,25 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Alert,
-  Box,
   Button,
+  Card,
+  CardContent,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
+  List,
+  ListItemButton,
+  ListItemText,
   Skeleton,
   Stack,
   TextField,
   Typography,
 } from "@mui/material";
-import { SearchOutlined } from "@mui/icons-material";
-import type { ColDef, SelectionChangedEvent } from "ag-grid-community";
+import { ArrowBackOutlined, ArrowForwardOutlined } from "@mui/icons-material";
 import type { GroupDto } from "@/react/pages/admin/datasource";
-import { PageableGridContent } from "@/react/components/ag-grid";
-import type {
-  AgGridCompatibleDataSource,
-  PageableGridContentHandle,
-} from "@/react/components/ag-grid/types";
 import { useConfirm, useToast } from "@/react/feedback";
 import { reactRolesApi, type GrantedGroupDto } from "./api";
 
@@ -30,364 +30,202 @@ interface Props {
   roleName: string;
 }
 
-const GRID_HEIGHT = 240;
+const TRANSFER_SECTION_MIN_HEIGHT = 300;
+const GROUP_LIST_MAX_HEIGHT = 220;
 
-class CandidateGroupsDataSource implements AgGridCompatibleDataSource<GroupDto> {
-  isLoaded = false;
-  loading = false;
-  error: unknown = null;
-  dataItems: GroupDto[] = [];
-  total = 0;
-  pageSize = 15;
-  page = 0;
-  private q = "";
+type TransferGroup = {
+  groupId: number;
+  name: string;
+  description?: string | null;
+  memberCount?: number;
+};
 
-  setPage(page: number) {
-    this.page = page;
-  }
-
-  setPageSize(size: number) {
-    this.pageSize = size;
-  }
-
-  setSort() {}
-
-  setSearch(q?: string) {
-    this.q = (q ?? "").trim();
-  }
-
-  setFilter(q?: string) {
-    this.setSearch(q);
-  }
-
-  applyFilter(filter?: Record<string, unknown>) {
-    this.q = String(filter?.q ?? "").trim();
-  }
-
-  async fetch() {
-    this.loading = true;
-    try {
-      const response = await reactRolesApi.searchGroups({
-        q: this.q || undefined,
-        page: this.page,
-        size: this.pageSize,
-      });
-      this.dataItems = response.content ?? [];
-      this.total = response.totalElements ?? 0;
-      this.isLoaded = true;
-    } finally {
-      this.loading = false;
-    }
-  }
-
-  async fetchForAgGrid({
-    startRow,
-    endRow,
-  }: {
-    startRow: number;
-    endRow: number;
-  }) {
-    const size = endRow - startRow || this.pageSize;
-    const page = Math.floor(startRow / size);
-    const response = await reactRolesApi.searchGroups({
-      q: this.q || undefined,
-      page,
-      size,
-    });
-
-    return {
-      rows: response.content ?? [],
-      total: response.totalElements ?? 0,
-    };
-  }
+function byName(left: { name: string }, right: { name: string }) {
+  return left.name.localeCompare(right.name);
 }
 
-class GrantedGroupsDataSource implements AgGridCompatibleDataSource<GrantedGroupDto> {
-  isLoaded = false;
-  loading = false;
-  error: unknown = null;
-  dataItems: GrantedGroupDto[] = [];
-  total = 0;
-  pageSize = 15;
-  page = 0;
-
-  constructor(
-    private readonly groups: GrantedGroupDto[],
-    private readonly q: string
-  ) {}
-
-  setPage(page: number) {
-    this.page = page;
-  }
-
-  setPageSize(size: number) {
-    this.pageSize = size;
-  }
-
-  setSort() {}
-  setSearch() {}
-  setFilter() {}
-  applyFilter() {}
-
-  private filterGroups() {
-    const keyword = this.q.trim().toLowerCase();
-    if (!keyword) {
-      return this.groups;
-    }
-
-    return this.groups.filter((group) =>
-      [group.name, group.description]
-        .filter((value): value is string => typeof value === "string")
-        .some((value) => value.toLowerCase().includes(keyword))
-    );
-  }
-
-  async fetch() {
-    const filtered = this.filterGroups();
-    const start = this.page * this.pageSize;
-    const end = start + this.pageSize;
-    this.dataItems = filtered.slice(start, end);
-    this.total = filtered.length;
-    this.isLoaded = true;
-  }
-
-  async fetchForAgGrid({
-    startRow,
-    endRow,
-  }: {
-    startRow: number;
-    endRow: number;
-  }) {
-    const filtered = this.filterGroups();
-    return {
-      rows: filtered.slice(startRow, endRow),
-      total: filtered.length,
-    };
-  }
-}
-
-function GroupsGridSkeleton() {
+function GroupsListSkeleton({ rows = 4 }: { rows?: number }) {
   return (
     <Stack spacing={1}>
-      {Array.from({ length: 5 }).map((_, index) => (
-        <Skeleton key={index} variant="rounded" height={40} />
-      ))}
+      <Skeleton variant="rounded" height={40} />
+      <Divider />
+      <Stack spacing={0.75}>
+        {Array.from({ length: rows }).map((_, index) => (
+          <Skeleton key={index} variant="rounded" height={48} />
+        ))}
+      </Stack>
     </Stack>
   );
 }
 
-export function RoleGrantedGroupsDialog({
-  open,
-  onClose,
-  roleId,
-  roleName,
-}: Props) {
+function toTransferGroup(group: GroupDto | GrantedGroupDto): TransferGroup {
+  return {
+    groupId: group.groupId,
+    name: group.name,
+    description: group.description,
+    memberCount: group.memberCount,
+  };
+}
+
+function sameIds(left: TransferGroup[], right: TransferGroup[]) {
+  const leftIds = left.map((group) => group.groupId).sort((a, b) => a - b);
+  const rightIds = right.map((group) => group.groupId).sort((a, b) => a - b);
+  return (
+    leftIds.length === rightIds.length &&
+    leftIds.every((groupId, index) => groupId === rightIds[index])
+  );
+}
+
+export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Props) {
   const toast = useToast();
   const confirm = useConfirm();
-  const candidatesGridRef = useRef<PageableGridContentHandle<GroupDto>>(null);
-  const grantedGridRef = useRef<PageableGridContentHandle<GrantedGroupDto>>(null);
-  const candidatesDataSource = useMemo(() => new CandidateGroupsDataSource(), []);
-  const [grantedGroups, setGrantedGroups] = useState<GrantedGroupDto[]>([]);
-  const [loadingGranted, setLoadingGranted] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [candidateSearchInput, setCandidateSearchInput] = useState("");
-  const [grantedSearchInput, setGrantedSearchInput] = useState("");
-  const [candidateGridKey, setCandidateGridKey] = useState(0);
-  const [grantedGridKey, setGrantedGridKey] = useState(0);
-  const [hasSearchedCandidates, setHasSearchedCandidates] = useState(false);
-  const [selectedCandidateCount, setSelectedCandidateCount] = useState(0);
-  const [selectedGrantedCount, setSelectedGrantedCount] = useState(0);
+  const [allGroups, setAllGroups] = useState<TransferGroup[]>([]);
+  const [grantedGroups, setGrantedGroups] = useState<TransferGroup[]>([]);
+  const [initialGrantedGroups, setInitialGrantedGroups] = useState<TransferGroup[]>([]);
+  const [selectedLeft, setSelectedLeft] = useState<number[]>([]);
+  const [selectedRight, setSelectedRight] = useState<number[]>([]);
+  const [searchLeft, setSearchLeft] = useState("");
+  const [searchRight, setSearchRight] = useState("");
+
+  async function loadData() {
+    setLoading(true);
+    try {
+      const [groupsResponse, grantedResponse] = await Promise.all([
+        reactRolesApi.searchGroups({ page: 0, size: 200 }),
+        reactRolesApi.getGrantedGroups(roleId),
+      ]);
+      const groups = (groupsResponse.content ?? []).map(toTransferGroup).sort(byName);
+      const granted = (Array.isArray(grantedResponse) ? grantedResponse : [])
+        .map((group) => {
+          const groupDetail = groups.find((candidate) => candidate.groupId === group.groupId);
+          return {
+            ...toTransferGroup(group),
+            description: group.description ?? groupDetail?.description,
+            memberCount: group.memberCount ?? groupDetail?.memberCount,
+          };
+        })
+        .sort(byName);
+
+      setAllGroups(groups);
+      setGrantedGroups(granted);
+      setInitialGrantedGroups(granted);
+      setSelectedLeft([]);
+      setSelectedRight([]);
+      setSearchLeft("");
+      setSearchRight("");
+    } catch {
+      toast.error("그룹 권한 목록 로딩 실패");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (open) {
+      void loadData();
+    }
+  }, [open, roleId]);
 
   const grantedGroupIds = useMemo(
     () => new Set(grantedGroups.map((group) => group.groupId)),
     [grantedGroups]
   );
 
-  const grantedDataSource = useMemo(
-    () => new GrantedGroupsDataSource(grantedGroups, grantedSearchInput),
-    [grantedGroups, grantedSearchInput]
+  const availableGroups = useMemo(
+    () =>
+      allGroups
+        .filter((group) => !grantedGroupIds.has(group.groupId))
+        .filter((group) => {
+          const keyword = searchLeft.trim().toLowerCase();
+          if (!keyword) return true;
+          return (
+            group.name.toLowerCase().includes(keyword) ||
+            String(group.groupId).includes(keyword) ||
+            (group.description ?? "").toLowerCase().includes(keyword)
+          );
+        }),
+    [allGroups, grantedGroupIds, searchLeft]
   );
 
-  const groupColumns = useMemo<ColDef<GroupDto | GrantedGroupDto>[]>(
-    () => [
-      { field: "name", headerName: "이름", flex: 0.8, filter: false, sortable: false },
-      {
-        field: "description",
-        headerName: "설명",
-        flex: 1.1,
-        filter: false,
-        sortable: false,
-        valueGetter: (params) => params.data?.description ?? "",
-      },
-      {
-        field: "memberCount",
-        headerName: "멤버",
-        width: 90,
-        maxWidth: 90,
-        filter: false,
-        sortable: false,
-        valueGetter: (params) => params.data?.memberCount ?? "",
-        cellStyle: { textAlign: "center" },
-      },
-    ],
-    []
+  const filteredGrantedGroups = useMemo(
+    () =>
+      grantedGroups.filter((group) => {
+        const keyword = searchRight.trim().toLowerCase();
+        if (!keyword) return true;
+        return (
+          group.name.toLowerCase().includes(keyword) ||
+          String(group.groupId).includes(keyword) ||
+          (group.description ?? "").toLowerCase().includes(keyword)
+        );
+      }),
+    [grantedGroups, searchRight]
   );
 
-  const candidateEvents = useMemo(
-    () => [
-      {
-        type: "selectionChanged",
-        listener: (event: SelectionChangedEvent<GroupDto>) =>
-          setSelectedCandidateCount(event.api.getSelectedRows().length ?? 0),
-      },
-    ],
-    []
-  );
-
-  const grantedEvents = useMemo(
-    () => [
-      {
-        type: "selectionChanged",
-        listener: (event: SelectionChangedEvent<GrantedGroupDto>) =>
-          setSelectedGrantedCount(event.api.getSelectedRows().length ?? 0),
-      },
-    ],
-    []
-  );
-
-  const resetSelection = useCallback(() => {
-    setSelectedCandidateCount(0);
-    setSelectedGrantedCount(0);
-    candidatesGridRef.current?.deselectAll();
-    grantedGridRef.current?.deselectAll();
-  }, []);
-
-  const loadGrantedGroups = useCallback(async () => {
-    setLoadingGranted(true);
-    try {
-      const data = await reactRolesApi.getGrantedGroups(roleId);
-      setGrantedGroups(Array.isArray(data) ? data : []);
-      setGrantedGridKey((current) => current + 1);
-    } catch {
-      toast.error("부여된 그룹 목록 로딩 실패");
-    } finally {
-      setLoadingGranted(false);
-    }
-  }, [roleId, toast]);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    setCandidateSearchInput("");
-    setGrantedSearchInput("");
-    setHasSearchedCandidates(false);
-    setCandidateGridKey(0);
-    resetSelection();
-    void loadGrantedGroups();
-  }, [open, loadGrantedGroups, resetSelection]);
-
-  const handleCandidateSearch = useCallback(() => {
-    const trimmed = candidateSearchInput.trim();
-    if (!trimmed) {
-      candidatesDataSource.applyFilter({});
-      setHasSearchedCandidates(false);
-      setSelectedCandidateCount(0);
-      setCandidateGridKey((current) => current + 1);
-      return;
-    }
-
-    candidatesDataSource.applyFilter({ q: trimmed });
-    setHasSearchedCandidates(true);
-    setSelectedCandidateCount(0);
-    setCandidateGridKey((current) => current + 1);
-  }, [candidateSearchInput, candidatesDataSource]);
-
-  const handleGrantedSearch = useCallback(() => {
-    setSelectedGrantedCount(0);
-    setGrantedGridKey((current) => current + 1);
-  }, []);
-
-  async function handleAssign() {
-    const selectedGroups = candidatesGridRef.current?.selectedRows() ?? [];
-    const groupIds = Array.from(
-      new Set(
-        selectedGroups
-          .map((group) => group.groupId)
-          .filter(
-            (groupId): groupId is number =>
-              typeof groupId === "number" && !grantedGroupIds.has(groupId)
-          )
-      )
+  function toggleSelected(
+    selected: number[],
+    setter: (value: number[]) => void,
+    groupId: number
+  ) {
+    setter(
+      selected.includes(groupId)
+        ? selected.filter((value) => value !== groupId)
+        : [...selected, groupId]
     );
-
-    if (groupIds.length === 0) {
-      toast.info("부여할 그룹이 없습니다.");
-      return;
-    }
-
-    const ok = await confirm({
-      title: "권한 부여 확인",
-      message: `선택된 그룹 ${groupIds.length}곳에 "${roleName}" 권한을 부여하시겠습니까?`,
-      okText: "확인",
-      cancelText: "취소",
-    });
-    if (!ok) {
-      return;
-    }
-
-    setSaving(true);
-    try {
-      await reactRolesApi.assignGroups(roleId, groupIds);
-      toast.success(`${groupIds.length}개 그룹에 권한을 부여했습니다.`);
-      resetSelection();
-      await loadGrantedGroups();
-      if (hasSearchedCandidates) {
-        setCandidateGridKey((current) => current + 1);
-      }
-    } catch {
-      toast.error("그룹 권한 부여에 실패했습니다.");
-    } finally {
-      setSaving(false);
-    }
   }
 
-  async function handleRevoke() {
-    const selectedGroups = grantedGridRef.current?.selectedRows() ?? [];
-    const groupIds = Array.from(
-      new Set(
-        selectedGroups
-          .map((group) => group.groupId)
-          .filter((groupId): groupId is number => typeof groupId === "number")
-      )
-    );
+  function moveToGranted() {
+    const nextGroups = allGroups.filter((group) => selectedLeft.includes(group.groupId));
 
-    if (groupIds.length === 0) {
+    setGrantedGroups((current) =>
+      [...current, ...nextGroups]
+        .filter(
+          (group, index, groups) =>
+            groups.findIndex((candidate) => candidate.groupId === group.groupId) === index
+        )
+        .sort(byName)
+    );
+    setSelectedLeft([]);
+  }
+
+  function moveToAvailable() {
+    setGrantedGroups((current) =>
+      current.filter((group) => !selectedRight.includes(group.groupId))
+    );
+    setSelectedRight([]);
+  }
+
+  async function handleSave() {
+    if (sameIds(initialGrantedGroups, grantedGroups)) {
+      toast.info("변경된 그룹 권한이 없습니다.");
+      onClose();
       return;
     }
+
+    const initialIds = new Set(initialGrantedGroups.map((group) => group.groupId));
+    const currentIds = new Set(grantedGroups.map((group) => group.groupId));
+    const toAdd = grantedGroups.filter((group) => !initialIds.has(group.groupId));
+    const toRemove = initialGrantedGroups.filter((group) => !currentIds.has(group.groupId));
 
     const ok = await confirm({
-      title: "권한 회수 확인",
-      message: `선택된 그룹 ${groupIds.length}곳에서 "${roleName}" 권한을 회수하시겠습니까?`,
-      okText: "확인",
+      title: "그룹 권한 변경 저장",
+      message: `그룹 ${toAdd.length}곳에 권한을 부여하고, ${toRemove.length}곳에서 권한을 회수하시겠습니까?`,
+      okText: "저장",
       cancelText: "취소",
     });
-    if (!ok) {
-      return;
-    }
+    if (!ok) return;
 
     setSaving(true);
     try {
-      await reactRolesApi.revokeGroups(roleId, groupIds);
-      toast.success(`${groupIds.length}개 그룹의 권한을 회수했습니다.`);
-      resetSelection();
-      await loadGrantedGroups();
-      if (hasSearchedCandidates) {
-        setCandidateGridKey((current) => current + 1);
-      }
+      await Promise.all([
+        reactRolesApi.assignGroups(roleId, toAdd.map((group) => group.groupId)),
+        reactRolesApi.revokeGroups(roleId, toRemove.map((group) => group.groupId)),
+      ]);
+      toast.success("그룹 권한이 저장되었습니다.");
+      onClose();
     } catch {
-      toast.error("그룹 권한 회수에 실패했습니다.");
+      toast.error("그룹 권한 저장에 실패했습니다.");
     } finally {
       setSaving(false);
     }
@@ -397,7 +235,7 @@ export function RoleGrantedGroupsDialog({
     <Dialog
       open={open}
       onClose={saving ? undefined : onClose}
-      maxWidth="lg"
+      maxWidth="md"
       fullWidth
       slotProps={{ paper: { sx: { borderRadius: 3 } } }}
     >
@@ -405,129 +243,130 @@ export function RoleGrantedGroupsDialog({
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
           <Alert severity="info">
-            검색 결과에서 그룹을 선택해 현재 역할을 부여하고, 아래 목록에서 현재 권한이 부여된 그룹을 선택해 회수할 수 있습니다.
+            그룹에 현재 역할을 부여하거나 회수합니다. 변경 내용은 저장 시점에 반영됩니다.
           </Alert>
 
-          <Stack spacing={1}>
-            <Typography variant="subtitle2">권한 부여 대상 그룹 검색</Typography>
-            <TextField
-              label="이름, 설명 검색"
-              size="small"
-              value={candidateSearchInput}
-              onChange={(event) => setCandidateSearchInput(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  handleCandidateSearch();
-                }
-              }}
-              fullWidth
-              slotProps={{
-                input: {
-                  endAdornment: (
-                    <Button
-                      size="small"
-                      variant="text"
-                      startIcon={<SearchOutlined />}
-                      onClick={handleCandidateSearch}
-                    >
-                      검색
-                    </Button>
-                  ),
-                },
-              }}
-            />
-            {hasSearchedCandidates ? (
-              <PageableGridContent<GroupDto>
-                key={candidateGridKey}
-                ref={candidatesGridRef}
-                datasource={candidatesDataSource}
-                columns={groupColumns as ColDef<GroupDto>[]}
-                events={candidateEvents}
-                rowSelection="multiple"
-                height={GRID_HEIGHT}
-              />
-            ) : (
-              <Box
-                sx={{
-                  height: GRID_HEIGHT,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  border: "1px solid",
-                  borderColor: "divider",
-                }}
-              >
-                <Typography variant="body2" color="text.secondary">
-                  검색어를 입력한 뒤 검색을 실행하면 결과가 표시됩니다.
-                </Typography>
-              </Box>
-            )}
-          </Stack>
+          <Stack direction={{ xs: "column", md: "row" }} spacing={2} alignItems="stretch">
+            <Card variant="outlined" sx={{ flex: 1, minWidth: 0 }}>
+              <CardContent>
+                <Stack spacing={1} sx={{ minHeight: TRANSFER_SECTION_MIN_HEIGHT }}>
+                  <Typography variant="subtitle2">부여 가능한 그룹</Typography>
+                  {loading ? (
+                    <GroupsListSkeleton />
+                  ) : (
+                    <>
+                      <TextField
+                        label="그룹 검색"
+                        size="small"
+                        value={searchLeft}
+                        onChange={(event) => setSearchLeft(event.target.value)}
+                        fullWidth
+                      />
+                      <Divider />
+                      {availableGroups.length === 0 ? (
+                        <Typography color="text.secondary" variant="body2">
+                          선택 가능한 그룹 없음
+                        </Typography>
+                      ) : (
+                        <List dense sx={{ maxHeight: GROUP_LIST_MAX_HEIGHT, overflowY: "auto" }}>
+                          {availableGroups.map((group) => (
+                            <ListItemButton
+                              key={group.groupId}
+                              selected={selectedLeft.includes(group.groupId)}
+                              onClick={() =>
+                                toggleSelected(selectedLeft, setSelectedLeft, group.groupId)
+                              }
+                            >
+                              <ListItemText
+                                primary={group.name}
+                                secondary={`ID: ${group.groupId}${group.description ? ` · ${group.description}` : ""}`}
+                              />
+                            </ListItemButton>
+                          ))}
+                        </List>
+                      )}
+                    </>
+                  )}
+                </Stack>
+              </CardContent>
+            </Card>
 
-          <Stack spacing={1}>
-            <Typography variant="subtitle2">현재 권한이 부여된 그룹</Typography>
-            <TextField
-              label="현재 부여 그룹 검색"
-              size="small"
-              value={grantedSearchInput}
-              onChange={(event) => setGrantedSearchInput(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  handleGrantedSearch();
-                }
-              }}
-              fullWidth
-              slotProps={{
-                input: {
-                  endAdornment: (
-                    <Button
-                      size="small"
-                      variant="text"
-                      startIcon={<SearchOutlined />}
-                      onClick={handleGrantedSearch}
-                    >
-                      검색
-                    </Button>
-                  ),
-                },
-              }}
-            />
-            {loadingGranted ? (
-              <GroupsGridSkeleton />
-            ) : (
-              <PageableGridContent<GrantedGroupDto>
-                key={grantedGridKey}
-                ref={grantedGridRef}
-                datasource={grantedDataSource}
-                columns={groupColumns as ColDef<GrantedGroupDto>[]}
-                events={grantedEvents}
-                rowSelection="multiple"
-                height={GRID_HEIGHT}
-              />
-            )}
+            <Stack
+              direction={{ xs: "row", md: "column" }}
+              spacing={1}
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Button
+                variant="outlined"
+                startIcon={<ArrowForwardOutlined />}
+                onClick={moveToGranted}
+                disabled={loading || selectedLeft.length === 0}
+              >
+                추가
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<ArrowBackOutlined />}
+                onClick={moveToAvailable}
+                disabled={loading || selectedRight.length === 0}
+              >
+                제거
+              </Button>
+            </Stack>
+
+            <Card variant="outlined" sx={{ flex: 1, minWidth: 0 }}>
+              <CardContent>
+                <Stack spacing={1} sx={{ minHeight: TRANSFER_SECTION_MIN_HEIGHT }}>
+                  <Typography variant="subtitle2">현재 권한이 부여된 그룹</Typography>
+                  {loading ? (
+                    <GroupsListSkeleton />
+                  ) : (
+                    <>
+                      <TextField
+                        label="부여 그룹 검색"
+                        size="small"
+                        value={searchRight}
+                        onChange={(event) => setSearchRight(event.target.value)}
+                        fullWidth
+                      />
+                      <Divider />
+                      {filteredGrantedGroups.length === 0 ? (
+                        <Typography color="text.secondary" variant="body2">
+                          부여된 그룹 없음
+                        </Typography>
+                      ) : (
+                        <List dense sx={{ maxHeight: GROUP_LIST_MAX_HEIGHT, overflowY: "auto" }}>
+                          {filteredGrantedGroups.map((group) => (
+                            <ListItemButton
+                              key={group.groupId}
+                              selected={selectedRight.includes(group.groupId)}
+                              onClick={() =>
+                                toggleSelected(selectedRight, setSelectedRight, group.groupId)
+                              }
+                            >
+                              <ListItemText
+                                primary={group.name}
+                                secondary={`ID: ${group.groupId}${group.description ? ` · ${group.description}` : ""}`}
+                              />
+                            </ListItemButton>
+                          ))}
+                        </List>
+                      )}
+                    </>
+                  )}
+                </Stack>
+              </CardContent>
+            </Card>
           </Stack>
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Box sx={{ display: "flex", gap: 1, mr: "auto" }}>
-          <Button
-            variant="outlined"
-            onClick={() => void handleAssign()}
-            disabled={saving || selectedCandidateCount === 0}
-          >
-            Assign Role
-          </Button>
-          <Button
-            variant="outlined"
-            color="error"
-            onClick={() => void handleRevoke()}
-            disabled={saving || selectedGrantedCount === 0}
-          >
-            Revoke Role
-          </Button>
-        </Box>
         <Button variant="outlined" onClick={onClose} disabled={saving}>
-          닫기
+          취소
+        </Button>
+        <Button variant="outlined" onClick={() => void handleSave()} disabled={saving}>
+          {saving ? <CircularProgress size={20} /> : "저장"}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/react/pages/admin/roles/RoleGrantedGroupsDialog.tsx
+++ b/src/react/pages/admin/roles/RoleGrantedGroupsDialog.tsx
@@ -81,7 +81,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
   const confirm = useConfirm();
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [loaded, setLoaded] = useState(false);
+  const [loadedRoleId, setLoadedRoleId] = useState<number | null>(null);
   const [allGroups, setAllGroups] = useState<TransferGroup[]>([]);
   const [grantedGroups, setGrantedGroups] = useState<TransferGroup[]>([]);
   const [initialGrantedGroups, setInitialGrantedGroups] = useState<TransferGroup[]>([]);
@@ -91,7 +91,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
   const [searchRight, setSearchRight] = useState("");
 
   function resetTransferState() {
-    setLoaded(false);
+    setLoadedRoleId(null);
     setAllGroups([]);
     setGrantedGroups([]);
     setInitialGrantedGroups([]);
@@ -128,7 +128,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
       setSelectedRight([]);
       setSearchLeft("");
       setSearchRight("");
-      setLoaded(true);
+      setLoadedRoleId(roleId);
     } catch {
       resetTransferState();
       toast.error("그룹 권한 목록 로딩 실패");
@@ -178,6 +178,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
     [grantedGroups, searchRight]
   );
 
+  const loaded = loadedRoleId === roleId;
   function toggleSelected(
     selected: number[],
     setter: (value: number[]) => void,

--- a/src/react/pages/admin/roles/RoleGrantedGroupsDialog.tsx
+++ b/src/react/pages/admin/roles/RoleGrantedGroupsDialog.tsx
@@ -81,6 +81,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
   const confirm = useConfirm();
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
   const [allGroups, setAllGroups] = useState<TransferGroup[]>([]);
   const [grantedGroups, setGrantedGroups] = useState<TransferGroup[]>([]);
   const [initialGrantedGroups, setInitialGrantedGroups] = useState<TransferGroup[]>([]);
@@ -89,7 +90,19 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
   const [searchLeft, setSearchLeft] = useState("");
   const [searchRight, setSearchRight] = useState("");
 
+  function resetTransferState() {
+    setLoaded(false);
+    setAllGroups([]);
+    setGrantedGroups([]);
+    setInitialGrantedGroups([]);
+    setSelectedLeft([]);
+    setSelectedRight([]);
+    setSearchLeft("");
+    setSearchRight("");
+  }
+
   async function loadData() {
+    resetTransferState();
     setLoading(true);
     try {
       const [groupsResponse, grantedResponse] = await Promise.all([
@@ -115,7 +128,9 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
       setSelectedRight([]);
       setSearchLeft("");
       setSearchRight("");
+      setLoaded(true);
     } catch {
+      resetTransferState();
       toast.error("그룹 권한 목록 로딩 실패");
     } finally {
       setLoading(false);
@@ -168,6 +183,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
     setter: (value: number[]) => void,
     groupId: number
   ) {
+    if (loading || saving || !loaded) return;
     setter(
       selected.includes(groupId)
         ? selected.filter((value) => value !== groupId)
@@ -176,6 +192,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
   }
 
   function moveToGranted() {
+    if (loading || saving || !loaded) return;
     const nextGroups = allGroups.filter((group) => selectedLeft.includes(group.groupId));
 
     setGrantedGroups((current) =>
@@ -190,6 +207,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
   }
 
   function moveToAvailable() {
+    if (loading || saving || !loaded) return;
     setGrantedGroups((current) =>
       current.filter((group) => !selectedRight.includes(group.groupId))
     );
@@ -197,6 +215,12 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
   }
 
   async function handleSave() {
+    if (loading || saving) return;
+    if (!loaded) {
+      toast.error("그룹 권한 목록을 먼저 불러와야 합니다.");
+      return;
+    }
+
     if (sameIds(initialGrantedGroups, grantedGroups)) {
       toast.info("변경된 그룹 권한이 없습니다.");
       onClose();
@@ -231,6 +255,8 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
     }
   }
 
+  const interactionDisabled = loading || saving || !loaded;
+
   return (
     <Dialog
       open={open}
@@ -260,6 +286,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
                         size="small"
                         value={searchLeft}
                         onChange={(event) => setSearchLeft(event.target.value)}
+                        disabled={saving || !loaded}
                         fullWidth
                       />
                       <Divider />
@@ -273,6 +300,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
                             <ListItemButton
                               key={group.groupId}
                               selected={selectedLeft.includes(group.groupId)}
+                              disabled={interactionDisabled}
                               onClick={() =>
                                 toggleSelected(selectedLeft, setSelectedLeft, group.groupId)
                               }
@@ -301,7 +329,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
                 variant="outlined"
                 startIcon={<ArrowForwardOutlined />}
                 onClick={moveToGranted}
-                disabled={loading || selectedLeft.length === 0}
+                disabled={interactionDisabled || selectedLeft.length === 0}
               >
                 추가
               </Button>
@@ -309,7 +337,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
                 variant="outlined"
                 startIcon={<ArrowBackOutlined />}
                 onClick={moveToAvailable}
-                disabled={loading || selectedRight.length === 0}
+                disabled={interactionDisabled || selectedRight.length === 0}
               >
                 제거
               </Button>
@@ -328,6 +356,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
                         size="small"
                         value={searchRight}
                         onChange={(event) => setSearchRight(event.target.value)}
+                        disabled={saving || !loaded}
                         fullWidth
                       />
                       <Divider />
@@ -341,6 +370,7 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
                             <ListItemButton
                               key={group.groupId}
                               selected={selectedRight.includes(group.groupId)}
+                              disabled={interactionDisabled}
                               onClick={() =>
                                 toggleSelected(selectedRight, setSelectedRight, group.groupId)
                               }
@@ -365,7 +395,11 @@ export function RoleGrantedGroupsDialog({ open, onClose, roleId, roleName }: Pro
         <Button variant="outlined" onClick={onClose} disabled={saving}>
           취소
         </Button>
-        <Button variant="outlined" onClick={() => void handleSave()} disabled={saving}>
+        <Button
+          variant="outlined"
+          onClick={() => void handleSave()}
+          disabled={saving || loading || !loaded}
+        >
           {saving ? <CircularProgress size={20} /> : "저장"}
         </Button>
       </DialogActions>


### PR DESCRIPTION
## Why
- 역할 상세의 그룹 관리 다이얼로그는 검색 후보 grid와 현재 부여 grid를 함께 보여주는 구조였습니다.
- 그룹 수가 대략 20개 내외라면 이 구조는 과하고, 그룹 상세의 역할 관리처럼 좌/우 이동 방식이 더 단순하고 이해하기 쉽습니다.

## What
- `RoleGrantedGroupsDialog`를 Transfer List 스타일로 전환했습니다.
- 왼쪽에는 부여 가능한 그룹, 오른쪽에는 현재 권한이 부여된 그룹을 표시합니다.
- 그룹을 좌우로 이동한 뒤 저장 시 추가/제거 diff를 계산해 `assignGroups` / `revokeGroups` wrapper를 호출합니다.
- 사용자 관리 다이얼로그는 변경하지 않았습니다.
- `CHANGELOG.md`에 `#93` 변경/검증 기록을 추가했습니다.

## Related Issues
- Closes #93
- Related #87

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 역할-그룹 권한 부여/회수 UI 흐름이 변경되므로 저장 diff 계산이 잘못되면 권한 부여 상태가 잘못 반영될 수 있습니다.
- Mitigation: 초기 부여 목록과 현재 우측 목록을 비교해 추가/제거 대상만 계산하고, confirm 후 저장하도록 유지했습니다.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - 모두 통과
  - `lint`는 기존 warning 16개 유지
  - `build`는 기존 Vite chunk warning 및 plugin timing warning 유지
- Additional checks:
  - 역할 상세 그룹 관리 Transfer List 흐름을 코드 기준으로 검토했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks:
- Ownership (files/modules/tasks):
- Main author post-integration validation:

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert 또는 `RoleGrantedGroupsDialog` 변경만 되돌리면 됩니다.
- Post-deploy checks: `/admin/roles/:roleId`에서 그룹 관리 다이얼로그를 열고 그룹 추가/제거/저장 동작을 확인합니다.
