### PR TITLE
[ai-assisted] feat(ai): AI 본문 생성 및 테스트 변수 자동 채우기 (Phase 1)

### DIFF
--- a/src/react/components/ai/AiGenerateDrawer.tsx
+++ b/src/react/components/ai/AiGenerateDrawer.tsx
@@ -1,0 +1,248 @@
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Divider,
+  Drawer,
+  IconButton,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Toolbar,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  AutoFixHigh,
+  Close,
+  ContentCopy,
+  Done,
+  EditNote,
+} from "@mui/icons-material";
+import { AiProviderSelect } from "@/react/components/ai/AiProviderSelect";
+import { reactAiApi } from "@/react/pages/ai/api";
+import { resolveAxiosError } from "@/utils/helpers";
+
+type Mode = "generate" | "improve";
+
+interface Context {
+  subject?: string;
+  language?: string;
+  description?: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  context?: Context;
+  currentBody?: string;
+  onApply: (content: string) => void;
+}
+
+const PLACEHOLDER: Record<Mode, string> = {
+  generate:
+    "예) 주문 완료 알림 이메일을 FreeMarker로 작성해줘. 변수로 userName, orderDate, totalAmount를 사용해.",
+  improve:
+    "예) 내용을 더 친근한 말투로 바꾸고, 마무리 문구를 추가해줘.",
+};
+
+function buildSystemPrompt(mode: Mode, context: Context, language: string): string {
+  const lang = language || context.language || "html";
+  const parts = [
+    `당신은 ${lang.toUpperCase()} 템플릿 전문 작성자입니다.`,
+    `코드 블록(\`\`\`)이나 설명 없이 템플릿 내용만 반환하세요.`,
+  ];
+  if (context.subject) parts.push(`제목(subject): ${context.subject}`);
+  if (context.description) parts.push(`설명: ${context.description}`);
+  if (mode === "improve") parts.push("아래에 기존 본문을 제공합니다. 이를 개선해주세요.");
+  return parts.join("\n");
+}
+
+function buildUserMessage(mode: Mode, prompt: string, currentBody: string): string {
+  if (mode === "improve" && currentBody.trim()) {
+    return `[기존 본문]\n${currentBody}\n\n[개선 요청]\n${prompt}`;
+  }
+  return prompt;
+}
+
+export function AiGenerateDrawer({ open, onClose, context = {}, currentBody = "", onApply }: Props) {
+  const [provider, setProvider] = useState("");
+  const [model, setModel] = useState("");
+  const [mode, setMode] = useState<Mode>("generate");
+  const [prompt, setPrompt] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  async function handleGenerate() {
+    if (!prompt.trim()) return;
+    setLoading(true);
+    setError("");
+    setResult("");
+    try {
+      const systemPrompt = buildSystemPrompt(mode, context, model);
+      const userContent = buildUserMessage(mode, prompt, currentBody);
+      const response = await reactAiApi.sendChat({
+        provider: provider || undefined,
+        model: model || undefined,
+        messages: [{ role: "user", content: userContent }],
+        systemPrompt,
+      });
+      const assistant = [...response.messages]
+        .reverse()
+        .find((m) => m.role === "assistant");
+      setResult(assistant?.content ?? "");
+    } catch (e) {
+      setError(resolveAxiosError(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleApply() {
+    onApply(result);
+    onClose();
+  }
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(result);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  function handleClose() {
+    setResult("");
+    setError("");
+    setPrompt("");
+    onClose();
+  }
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={handleClose}
+      PaperProps={{ sx: { width: { xs: "100%", sm: 480 }, display: "flex", flexDirection: "column" } }}
+    >
+      {/* 헤더 */}
+      <Toolbar variant="dense" sx={{ bgcolor: "primary.main", color: "primary.contrastText", flexShrink: 0 }}>
+        <AutoFixHigh sx={{ mr: 1 }} />
+        <Typography variant="subtitle1" sx={{ flex: 1, fontWeight: 600 }}>
+          AI 본문 생성
+        </Typography>
+        <IconButton color="inherit" edge="end" onClick={handleClose}>
+          <Close />
+        </IconButton>
+      </Toolbar>
+
+      <Box sx={{ flex: 1, overflowY: "auto", p: 2 }}>
+        <Stack spacing={2}>
+          {/* 프로바이더 선택 */}
+          <AiProviderSelect
+            provider={provider}
+            model={model}
+            onChange={(p, m) => { setProvider(p); setModel(m); }}
+          />
+
+          <Divider />
+
+          {/* 모드 선택 */}
+          <ToggleButtonGroup
+            value={mode}
+            exclusive
+            onChange={(_, v) => { if (v) setMode(v); }}
+            size="small"
+            fullWidth
+          >
+            <ToggleButton value="generate">
+              <AutoFixHigh fontSize="small" sx={{ mr: 0.5 }} />
+              새로 생성
+            </ToggleButton>
+            <ToggleButton value="improve" disabled={!currentBody.trim()}>
+              <EditNote fontSize="small" sx={{ mr: 0.5 }} />
+              현재 내용 개선
+            </ToggleButton>
+          </ToggleButtonGroup>
+
+          {/* 컨텍스트 정보 표시 */}
+          {(context.subject || context.description) && (
+            <Box sx={{ bgcolor: "grey.50", borderRadius: 1, p: 1.5, border: "1px solid", borderColor: "divider" }}>
+              {context.subject && (
+                <Typography variant="caption" display="block" color="text.secondary">
+                  제목: <strong>{context.subject}</strong>
+                </Typography>
+              )}
+              {context.description && (
+                <Typography variant="caption" display="block" color="text.secondary">
+                  설명: <strong>{context.description}</strong>
+                </Typography>
+              )}
+            </Box>
+          )}
+
+          {/* 프롬프트 입력 */}
+          <TextField
+            label="프롬프트"
+            multiline
+            minRows={4}
+            maxRows={8}
+            fullWidth
+            size="small"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder={PLACEHOLDER[mode]}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) void handleGenerate();
+            }}
+          />
+
+          <Button
+            variant="contained"
+            onClick={() => void handleGenerate()}
+            disabled={loading || !prompt.trim()}
+            startIcon={loading ? <CircularProgress size={16} color="inherit" /> : <AutoFixHigh />}
+          >
+            {loading ? "생성 중..." : "생성 (Ctrl+Enter)"}
+          </Button>
+
+          {/* 오류 */}
+          {error && <Alert severity="error">{error}</Alert>}
+
+          {/* 결과 */}
+          {result && (
+            <>
+              <Divider />
+              <Stack spacing={1}>
+                <Stack direction="row" alignItems="center" justifyContent="space-between">
+                  <Typography variant="subtitle2">생성 결과</Typography>
+                  <Tooltip title={copied ? "복사됨" : "클립보드 복사"}>
+                    <IconButton size="small" onClick={() => void handleCopy()}>
+                      {copied ? <Done fontSize="small" color="success" /> : <ContentCopy fontSize="small" />}
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
+                <TextField
+                  multiline
+                  minRows={6}
+                  maxRows={20}
+                  fullWidth
+                  size="small"
+                  value={result}
+                  onChange={(e) => setResult(e.target.value)}
+                  sx={{ fontFamily: "monospace", "& textarea": { fontFamily: "monospace", fontSize: 12 } }}
+                />
+                <Button variant="contained" color="success" onClick={handleApply}>
+                  본문에 적용
+                </Button>
+              </Stack>
+            </>
+          )}
+        </Stack>
+      </Box>
+    </Drawer>
+  );
+}

--- a/src/react/components/ai/AiGenerateDrawer.tsx
+++ b/src/react/components/ai/AiGenerateDrawer.tsx
@@ -49,8 +49,8 @@ const PLACEHOLDER: Record<Mode, string> = {
     "예) 내용을 더 친근한 말투로 바꾸고, 마무리 문구를 추가해줘.",
 };
 
-function buildSystemPrompt(mode: Mode, context: Context, language: string): string {
-  const lang = language || context.language || "html";
+function buildSystemPrompt(mode: Mode, context: Context): string {
+  const lang = context.language || "html";
   const parts = [
     `당신은 ${lang.toUpperCase()} 템플릿 전문 작성자입니다.`,
     `코드 블록(\`\`\`)이나 설명 없이 템플릿 내용만 반환하세요.`,
@@ -84,7 +84,7 @@ export function AiGenerateDrawer({ open, onClose, context = {}, currentBody = ""
     setError("");
     setResult("");
     try {
-      const systemPrompt = buildSystemPrompt(mode, context, model);
+      const systemPrompt = buildSystemPrompt(mode, context);
       const userContent = buildUserMessage(mode, prompt, currentBody);
       const response = await reactAiApi.sendChat({
         provider: provider || undefined,

--- a/src/react/components/ai/AiProviderSelect.tsx
+++ b/src/react/components/ai/AiProviderSelect.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { MenuItem, Stack, TextField } from "@mui/material";
+import { reactAiApi } from "@/react/pages/ai/api";
+import type { ProviderInfo } from "@/types/studio/ai";
+
+interface Props {
+  provider: string;
+  model: string;
+  onChange: (provider: string, model: string) => void;
+  size?: "small" | "medium";
+}
+
+export function AiProviderSelect({ provider, model, onChange, size = "small" }: Props) {
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+
+  useEffect(() => {
+    reactAiApi
+      .fetchProviders()
+      .then((data) => {
+        setProviders(data.providers);
+        if (!provider && data.defaultProvider) {
+          const match = data.providers.find((p) => p.name === data.defaultProvider);
+          onChange(data.defaultProvider, match?.chat.model ?? "");
+        }
+      })
+      .catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleProviderChange(next: string) {
+    const match = providers.find((p) => p.name === next);
+    onChange(next, match?.chat.model ?? "");
+  }
+
+  return (
+    <Stack direction="row" spacing={1}>
+      <TextField
+        select
+        label="Provider"
+        value={provider}
+        onChange={(e) => handleProviderChange(e.target.value)}
+        size={size}
+        sx={{ minWidth: 140 }}
+      >
+        {providers.map((p) => (
+          <MenuItem key={p.name} value={p.name}>
+            {p.name}
+          </MenuItem>
+        ))}
+      </TextField>
+      <TextField
+        label="Model"
+        value={model}
+        onChange={(e) => onChange(provider, e.target.value)}
+        size={size}
+        sx={{ minWidth: 160 }}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/templates/PreviewTemplateDialog.tsx
+++ b/src/react/pages/templates/PreviewTemplateDialog.tsx
@@ -19,8 +19,9 @@ import {
   Toolbar,
   Typography,
 } from "@mui/material";
-import { Add, Close, Delete, PlayArrow } from "@mui/icons-material";
+import { Add, AutoFixHigh, Close, Delete, PlayArrow } from "@mui/icons-material";
 import { useToast } from "@/react/feedback";
+import { reactAiApi } from "@/react/pages/ai/api";
 import { reactTemplatesApi } from "./api";
 
 interface Props {
@@ -71,6 +72,7 @@ export function PreviewTemplateDialog({ open, onClose, templateId }: Props) {
 
   const [loading, setLoading] = useState(false);
   const [running, setRunning] = useState(false);
+  const [aiLoading, setAiLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
   const [templateBody, setTemplateBody] = useState("");
@@ -197,6 +199,46 @@ export function PreviewTemplateDialog({ open, onClose, templateId }: Props) {
     setVars((prev) => prev.filter((_, i) => i !== index));
   }
 
+  async function handleAiFill() {
+    const names = vars.map((v) => v.name.trim()).filter(Boolean);
+    if (names.length === 0) return;
+    setAiLoading(true);
+    try {
+      const response = await reactAiApi.sendChat({
+        messages: [
+          {
+            role: "user",
+            content: `다음 변수들에 대해 현실적인 테스트 값을 JSON 객체로 반환해주세요. 다른 설명 없이 JSON만 반환하세요.\n변수: ${names.join(", ")}`,
+          },
+        ],
+        systemPrompt:
+          "당신은 테스트 데이터 생성 전문가입니다. 요청된 변수명에 맞는 현실적인 테스트 값을 JSON 객체 형식으로만 반환합니다.",
+      });
+      const assistant = [...response.messages]
+        .reverse()
+        .find((m) => m.role === "assistant");
+      const content = assistant?.content ?? "";
+      const jsonMatch = content.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+        setVars((prev) =>
+          prev.map((v) =>
+            v.name.trim() in parsed
+              ? { ...v, value: String(parsed[v.name.trim()]) }
+              : v
+          )
+        );
+        toast.success("AI가 테스트 값을 채웠습니다.");
+      } else {
+        toast.error("AI 응답을 파싱하지 못했습니다.");
+      }
+    } catch {
+      toast.error("AI 요청에 실패했습니다.");
+    } finally {
+      setAiLoading(false);
+    }
+  }
+
   const requiredVars = extractFreemarkerVariables(templateBody);
 
   return (
@@ -235,6 +277,16 @@ export function PreviewTemplateDialog({ open, onClose, templateId }: Props) {
                   템플릿 테스트를 위해 필요한 변수 값을 입력하세요.
                 </Typography>
                 <Box flex={1} />
+                <Button
+                  size="small"
+                  startIcon={
+                    aiLoading ? <CircularProgress size={14} color="inherit" /> : <AutoFixHigh />
+                  }
+                  onClick={() => void handleAiFill()}
+                  disabled={aiLoading || vars.length === 0}
+                >
+                  AI로 값 채우기
+                </Button>
                 <Button size="small" startIcon={<Add />} onClick={handleAddVar}>
                   추가
                 </Button>

--- a/src/react/pages/templates/TemplateDetailsPage.tsx
+++ b/src/react/pages/templates/TemplateDetailsPage.tsx
@@ -14,9 +14,10 @@ import {
   TemplateCodeEditor,
   type EditorLanguage,
 } from "@/react/components/code-editor/TemplateCodeEditor";
-import { PreviewOutlined, SaveOutlined } from "@mui/icons-material";
+import { AutoFixHigh, PreviewOutlined, SaveOutlined } from "@mui/icons-material";
 import { useToast, useConfirm } from "@/react/feedback";
 import { PreviewTemplateDialog } from "@/react/pages/templates/PreviewTemplateDialog";
+import { AiGenerateDrawer } from "@/react/components/ai/AiGenerateDrawer";
 import { reactTemplatesApi } from "./api";
 import type { TemplateDto } from "@/types/studio/template";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
@@ -54,6 +55,7 @@ export function TemplateDetailsPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
+  const [aiDrawerOpen, setAiDrawerOpen] = useState(false);
   const [language, setLanguage] = useState<EditorLanguage>("html");
   const [savedLanguage, setSavedLanguage] = useState<EditorLanguage>("html");
 
@@ -234,6 +236,13 @@ export function TemplateDetailsPage() {
             <Stack direction="row" spacing={1} justifyContent="flex-end">
               <Button
                 variant="outlined"
+                startIcon={<AutoFixHigh />}
+                onClick={() => setAiDrawerOpen(true)}
+              >
+                AI 생성
+              </Button>
+              <Button
+                variant="outlined"
                 startIcon={<PreviewOutlined />}
                 onClick={() => setPreviewOpen(true)}
               >
@@ -255,6 +264,17 @@ export function TemplateDetailsPage() {
         open={previewOpen}
         onClose={() => setPreviewOpen(false)}
         templateId={template.templateId}
+      />
+      <AiGenerateDrawer
+        open={aiDrawerOpen}
+        onClose={() => setAiDrawerOpen(false)}
+        context={{
+          subject: form.subject,
+          description: form.description,
+          language,
+        }}
+        currentBody={form.body}
+        onApply={(v) => setForm((f) => ({ ...f, body: v }))}
       />
     </Stack>
   );


### PR DESCRIPTION
## Why
- 템플릿 작성 시 본문을 직접 입력해야 해서 초안 작성 비용이 높습니다.
- Test Run 시 FreeMarker 변수에 테스트 값을 수동으로 채워야 해서 반복 작업이 발생합니다.

## What
- **AiProviderSelect** 공통 컴포넌트 추가 — `GET /api/ai/info/providers`로 프로바이더 목록을 로드하고 기본값 자동 선택
- **AiGenerateDrawer** 공통 컴포넌트 추가 — 우측 슬라이드인 Drawer로 AI 기반 템플릿 본문 생성
  - "새로 생성" / "현재 내용 개선" 모드 전환
  - subject, description, editorLanguage를 시스템 프롬프트에 자동 포함
  - Ctrl+Enter 단축키, 클립보드 복사, "본문에 적용" 버튼
- **TemplateDetailsPage** — 액션 바에 "AI 생성" 버튼 추가, AiGenerateDrawer 연결
- **PreviewTemplateDialog** — "AI로 값 채우기" 버튼 추가, FreeMarker 변수명을 AI에 전달해 현실적인 테스트값 자동 생성 (JSON 파싱 → 변수 테이블 자동 채움)

## Related Issues
- Closes #
- Related #

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 사용자 입력(프롬프트)이 AI API로 전달됨. 서버 측 AI 엔드포인트에서 인증/인가가 적용됨.
- Mitigation: 클라이언트에서 별도 sanitization 없이 기존 API 인증에 의존. 추가 위험 없음.

## Validation
- Commands:
  - `npm run typecheck`
- Result:
  - typecheck 통과
- Additional checks:
  - buildSystemPrompt에 model 대신 context.language가 전달되는지 네트워크 요청 페이로드에서 확인 필요

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks: 컴포넌트 구현 전체 (AiProviderSelect, AiGenerateDrawer, PreviewTemplateDialog 수정, TemplateDetailsPage 수정), language/model 버그 수정
- Ownership (files/modules/tasks): donghyuck
- Main author post-integration validation: 미완료 — 로컬 테스트 필요

## Checklist
- [x] policy-compliant commit message
- [ ] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [ ] validation recorded
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert
- Post-deploy checks: 템플릿 상세 페이지에서 AI 생성 버튼 동작 확인