### PR TITLE
[ai-assisted] feat(object-type): 저장된 정책 없을 때 기본 정책 적용 안내

### DIFF
--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -28,6 +28,7 @@ export function ObjectTypeDetailPage() {
   const { user } = useAuthStore();
   const [objectType, setObjectType] = useState<ObjectTypeDto | null>(null);
   const [policy, setPolicy] = useState<ObjectTypePolicyDto | null>(null);
+  const [policySource, setPolicySource] = useState<"stored" | "default" | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -44,8 +45,9 @@ export function ObjectTypeDetailPage() {
     Promise.all([
       reactObjectTypeApi.get(Number(objectTypeId)),
       reactObjectTypeApi.getPolicy(Number(objectTypeId)).catch(() => null),
+      reactObjectTypeApi.getEffectivePolicy(Number(objectTypeId)).catch(() => null),
     ])
-      .then(([ot, pol]) => {
+      .then(([ot, pol, effective]) => {
         setObjectType(ot);
         setForm({
           name: ot.name,
@@ -60,6 +62,7 @@ export function ObjectTypeDetailPage() {
             allowedMime: pol.allowedMime ?? "",
           });
         }
+        setPolicySource(effective?.source ?? null);
         setError(null);
       })
       .catch(() => setError("오브젝트 타입을 불러오지 못했습니다."))
@@ -232,6 +235,11 @@ export function ObjectTypeDetailPage() {
             파일 정책
           </AccordionSummary>
           <AccordionDetails>
+            {policySource === "default" && (
+              <Alert severity="info" sx={{ mb: 2 }}>
+                저장된 정책이 없습니다. 현재 파일 크기·확장자·MIME 제한이 없는 기본 정책이 적용됩니다.
+              </Alert>
+            )}
             <Grid container spacing={1} alignItems="center">
               <Grid size={{ xs: 12, md: 4 }}>
                 <TextField

--- a/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
+++ b/src/react/pages/objecttype/ObjectTypeDetailPage.tsx
@@ -230,16 +230,16 @@ export function ObjectTypeDetailPage() {
         </Grid>
       </Container>
       <Container maxWidth="md" disableGutters>
+        {policySource === "default" && (
+          <Alert severity="info" sx={{ mb: 1 }}>
+            저장된 정책이 없습니다. 현재 파일 크기·확장자·MIME 제한이 없는 기본 정책이 적용됩니다.
+          </Alert>
+        )}
         <Accordion disableGutters>
           <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
             파일 정책
           </AccordionSummary>
           <AccordionDetails>
-            {policySource === "default" && (
-              <Alert severity="info" sx={{ mb: 2 }}>
-                저장된 정책이 없습니다. 현재 파일 크기·확장자·MIME 제한이 없는 기본 정책이 적용됩니다.
-              </Alert>
-            )}
             <Grid container spacing={1} alignItems="center">
               <Grid size={{ xs: 12, md: 4 }}>
                 <TextField

--- a/src/react/pages/objecttype/api.ts
+++ b/src/react/pages/objecttype/api.ts
@@ -1,6 +1,7 @@
 import { apiRequest } from "@/react/query/fetcher";
 import type {
   ObjectTypeDto,
+  ObjectTypeEffectivePolicyDto,
   ObjectTypePatchRequest,
   ObjectTypePolicyDto,
   ObjectTypePolicyUpsertRequest,
@@ -27,6 +28,9 @@ export const reactObjectTypeApi = {
 
   getPolicy: (objectType: number) =>
     apiRequest<ObjectTypePolicyDto>("get", `${BASE}/${objectType}/policy`),
+
+  getEffectivePolicy: (objectType: number) =>
+    apiRequest<ObjectTypeEffectivePolicyDto>("get", `${BASE}/${objectType}/policy/effective`),
 
   upsertPolicy: (objectType: number, payload: ObjectTypePolicyUpsertRequest) =>
     apiRequest<ObjectTypePolicyDto>("put", `${BASE}/${objectType}/policy`, { data: payload }),

--- a/src/types/studio/objecttype.ts
+++ b/src/types/studio/objecttype.ts
@@ -29,6 +29,15 @@ export interface ObjectTypePolicyDto {
   updatedAt?: string | null;
 }
 
+export interface ObjectTypeEffectivePolicyDto {
+  objectType: number;
+  maxFileMb?: number | null;
+  allowedExt?: string | null;
+  allowedMime?: string | null;
+  policyJson?: string | null;
+  source: "stored" | "default";
+}
+
 export interface ObjectTypeDefinitionDto {
   type: ObjectTypeDto;
   policy?: ObjectTypePolicyDto | null;


### PR DESCRIPTION
## Why
- ObjectType 파일 정책 아코디언을 열었을 때 저장된 정책이 없는 경우, 현재 어떤 정책이 적용 중인지 사용자가 알 수 없습니다.
- `GET /api/mgmt/object-types/{objectType}/policy/effective` API가 `source` 필드로 저장 정책 여부를 제공합니다.

## What
- `ObjectTypeEffectivePolicyDto` 타입 추가 (`source: "stored" | "default"`)
- `reactObjectTypeApi.getEffectivePolicy()` 추가 — `GET .../policy/effective` 호출
- `loadObjectType` 의 `Promise.all` 에 effective policy fetch 추가
- `source === "default"` 일 때 파일 정책 아코디언 내부 상단에 info Alert 표시:
  > 저장된 정책이 없습니다. 현재 파일 크기·확장자·MIME 제한이 없는 기본 정책이 적용됩니다.

## Related Issues
- Closes #
- Related #

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 없음
- Mitigation: N/A

## Validation
- Commands:
  - `npm run typecheck`
- Result:
  - 통과
- Additional checks:
  - 저장된 정책이 없는 ObjectType 상세 페이지에서 파일 정책 아코디언 열기 → info Alert 표시 확인 필요
  - 저장된 정책이 있는 ObjectType에서는 Alert 미표시 확인 필요

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks: 타입 추가, API 메서드 추가, 페이지 수정
- Ownership (files/modules/tasks): donghyuck
- Main author post-integration validation: 미완료 — 로컬 수동 확인 필요

## Checklist
- [x] policy-compliant commit message
- [ ] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [ ] validation recorded
- [ ] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert
- Post-deploy checks: ObjectType 상세 페이지 파일 정책 아코디언 동작 확인