### PR TITLE
[ai-assisted] feat(ai): align chat client with memory capability

### DIFF
--- a/src/react/components/ai/AiProviderSelect.tsx
+++ b/src/react/components/ai/AiProviderSelect.tsx
@@ -27,7 +27,6 @@ export function AiProviderSelect({ provider, model, onChange, size = "small" }: 
       })
       .catch(() => setError(true))
       .finally(() => setLoading(false));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function handleProviderChange(next: string) {

--- a/src/react/pages/ai/ChatPage.tsx
+++ b/src/react/pages/ai/ChatPage.tsx
@@ -1,33 +1,66 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   Alert,
+  Avatar,
   Box,
   Button,
   Card,
   CardContent,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
   MenuItem,
+  Paper,
+  Popover,
   Stack,
+  Switch,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
+import {
+  ArrowUpwardOutlined,
+  CheckOutlined,
+  ContentCopyOutlined,
+  EditNoteOutlined,
+  ExpandMoreOutlined,
+  SettingsOutlined,
+  SmartToyOutlined,
+} from "@mui/icons-material";
 import { reactAiApi } from "@/react/pages/ai/api";
 import type { AiInfoResponse, ChatMessageDto, ProviderInfo } from "@/types/studio/ai";
 import { resolveAxiosError } from "@/utils/helpers";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
 
-type ChatMessage = ChatMessageDto & { model?: string };
+type ChatMessage = ChatMessageDto & {
+  id?: string;
+  createdAt?: string;
+  model?: string;
+  metadata?: Record<string, unknown>;
+};
 
 export function ChatPage() {
   const [aiInfo, setAiInfo] = useState<AiInfoResponse | null>(null);
   const [provider, setProvider] = useState("");
   const [model, setModel] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
+  const [memoryEnabled, setMemoryEnabled] = useState(false);
+  const [conversationId, setConversationId] = useState(() => crypto.randomUUID());
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [modelAnchorEl, setModelAnchorEl] = useState<HTMLElement | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
 
   const providers = useMemo<ProviderInfo[]>(() => aiInfo?.providers ?? [], [aiInfo]);
+  const selectedProvider = providers.find((item) => item.name === provider);
+  const configurationMissing = !provider || !model;
+  const serverMemoryEnabled = aiInfo?.chat?.memory?.enabled === true;
+  const modelMenuOpen = Boolean(modelAnchorEl);
 
   useEffect(() => {
     reactAiApi
@@ -47,13 +80,28 @@ export function ChatPage() {
     setModel(match?.chat.model ?? "");
   }
 
+  function handleModelMenuClose() {
+    setModelAnchorEl(null);
+  }
+
+  function handleModelSelect(nextProvider: string) {
+    handleProviderChange(nextProvider);
+    handleModelMenuClose();
+  }
+
   async function handleSend() {
     const trimmed = input.trim();
     if (!trimmed) {
       return;
     }
-    const userMessage: ChatMessage = { role: "user", content: trimmed };
+    const userMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: trimmed,
+      createdAt: new Date().toISOString(),
+    };
     const nextMessages: ChatMessage[] = [...messages, userMessage];
+    const requestMessages = memoryEnabled ? [userMessage] : nextMessages;
     setMessages(nextMessages);
     setInput("");
     setSending(true);
@@ -62,33 +110,131 @@ export function ChatPage() {
       const response = await reactAiApi.sendChat({
         provider: provider || undefined,
         model: model || undefined,
-        messages: nextMessages,
+        messages: requestMessages,
         systemPrompt: systemPrompt.trim() || undefined,
+        memory: memoryEnabled ? { enabled: true, conversationId } : undefined,
       });
       const assistant = [...response.messages].reverse().find((item) => item.role === "assistant");
       if (assistant) {
-        setMessages((current) => [...current, { ...assistant, model: response.model ?? model }]);
+        setMessages((current) => [
+          ...current,
+          { ...assistant, id: crypto.randomUUID(), model: response.model ?? model, metadata: response.metadata, createdAt: new Date().toISOString() },
+        ]);
       }
     } catch (sendError) {
       const message = resolveAxiosError(sendError);
       setError(message);
-      setMessages((current) => [...current, { role: "assistant", content: `오류: ${message}`, model }]);
+      setMessages((current) => [
+        ...current,
+        { id: crypto.randomUUID(), role: "assistant", content: `오류: ${message}`, model, createdAt: new Date().toISOString() },
+      ]);
     } finally {
       setSending(false);
     }
   }
 
+  function handleNewConversation() {
+    setConversationId(crypto.randomUUID());
+    setMessages([]);
+    setInput("");
+    setError(null);
+  }
+
+  function renderTokenUsage(metadata?: Record<string, unknown>) {
+    const usage = metadata?.tokenUsage as
+      | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
+      | undefined;
+    if (!usage) return null;
+
+    return (
+      <Typography variant="caption" color="text.secondary" sx={{ mt: 0.75, display: "block", fontSize: 11 }}>
+        tokens · input {usage.inputTokens ?? "-"} · output {usage.outputTokens ?? "-"} · total{" "}
+        {usage.totalTokens ?? "-"}
+      </Typography>
+    );
+  }
+
+  function formatMessageTime(value?: string) {
+    if (!value) return "";
+    return new Date(value).toLocaleTimeString("ko-KR", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+
+  async function handleCopyMessage(content: string) {
+    await navigator.clipboard.writeText(content);
+  }
+
+  function handleEditMessage(index: number, content: string) {
+    setInput(content);
+    setMessages((current) => current.slice(0, index));
+  }
+
   return (
     <Stack spacing={1}>
       <PageToolbar
-        divider={false}
+        divider={true}
         breadcrumbs={["서비스 관리", "AI", "Chat"]}
         label="Provider와 모델을 선택해 AI Chat 요청을 보냅니다."
+        actions={
+          <>
+            <Tooltip title={memoryEnabled ? "새 대화 시작" : "대화 기억을 켜면 새 대화를 시작할 수 있습니다"}>
+              <span>
+                <IconButton size="small" onClick={handleNewConversation} disabled={!memoryEnabled}>
+                  <EditNoteOutlined fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="설정">
+              <IconButton size="small" onClick={() => setSettingsOpen(true)}>
+                <SettingsOutlined fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </>
+        }
       />
       {error ? <Alert severity="error">{error}</Alert> : null}
-      <Card variant="outlined">
-        <CardContent>
+      {configurationMissing ? (
+        <Alert severity="warning">
+          AI Chat을 사용하려면 Provider와 Model 설정이 필요합니다. 상단 설정 아이콘을 눌러 사용할
+          provider와 모델을 선택하거나 입력하세요.
+        </Alert>
+      ) : null}
+      {memoryEnabled ? (
+        <Alert severity="info">
+          대화 기억 사용 중입니다. 새 대화를 시작하면 이전 대화와 분리됩니다.
+        </Alert>
+      ) : null}
+
+      <Dialog
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        maxWidth="sm"
+        fullWidth
+        slotProps={{
+          paper: {
+            sx: { borderRadius: 3 },
+          },
+        }}
+      >
+        <DialogTitle>AI 모델 설정</DialogTitle>
+        <DialogContent>
           <Stack spacing={2}>
+            <Alert severity="info">
+              Provider를 비우면 서버 기본 provider가 사용됩니다. System Prompt는 별도 systemPrompt
+              필드로 전송되며, 대화 메시지에는 사용자와 assistant 메시지만 유지됩니다.
+            </Alert>
+            {serverMemoryEnabled ? (
+              <Alert severity="info">
+                서버가 conversationId 기반 대화 기억을 지원합니다. 켜면 이전 대화는 서버 메모리에서
+                이어지며, 클라이언트는 현재 턴 메시지만 전송합니다.
+              </Alert>
+            ) : (
+              <Alert severity="warning">
+                서버에서 대화 기억 기능이 비활성화되어 있습니다.
+              </Alert>
+            )}
             <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
               <TextField
                 select
@@ -100,12 +246,23 @@ export function ChatPage() {
               >
                 {providers.map((item) => (
                   <MenuItem key={item.name} value={item.name}>
-                    {item.name}
+                    <Stack spacing={0}>
+                      <Typography variant="body2">{item.name}</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        chat: {item.chat.enabled ? item.chat.model : "disabled"}
+                      </Typography>
+                    </Stack>
                   </MenuItem>
                 ))}
               </TextField>
               <TextField label="Model" value={model} onChange={(event) => setModel(event.target.value)} fullWidth size="small" />
             </Stack>
+            {selectedProvider ? (
+              <Typography variant="caption" color="text.secondary">
+                Embedding: {selectedProvider.embedding.enabled ? selectedProvider.embedding.model : "disabled"}
+                {aiInfo?.vector.available ? ` · Vector: ${aiInfo.vector.implementation}` : " · Vector: unavailable"}
+              </Typography>
+            ) : null}
             <TextField
               label="System Prompt"
               value={systemPrompt}
@@ -113,50 +270,270 @@ export function ChatPage() {
               multiline
               minRows={2}
               size="small"
+              fullWidth
             />
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+              <Stack spacing={0} sx={{ flex: 1 }}>
+                <Typography variant="body2">대화 기억</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {memoryEnabled ? `사용 중 · ${conversationId}` : "사용하지 않음"}
+                </Typography>
+              </Stack>
+              <Switch
+                checked={memoryEnabled}
+                disabled={!serverMemoryEnabled}
+                onChange={(event) => setMemoryEnabled(event.target.checked)}
+              />
+            </Stack>
           </Stack>
-        </CardContent>
-      </Card>
-      <Card variant="outlined">
-        <CardContent>
-          <Stack spacing={1.5}>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" onClick={() => setSettingsOpen(false)}>
+            닫기
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Paper
+        elevation={0}
+        sx={{ minHeight: "calc(100vh - 170px)", display: "flex", flexDirection: "column" }}
+      >
+        <Box sx={{ flex: 1, overflowY: "auto", px: { xs: 1, md: 8 }, py: 3 }}>
+          <Stack spacing={2}>
             {messages.length === 0 ? (
-              <Typography color="text.secondary">대화를 시작하세요.</Typography>
+              <Stack spacing={1} alignItems="center" justifyContent="center" sx={{ minHeight: 260 }}>
+                <Avatar sx={{ bgcolor: "primary.main" }}>
+                  <SmartToyOutlined />
+                </Avatar>
+                <Typography color="text.secondary">메시지를 입력해 AI와 대화를 시작하세요.</Typography>
+              </Stack>
             ) : (
               messages.map((message, index) => (
-                <Box
+                <Stack
                   key={`${message.role}-${index}`}
+                  direction="row"
+                  justifyContent={message.role === "user" ? "flex-end" : "flex-start"}
                   sx={{
-                    alignSelf: message.role === "user" ? "flex-end" : "flex-start",
-                    maxWidth: "80%",
-                    p: 1.5,
-                    borderRadius: 1,
-                    bgcolor: message.role === "user" ? "primary.light" : "grey.100",
+                    "& .user-message-actions": {
+                      opacity: 0,
+                      transition: "opacity 120ms ease",
+                    },
+                    "&:hover .user-message-actions": {
+                      opacity: 1,
+                    },
                   }}
                 >
-                  <Typography variant="caption" color="text.secondary">
-                    {message.role}
-                    {message.model ? ` · ${message.model}` : ""}
-                  </Typography>
-                  <Typography>{message.content}</Typography>
-                </Box>
+                  <Stack spacing={0.5} alignItems={message.role === "user" ? "flex-end" : "flex-start"}>
+                    <Box
+                      sx={{
+                        maxWidth: { xs: "92%", md: message.role === "user" ? "76%" : "72%" },
+                        px: message.role === "user" ? 1.75 : 2,
+                        py: message.role === "user" ? 1 : 1.5,
+                        borderRadius: message.role === "user" ? 2 : "18px 18px 18px 4px",
+                        bgcolor: message.role === "user" ? "rgba(2, 132, 199, 0.10)" : "background.paper",
+                        color: message.role === "user" ? "info.main" : "text.primary",
+                        border: "none",
+                        boxShadow: message.role === "user" ? "0 1px 2px rgba(15, 23, 42, 0.08)" : "none",
+                      }}
+                    >
+                      {message.role === "assistant" ? (
+                        <Typography variant="ca
+                        ption" color="text.secondary">
+                          Assistant{message.model ? ` · ${message.model}` : ""}
+                        </Typography>
+                      ) : null}
+                      <Typography sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: message.role === "assistant" ? 13 : 14 }}>
+                        {message.content}
+                      </Typography>
+                      {message.role === "assistant" ? renderTokenUsage(message.metadata) : null}
+                    </Box>
+                    {message.role === "user" ? (
+                      <Stack
+                        className="user-message-actions"
+                        direction="row"
+                        spacing={0.5}
+                        alignItems="center"
+                        sx={{ pr: 0.5 }}
+                      >
+                        <Typography variant="caption" color="text.secondary">
+                          {formatMessageTime(message.createdAt)}
+                        </Typography>
+                        <Tooltip title="복사">
+                          <IconButton size="small" onClick={() => void handleCopyMessage(message.content)}>
+                            <ContentCopyOutlined fontSize="inherit" />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="편집">
+                          <IconButton size="small" onClick={() => handleEditMessage(index, message.content)}>
+                            <EditNoteOutlined fontSize="inherit" />
+                          </IconButton>
+                        </Tooltip>
+                      </Stack>
+                    ) : null}
+                  </Stack>
+                </Stack>
               ))
             )}
+            {sending ? (
+              <Stack direction="row" justifyContent="flex-start">
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1,
+                    p: 1.5,
+                    borderRadius: 2,
+                    bgcolor: "background.paper",
+                    border: "1px solid",
+                    borderColor: "divider",
+                  }}
+                >
+                  <CircularProgress size={16} />
+                  <Typography variant="body2" color="text.secondary">
+                    응답 생성 중...
+                  </Typography>
+                </Box>
+              </Stack>
+            ) : null}
           </Stack>
-        </CardContent>
-      </Card>
-      <TextField
-        label="Text"
-        value={input}
-        onChange={(event) => setInput(event.target.value)}
-        multiline
-        minRows={3}
-      />
-      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-        <Button variant="contained" onClick={() => void handleSend()} disabled={sending || !input.trim()}>
-          전송
-        </Button>
-      </Box>
+        </Box>
+        <Box sx={{ px: { xs: 1, md: 6 }, pb: 2 }}>
+          <Card
+            variant="outlined"
+            sx={{
+              borderRadius: 3,
+              bgcolor: "background.paper",
+              boxShadow: "0 8px 28px rgba(15, 23, 42, 0.08)",
+            }}
+          >
+            <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
+              <Stack spacing={1}>
+                <TextField
+                  value={input}
+                  onChange={(event) => setInput(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+                      void handleSend();
+                    }
+                  }}
+                  placeholder="답글..."
+                  multiline
+                  minRows={2}
+                  maxRows={6}
+                  fullWidth
+                  variant="standard"
+                  InputProps={{ disableUnderline: true }}
+                />
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Box sx={{ flex: 1 }} />
+                  <Tooltip title="모델 선택">
+                    <Button
+                      size="small"
+                      variant="text"
+                      endIcon={<ExpandMoreOutlined fontSize="small" />}
+                      onClick={(event) => setModelAnchorEl(event.currentTarget)}
+                      sx={{
+                        color: "text.primary",
+                        px: 1,
+                        minWidth: 0,
+                        "&:hover": { bgcolor: "action.hover" },
+                      }}
+                    >
+                      {model || "모델 설정"}
+                    </Button>
+                  </Tooltip>
+                  <Tooltip title="보내기">
+                    <span>
+                      <IconButton
+                        color="primary"
+                        onClick={() => void handleSend()}
+                        disabled={sending || !input.trim() || configurationMissing}
+                        sx={{
+                          width: 40,
+                          height: 40,
+                          bgcolor: "primary.main",
+                          color: "primary.contrastText",
+                          "&:hover": { bgcolor: "primary.dark" },
+                          "&.Mui-disabled": {
+                            bgcolor: "action.disabledBackground",
+                            color: "action.disabled",
+                          },
+                        }}
+                      >
+                        <ArrowUpwardOutlined fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+          <Popover
+            open={modelMenuOpen}
+            anchorEl={modelAnchorEl}
+            onClose={handleModelMenuClose}
+            anchorOrigin={{ vertical: "top", horizontal: "right" }}
+            transformOrigin={{ vertical: "bottom", horizontal: "right" }}
+            PaperProps={{
+              sx: {
+                width: 360,
+                borderRadius: 2,
+                p: 1,
+                mb: 1,
+              },
+            }}
+          >
+            <Stack spacing={0.5}>
+              {providers
+                .filter((item) => item.chat.enabled)
+                .map((item) => {
+                  const selected = item.name === provider;
+                  return (
+                    <Button
+                      key={item.name}
+                      variant="text"
+                      onClick={() => handleModelSelect(item.name)}
+                      sx={{
+                        justifyContent: "space-between",
+                        textAlign: "left",
+                        color: "text.primary",
+                        px: 1.5,
+                        py: 1,
+                      }}
+                    >
+                      <Box>
+                        <Typography variant="body2">{item.chat.model || item.name}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {item.name}
+                        </Typography>
+                      </Box>
+                      {selected ? <CheckOutlined color="primary" fontSize="small" /> : null}
+                    </Button>
+                  );
+                })}
+              <Button
+                variant="text"
+                onClick={() => {
+                  handleModelMenuClose();
+                  setSettingsOpen(true);
+                }}
+                sx={{ justifyContent: "space-between", color: "text.primary", px: 1.5, py: 1 }}
+              >
+                <Box>
+                  <Typography variant="body2">더 많은 모델</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    provider와 model을 직접 설정합니다.
+                  </Typography>
+                </Box>
+                <ExpandMoreOutlined fontSize="small" sx={{ transform: "rotate(-90deg)" }} />
+              </Button>
+            </Stack>
+          </Popover>
+          <Typography variant="caption" color="text.secondary" display="block" textAlign="center" sx={{ mt: 1 }}>
+            AI는 실수할 수 있습니다. 중요한 결과는 다시 확인하세요.
+          </Typography>
+        </Box>
+      </Paper>
     </Stack>
   );
 }

--- a/src/react/pages/ai/ChatPage.tsx
+++ b/src/react/pages/ai/ChatPage.tsx
@@ -337,8 +337,7 @@ export function ChatPage() {
                       }}
                     >
                       {message.role === "assistant" ? (
-                        <Typography variant="ca
-                        ption" color="text.secondary">
+                        <Typography variant="caption" color="text.secondary">
                           Assistant{message.model ? ` · ${message.model}` : ""}
                         </Typography>
                       ) : null}

--- a/src/react/pages/ai/RagPage.tsx
+++ b/src/react/pages/ai/RagPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   Alert,
+  Box,
   Button,
   Card,
   CardContent,
@@ -28,11 +29,15 @@ export function RagPage() {
   const [model, setModel] = useState("");
   const [query, setQuery] = useState("");
   const [topK, setTopK] = useState("3");
+  const [objectType, setObjectType] = useState("");
+  const [objectId, setObjectId] = useState("");
+  const [debug, setDebug] = useState(false);
   const [expandedQuery, setExpandedQuery] = useState("");
   const [expandedKeywords, setExpandedKeywords] = useState<string[]>([]);
   const [rows, setRows] = useState<VectorSearchResultDto[]>([]);
   const [chatInput, setChatInput] = useState("");
   const [chatMessages, setChatMessages] = useState<ChatMessageDto[]>([]);
+  const [ragDiagnostics, setRagDiagnostics] = useState<Record<string, unknown> | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const providers = useMemo<ProviderInfo[]>(() => aiInfo?.providers ?? [], [aiInfo]);
@@ -53,6 +58,17 @@ export function RagPage() {
     () => [
       { field: "id", headerName: "ID", flex: 0.5 },
       { field: "score", headerName: "유사도", flex: 0.3, sortable: true },
+      {
+        colId: "objectScope",
+        headerName: "객체 범위",
+        flex: 0.6,
+        valueGetter: (params) => {
+          const metadata = params.data?.metadata ?? {};
+          const type = metadata.objectType;
+          const id = metadata.objectId;
+          return type || id ? `${type ?? "-"}#${id ?? "-"}` : "-";
+        },
+      },
       { field: "content", headerName: "콘텐츠", flex: 1.3 },
     ],
     []
@@ -65,6 +81,8 @@ export function RagPage() {
         query: usingExpandedQuery ? expandedQuery : query,
         topK: Number(topK) || 3,
         hybrid: true,
+        objectType: objectType.trim() || undefined,
+        objectId: objectId.trim() || undefined,
       });
       setRows(data);
     } catch (searchError) {
@@ -96,6 +114,7 @@ export function RagPage() {
 
     setChatMessages(nextMessages);
     setChatInput("");
+    setRagDiagnostics(null);
     setError(null);
 
     try {
@@ -107,6 +126,9 @@ export function RagPage() {
         },
         ragQuery: expandedQuery.trim() || query.trim() || trimmed,
         ragTopK: Number(topK) || 3,
+        objectType: objectType.trim() || undefined,
+        objectId: objectId.trim() || undefined,
+        debug,
       });
 
       const assistant = [...response.messages]
@@ -116,6 +138,9 @@ export function RagPage() {
       if (assistant) {
         setChatMessages((current) => [...current, assistant]);
       }
+      setRagDiagnostics(
+        (response.metadata?.ragDiagnostics as Record<string, unknown> | undefined) ?? null
+      );
     } catch (chatError) {
       setError(resolveAxiosError(chatError));
     }
@@ -154,6 +179,38 @@ export function RagPage() {
               </TextField>
               <TextField label="Model" value={model} onChange={(event) => setModel(event.target.value)} fullWidth size="small" />
               <TextField label="topK" value={topK} onChange={(event) => setTopK(event.target.value)} sx={{ maxWidth: 140 }} size="small" />
+            </Stack>
+            <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+              <TextField
+                label="objectType"
+                value={objectType}
+                onChange={(event) => setObjectType(event.target.value)}
+                placeholder="예: attachment"
+                helperText="첨부 파일 RAG는 attachment를 사용합니다."
+                fullWidth
+                size="small"
+              />
+              <TextField
+                label="objectId"
+                value={objectId}
+                onChange={(event) => setObjectId(event.target.value)}
+                placeholder="예: 123"
+                helperText="파일 기반 RAG는 attachmentId를 입력합니다."
+                fullWidth
+                size="small"
+              />
+              <TextField
+                select
+                label="debug"
+                value={debug ? "true" : "false"}
+                onChange={(event) => setDebug(event.target.value === "true")}
+                sx={{ maxWidth: 140 }}
+                size="small"
+                helperText="운영 정보 표시"
+              >
+                <MenuItem value="false">false</MenuItem>
+                <MenuItem value="true">true</MenuItem>
+              </TextField>
             </Stack>
             <TextField label="쿼리" value={query} onChange={(event) => setQuery(event.target.value)} size="small" />
             <Stack direction="row" spacing={1}>
@@ -216,6 +273,28 @@ export function RagPage() {
                 ))}
               </Stack>
               <TextField label="확장 쿼리" value={expandedQuery} InputProps={{ readOnly: true }} />
+            </Stack>
+          </CardContent>
+        </Card>
+      ) : null}
+      {ragDiagnostics ? (
+        <Card variant="outlined">
+          <CardContent>
+            <Stack spacing={1}>
+              <Typography variant="subtitle2">RAG Diagnostics</Typography>
+              <Box
+                component="pre"
+                sx={{
+                  m: 0,
+                  p: 1,
+                  bgcolor: "grey.100",
+                  borderRadius: 1,
+                  overflow: "auto",
+                  fontSize: 12,
+                }}
+              >
+                {JSON.stringify(ragDiagnostics, null, 2)}
+              </Box>
             </Stack>
           </CardContent>
         </Card>

--- a/src/react/pages/ai/api.ts
+++ b/src/react/pages/ai/api.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/types/studio/ai";
 
 const BASE = "/api/ai";
+const MGMT_BASE = "/api/mgmt/ai";
 
 export const reactAiApi = {
   sendChat(req: ChatRequestDto) {
@@ -26,7 +27,7 @@ export const reactAiApi = {
   },
 
   searchVector(req: VectorSearchRequestDto) {
-    return apiRequest<VectorSearchResultDto[]>("post", `${BASE}/vectors/search`, { data: req });
+    return apiRequest<VectorSearchResultDto[]>("post", `${MGMT_BASE}/vectors/search`, { data: req });
   },
 
   rewriteQuery(req: QueryRewriteRequestDto) {

--- a/src/types/studio/ai.ts
+++ b/src/types/studio/ai.ts
@@ -12,8 +12,15 @@ export interface ChatRequestDto {
   systemPrompt?: string; // 선택
   temperature?: number; // 선택
   topP?: number; // 선택
+  topK?: number; // 선택
   maxOutputTokens?: number; // 선택
   stopSequences?: string[]; // 선택
+  memory?: ChatMemoryOptionsDto;
+}
+
+export interface ChatMemoryOptionsDto {
+  enabled?: boolean;
+  conversationId?: string;
 }
 
 export interface ChatResponseDto {
@@ -28,6 +35,7 @@ export interface ChatRagRequestDto {
   ragTopK?: number; // 선택
   objectType?: string;
   objectId?: string;
+  debug?: boolean;
 }
 
 export interface TokenUsageDto {
@@ -59,6 +67,18 @@ export interface AiInfoResponse {
   readonly providers: ProviderInfo[];
   readonly defaultProvider: string;
   readonly vector: VectorInfo;
+  readonly chat?: ChatInfo;
+}
+
+export interface ChatInfo {
+  readonly memory?: ChatMemoryInfo;
+}
+
+export interface ChatMemoryInfo {
+  readonly enabled: boolean;
+  readonly maxMessages?: number;
+  readonly maxConversations?: number;
+  readonly ttl?: string;
 }
 
 export interface AclActionMaskDto {
@@ -86,6 +106,9 @@ export interface SearchResponseDto {
 
 export interface VectorSearchRequestDto extends SearchRequestDto {
   embedding?: number[];
+  objectType?: string;
+  objectId?: string;
+  minScore?: number;
 }
 
 export interface VectorDocumentDto {


### PR DESCRIPTION
## Why
- Align the AI chat and RAG client with the updated server AI API guide and chat memory capability response.
- No issue number was provided, so this PR records the AI chat client update directly.

## What
- Added chat memory capability typing and opt-in UI with conversation reset.
- Updated chat sending to transmit only the current user turn when memory is enabled.
- Moved AI chat settings to a toolbar dialog.
- Improved the chatbot-style conversation UI, model selector, user message hover actions, and token usage display.
- Updated vector search to use `/api/mgmt/ai/vectors/search` and added RAG object scope/debug diagnostics handling.

## Related Issues
- Closes #
- Related #

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: Chat memory stores recent conversation turns server-side when explicitly enabled by the user.
- Mitigation: Client only opts in when server capability is advertised, sends only the current turn when memory is enabled, and provides a new-conversation reset action.

## Validation
- Commands:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Result:
  - `npm run typecheck` passed
  - `npm run lint` passed with existing warnings only
  - `npm run build` passed with existing Vite large chunk warning

## Subagent Usage
- [x] No

## Checklist
- [x] policy-compliant commit message
- [x] validation recorded
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: Deploy after the server capability PR that adds `chat.memory` to `/api/ai/info/providers`.
- Rollback plan: Revert this PR.
- Post-deploy checks: Verify chat settings, memory opt-in, new conversation reset, and RAG vector search.