### PR TITLE
[ai-assisted] fix(ai): AiProviderSelect 로딩/오류 상태 누락

### DIFF
--- a/src/react/components/ai/AiProviderSelect.tsx
+++ b/src/react/components/ai/AiProviderSelect.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { MenuItem, Stack, TextField } from "@mui/material";
+import { Alert, MenuItem, Stack, TextField } from "@mui/material";
 import { reactAiApi } from "@/react/pages/ai/api";
 import type { ProviderInfo } from "@/types/studio/ai";
 
@@ -12,6 +12,8 @@ interface Props {
 
 export function AiProviderSelect({ provider, model, onChange, size = "small" }: Props) {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     reactAiApi
@@ -23,13 +25,18 @@ export function AiProviderSelect({ provider, model, onChange, size = "small" }: 
           onChange(data.defaultProvider, match?.chat.model ?? "");
         }
       })
-      .catch(() => {});
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function handleProviderChange(next: string) {
     const match = providers.find((p) => p.name === next);
     onChange(next, match?.chat.model ?? "");
+  }
+
+  if (error) {
+    return <Alert severity="error" sx={{ py: 0 }}>프로바이더 목록을 불러오지 못했습니다.</Alert>;
   }
 
   return (
@@ -41,6 +48,7 @@ export function AiProviderSelect({ provider, model, onChange, size = "small" }: 
         onChange={(e) => handleProviderChange(e.target.value)}
         size={size}
         sx={{ minWidth: 140 }}
+        disabled={loading}
       >
         {providers.map((p) => (
           <MenuItem key={p.name} value={p.name}>
@@ -54,6 +62,7 @@ export function AiProviderSelect({ provider, model, onChange, size = "small" }: 
         onChange={(e) => onChange(provider, e.target.value)}
         size={size}
         sx={{ minWidth: 160 }}
+        disabled={loading}
       />
     </Stack>
   );


### PR DESCRIPTION
## Why
- 프로바이더 목록 fetch 중 Provider/Model 필드가 빈 상태로 표시되어 동작이 멈춘 것처럼 보임
- fetch 실패 시 `.catch(() => {})` 로 무시되어 사용자가 이유를 알 수 없음

## What
- `loading` 상태 추가 — fetch 완료 전까지 Provider/Model 필드 `disabled` 처리
- `error` 상태 추가 — fetch 실패 시 "프로바이더 목록을 불러오지 못했습니다." Alert 표시
- 파일: `src/react/components/ai/AiProviderSelect.tsx`

## Related Issues
- Closes #101
- Related #100

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 없음
- Mitigation: N/A

## Validation
- Commands:
  - `npm run typecheck`
- Result:
  - 통과
- Additional checks:
  - 프로바이더 fetch 성공 시 필드 활성화 및 기본값 선택 확인 필요
  - 네트워크 오류 시 Alert 표시 확인 필요

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks: 버그 분석, 코드 수정
- Ownership (files/modules/tasks): donghyuck
- Main author post-integration validation: 미완료 — 로컬 수동 확인 필요

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [ ] validation recorded
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert
- Post-deploy checks: AI 생성 Drawer에서 Provider 드롭다운 로딩/오류 동작 확인