### PR TITLE
[ai-assisted] feat(ai-rag): RAG 운영과 대화 UI 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,10 @@ replay_pid*
 **/bin
 **/build
 .gradle/
-
+.claude/
+.omx/
+.tmp/
+.policy*/
 .env.local
 .package-lock.json
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 2026-04-28
+
+### Changed
+
+- AI RAG management now uses a job-list-first screen with `sourceName` document display and a dedicated job detail route for logs, chunks, and metadata.
+- AI RAG management now exposes the chunking simulation dialog from the job list toolbar.
+- AI RAG job list and detail pages now follow the admin users list/detail layout pattern with icon-only list actions and right-side detail contents navigation.
+- AI RAG job list status chips now include status icons so failed and warning jobs are distinguishable beyond background color.
+- AI RAG job detail now renders the indexed chunk result grid directly instead of hiding it behind an accordion.
+- AI RAG job detail chunk grid now follows the ACL entry grid pattern with a section header, taller grid, and row tooltips.
+- AI RAG job detail summary now shows the chunking strategy, falling back to chunk metadata when the job response does not include explicit chunking fields.
+- AI RAG search validation now lives on the job list page and runs against the selected job scope, while the job detail page focuses on progress, chunks, logs, and metadata.
+- AI RAG job detail summary now includes a progress stepper for pending, extraction, chunking, embedding, indexing, and completion states.
+- AI RAG job detail now shows selected chunk details in a structured inspector with content, provenance, chunk links, embedding fields, and collapsed raw metadata.
+- AI RAG job detail no longer shows a separate object metadata section because selected chunk metadata is available in the chunk inspector.
+- AI RAG job detail now shows failure and warning logs as a direct grid section instead of an accordion.
+- AI RAG job detail chunk review now uses compact provenance, length quality bars, a smaller status chip, a two-column chunk inspector, image-caption cues, and a selected-chunk similarity test action.
+
+### Verification
+
+- AI RAG job list/detail split: `npm run typecheck`
+- AI RAG job list/detail split: `npm run lint`
+- AI RAG job list/detail split: `npm run build`
+- AI RAG chunking simulation dialog: `npm run typecheck`
+- AI RAG chunking simulation dialog: `npm run lint`
+- AI RAG admin-users layout alignment: `npm run typecheck`
+- AI RAG admin-users layout alignment: `npm run lint`
+- AI RAG status icon chips: `npm run typecheck`
+- AI RAG status icon chips: `npm run lint`
+- AI RAG direct chunk grid detail: `npm run typecheck`
+- AI RAG chunk grid ACL-entry alignment: `npm run typecheck`
+- AI RAG chunk grid ACL-entry alignment: `npm run lint`
+- AI RAG chunking strategy summary: `npm run typecheck`
+- AI RAG search validation list move and detail stepper: `npm run typecheck`
+- AI RAG search validation list move and detail stepper: `npm run lint`
+- AI RAG chunk detail inspector: `npm run typecheck`
+- AI RAG chunk detail inspector: `npm run lint`
+- AI RAG detail metadata section removal: `npm run typecheck`
+- AI RAG detail metadata section removal: `npm run lint`
+- AI RAG direct failure and warning log grid: `npm run typecheck`
+- AI RAG direct failure and warning log grid: `npm run lint`
+- AI RAG chunk review efficiency UI: `npm run typecheck`
+- AI RAG chunk review efficiency UI: `npm run lint`
+
 ## 2026-04-13
 
 ### Changed

--- a/src/react/components/ag-grid/GridContent.tsx
+++ b/src/react/components/ag-grid/GridContent.tsx
@@ -36,6 +36,7 @@ function GridContentInner<TData = unknown>(
     events,
     rowSelection,
     rowData,
+    loading,
     autoResize,
     height,
     onFilterActived,
@@ -113,6 +114,28 @@ function GridContentInner<TData = unknown>(
   }, [rowData]);
 
   useEffect(() => {
+    gridApiRef.current?.setGridOption("loading", Boolean(loading));
+  }, [loading]);
+
+  useEffect(() => {
+    const gridApi = gridApiRef.current;
+    if (!gridApi) {
+      return;
+    }
+
+    if (loading) {
+      gridApi.hideOverlay();
+      return;
+    }
+
+    if (rowData.length > 0) {
+      gridApi.hideOverlay();
+    } else {
+      gridApi.showNoRowsOverlay();
+    }
+  }, [loading, rowData]);
+
+  useEffect(() => {
     if (!shouldAutoResize) {
       return;
     }
@@ -161,6 +184,7 @@ function GridContentInner<TData = unknown>(
         rowSelection={normalizedRowSelection}
         columnDefs={columnDefs}
         rowData={rowData}
+        loading={loading}
         onRowSelected={onRowSelected}
         onFilterChanged={handleFilterChanged}
         onSelectionChanged={handleSelectionChanged}

--- a/src/react/components/ag-grid/GridContent.tsx
+++ b/src/react/components/ag-grid/GridContent.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useTheme } from "@mui/material/styles";
 import type {
   ColDef,
   FilterChangedEvent,
@@ -17,6 +18,7 @@ import type {
 } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { defaultGridOptions } from "@/react/components/ag-grid/gridOptions";
+import { createAgGridTheme } from "@/react/components/ag-grid/theme";
 import type {
   GridContentHandle,
   GridContentProps,
@@ -41,6 +43,7 @@ function GridContentInner<TData = unknown>(
   }: GridContentProps<TData>,
   ref: React.ForwardedRef<GridContentHandle<TData>>
 ) {
+  const muiTheme = useTheme();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const gridApiRef = useRef<GridApi<TData> | null>(null);
   const reservedScrollIndexRef = useRef(0);
@@ -57,6 +60,7 @@ function GridContentInner<TData = unknown>(
     () => normalizeRowSelection(rowSelection),
     [rowSelection]
   );
+  const agGridTheme = useMemo(() => createAgGridTheme(muiTheme), [muiTheme]);
 
   const resizeGrid = useCallback(() => {
     if (!containerRef.current) {
@@ -148,11 +152,12 @@ function GridContentInner<TData = unknown>(
   return (
     <div
       ref={containerRef}
-      className="ag-theme-material react-grid-host"
+      className="react-grid-host"
       style={{ width: "100%", height: gridHeight }}
     >
       <AgGridReact<TData>
         gridOptions={gridOptions}
+        theme={agGridTheme}
         rowSelection={normalizedRowSelection}
         columnDefs={columnDefs}
         rowData={rowData}

--- a/src/react/components/ag-grid/PageableGridContent.tsx
+++ b/src/react/components/ag-grid/PageableGridContent.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useTheme } from "@mui/material/styles";
 import type {
   ColDef,
   GridApi,
@@ -19,6 +20,7 @@ import type {
 import { AgGridReact } from "ag-grid-react";
 import { toast } from "@/react/feedback";
 import { defaultGridOptions } from "@/react/components/ag-grid/gridOptions";
+import { createAgGridTheme } from "@/react/components/ag-grid/theme";
 import type {
   AgGridCompatibleDataSource,
   PageableGridContentHandle,
@@ -55,6 +57,7 @@ function PageableGridContentInner<TData = unknown>(
   }: PageableGridContentProps<TData>,
   ref: React.ForwardedRef<PageableGridContentHandle<TData>>
 ) {
+  const muiTheme = useTheme();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const gridApiRef = useRef<GridApi<TData> | null>(null);
   const [gridHeight, setGridHeight] = useState(height ?? 400);
@@ -73,6 +76,7 @@ function PageableGridContentInner<TData = unknown>(
     () => normalizeRowSelection(rowSelection),
     [rowSelection]
   );
+  const agGridTheme = useMemo(() => createAgGridTheme(muiTheme), [muiTheme]);
 
   const columnDefs = useMemo<ColDef<TData>[]>(
     () =>
@@ -215,12 +219,13 @@ function PageableGridContentInner<TData = unknown>(
   return (
     <div
       ref={containerRef}
-      className="ag-theme-material react-grid-host"
+      className="react-grid-host"
       style={{ width: "100%", height: gridHeight }}
     >
       <AgGridReact<TData>
         rowModelType={effectiveRowModelType}
         gridOptions={gridOptions}
+        theme={agGridTheme}
         rowSelection={normalizedRowSelection}
         columnDefs={columnDefs}
         pagination

--- a/src/react/components/ag-grid/styles.css
+++ b/src/react/components/ag-grid/styles.css
@@ -1,14 +1,9 @@
-@import "ag-grid-community/styles/ag-grid.css";
-@import "ag-grid-community/styles/ag-theme-material.css";
-
 .react-grid-host {
   width: 100%;
   height: 100%;
-  --ag-header-background-color: #f5f5f5;
   --ag-header-column-separator-display: block;
   --ag-header-column-separator-height: 60%;
   --ag-header-column-separator-width: 1px;
-  --ag-header-column-separator-color: rgba(148, 163, 184, 0.45);
 }
 
 .react-grid-host .ag-root-wrapper {
@@ -18,7 +13,6 @@
 .react-grid-host .ag-header,
 .react-grid-host .ag-header-row {
   min-height: 44px;
-  background-color: #f5f5f5;
 }
 
 .react-grid-host .ag-header-cell,
@@ -31,8 +25,7 @@
 .react-grid-host .ag-header-cell {
   padding-top: 0;
   padding-bottom: 0;
-  border-right: 1px solid rgba(148, 163, 184, 0.45);
-  background-color: #f5f5f5;
+  border-right: 1px solid var(--ag-header-column-separator-color);
 }
 
 .react-grid-host .ag-header-cell-label,
@@ -84,6 +77,40 @@
 
 .react-grid-host .ag-selection-checkbox {
   width: 100%;
+}
+
+.react-grid-host .ag-header-cell.selection-column-centered .ag-header-cell-comp-wrapper,
+.react-grid-host .ag-header-cell.selection-column-centered .ag-header-select-all,
+.react-grid-host .ag-cell.selection-column-centered .ag-cell-wrapper,
+.react-grid-host .ag-cell.selection-column-centered .ag-cell-value {
+  width: 100%;
+  justify-content: center;
+}
+
+.react-grid-host .ag-cell.selection-column-centered,
+.react-grid-host .ag-header-cell.selection-column-centered {
+  padding-left: 0;
+  padding-right: 0;
+  justify-content: center;
+  position: relative;
+}
+
+.react-grid-host .ag-cell.selection-column-centered .ag-selection-checkbox,
+.react-grid-host .ag-header-cell.selection-column-centered .ag-selection-checkbox {
+  width: fit-content;
+  display: inline-flex;
+  flex: 0 0 auto;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.react-grid-host .ag-header-cell.id-column-centered .ag-header-cell-comp-wrapper,
+.react-grid-host .ag-header-cell.id-column-centered .ag-header-cell-label,
+.react-grid-host .ag-cell.id-column-centered .ag-cell-wrapper,
+.react-grid-host .ag-cell.id-column-centered .ag-cell-value {
+  width: 100%;
+  justify-content: center;
 }
 
 .react-grid-host .ag-paging-panel {

--- a/src/react/components/ag-grid/styles.css
+++ b/src/react/components/ag-grid/styles.css
@@ -70,6 +70,11 @@
   padding: 0;
 }
 
+.react-grid-host .ag-selection-checkbox .ag-checkbox-input-wrapper {
+  display: inline-flex;
+  line-height: 1;
+}
+
 .react-grid-host .ag-cell[col-id="ag-Grid-SelectionColumn"] .ag-cell-wrapper,
 .react-grid-host .ag-cell[col-id="ag-Grid-SelectionColumn"] .ag-cell-value {
   justify-content: center;
@@ -82,8 +87,12 @@
 .react-grid-host .ag-header-cell.selection-column-centered .ag-header-cell-comp-wrapper,
 .react-grid-host .ag-header-cell.selection-column-centered .ag-header-select-all,
 .react-grid-host .ag-cell.selection-column-centered .ag-cell-wrapper,
-.react-grid-host .ag-cell.selection-column-centered .ag-cell-value {
+.react-grid-host .ag-cell.selection-column-centered .ag-cell-value,
+.react-grid-host .ag-cell.selection-column-centered .ag-react-container {
+  height: 100%;
   width: 100%;
+  display: flex;
+  align-items: center;
   justify-content: center;
 }
 
@@ -102,7 +111,31 @@
   flex: 0 0 auto;
   position: absolute;
   left: 50%;
-  transform: translateX(-50%);
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.react-grid-host .ag-cell.selection-column-centered .ag-react-container > .MuiBox-root,
+.react-grid-host .ag-header-cell.selection-column-centered .MuiBox-root {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.react-grid-host .ag-cell.selection-column-centered input[type="checkbox"],
+.react-grid-host .ag-header-cell.selection-column-centered input[type="checkbox"] {
+  display: block;
+  flex: 0 0 auto;
+  vertical-align: middle;
+}
+
+.react-grid-host input[type="checkbox"][aria-label="전체 선택"] {
+  vertical-align: middle;
+}
+
+.react-grid-host input[type="checkbox"][aria-label="행 선택"] {
+  vertical-align: middle;
 }
 
 .react-grid-host .ag-header-cell.id-column-centered .ag-header-cell-comp-wrapper,

--- a/src/react/components/ag-grid/theme.ts
+++ b/src/react/components/ag-grid/theme.ts
@@ -1,0 +1,21 @@
+import type { Theme as MuiTheme } from "@mui/material/styles";
+import { themeMaterial } from "ag-grid-community";
+
+export function createAgGridTheme(theme: MuiTheme) {
+  const dark = theme.palette.mode === "dark";
+
+  return themeMaterial.withParams({
+    primaryColor: theme.palette.primary.main,
+    backgroundColor: dark ? "#1f2836" : theme.palette.background.paper,
+    foregroundColor: dark ? "#e5e7eb" : theme.palette.text.primary,
+    headerBackgroundColor: dark ? "#1f2836" : theme.palette.grey[50],
+    headerTextColor: dark ? "#e5e7eb" : theme.palette.text.primary,
+    borderColor: dark ? "rgba(255, 255, 255, 0.16)" : theme.palette.divider,
+    rowHoverColor: dark ? "rgba(96, 165, 250, 0.14)" : "rgba(21, 101, 192, 0.06)",
+    selectedRowBackgroundColor: dark ? "rgba(96, 165, 250, 0.18)" : "rgba(21, 101, 192, 0.10)",
+    wrapperBorderRadius: 8,
+    borderRadius: 8,
+    fontSize: 14,
+    headerFontWeight: 400,
+  });
+}

--- a/src/react/components/ag-grid/types.ts
+++ b/src/react/components/ag-grid/types.ts
@@ -18,6 +18,7 @@ export interface GridContentProps<TData = unknown> {
   events?: GridEventListener[];
   rowSelection?: RowSelectionOptions<TData> | "single" | "multiple";
   rowData: TData[];
+  loading?: boolean;
   autoResize?: boolean;
   height?: number;
   onFilterActived?: (active: boolean) => void;

--- a/src/react/components/code-editor/TemplateCodeEditor.tsx
+++ b/src/react/components/code-editor/TemplateCodeEditor.tsx
@@ -8,6 +8,7 @@ import { java } from "@codemirror/lang-java";
 import { markdown } from "@codemirror/lang-markdown";
 import { json } from "@codemirror/lang-json";
 import {
+  alpha,
   Box,
   FormControl,
   FormControlLabel,
@@ -17,6 +18,7 @@ import {
   Switch,
   Typography,
 } from "@mui/material";
+import { useTheme, type Theme as MuiTheme } from "@mui/material/styles";
 import type { Extension } from "@codemirror/state";
 
 export type EditorLanguage =
@@ -38,8 +40,64 @@ const LANGUAGE_OPTIONS: { value: EditorLanguage; label: string }[] = [
   { value: "text", label: "Plain Text" },
 ];
 
-function getExtensions(language: EditorLanguage, wordWrap: boolean): Extension[] {
-  const langExt: Extension[] = [];
+function getEditorTheme(theme: MuiTheme): Extension {
+  const dark = theme.palette.mode === "dark";
+
+  return EditorView.theme(
+    {
+      "&": {
+        color: theme.palette.text.primary,
+        backgroundColor: theme.palette.background.paper,
+      },
+      ".cm-content": {
+        color: theme.palette.text.primary,
+        caretColor: theme.palette.primary.main,
+      },
+      ".cm-line": {
+        color: theme.palette.text.primary,
+      },
+      ".cm-gutters": {
+        color: theme.palette.text.secondary,
+        backgroundColor: dark
+          ? alpha(theme.palette.common.black, 0.16)
+          : theme.palette.grey[50],
+        borderRightColor: theme.palette.divider,
+      },
+      ".cm-activeLine": {
+        backgroundColor: dark
+          ? alpha(theme.palette.primary.main, 0.12)
+          : alpha(theme.palette.primary.main, 0.06),
+      },
+      ".cm-activeLineGutter": {
+        color: theme.palette.text.primary,
+        backgroundColor: dark
+          ? alpha(theme.palette.primary.main, 0.16)
+          : alpha(theme.palette.primary.main, 0.08),
+      },
+      ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
+        backgroundColor: dark
+          ? alpha(theme.palette.primary.light, 0.35)
+          : alpha(theme.palette.primary.main, 0.22),
+      },
+      ".cm-cursor": {
+        borderLeftColor: theme.palette.primary.main,
+      },
+      ".cm-tooltip": {
+        color: theme.palette.text.primary,
+        backgroundColor: theme.palette.background.paper,
+        borderColor: theme.palette.divider,
+      },
+    },
+    { dark }
+  );
+}
+
+function getExtensions(
+  language: EditorLanguage,
+  wordWrap: boolean,
+  theme: MuiTheme
+): Extension[] {
+  const langExt: Extension[] = [getEditorTheme(theme)];
   switch (language) {
     case "html":
       langExt.push(html());
@@ -79,6 +137,7 @@ export function TemplateCodeEditor({
   language,
   onLanguageChange,
 }: TemplateCodeEditorProps) {
+  const theme = useTheme();
   const [wordWrap, setWordWrap] = useState(false);
 
   return (
@@ -104,7 +163,7 @@ export function TemplateCodeEditor({
           py: 0.75,
           borderBottom: "1px solid",
           borderColor: "divider",
-          bgcolor: "grey.50",
+          bgcolor: "background.default",
           flexWrap: "wrap",
         }}
       >
@@ -150,7 +209,8 @@ export function TemplateCodeEditor({
         <CodeMirror
           value={value}
           height="400px"
-          extensions={getExtensions(language, wordWrap)}
+          theme={theme.palette.mode}
+          extensions={getExtensions(language, wordWrap, theme)}
           onChange={onChange}
           basicSetup={{
             lineNumbers: true,

--- a/src/react/components/page/PageToolbar.tsx
+++ b/src/react/components/page/PageToolbar.tsx
@@ -1,4 +1,5 @@
 import {
+  alpha,
   Box,
   Breadcrumbs,
   Divider,
@@ -189,7 +190,9 @@ export function PageToolbar({
         </Box>
       </Stack>
 
-      {divider ? <Divider sx={{ mt: "4px", borderColor: "rgba(148, 163, 184, 0.45)" }} /> : null}
+      {divider ? (
+        <Divider sx={{ mt: "4px", borderColor: (theme) => alpha(theme.palette.divider, 0.9) }} />
+      ) : null}
     </Stack>
   );
 }

--- a/src/react/layouts/AppShellHeader.tsx
+++ b/src/react/layouts/AppShellHeader.tsx
@@ -14,7 +14,7 @@ export function AppShellHeader({ children, leading }: Props) {
           justifyContent: "space-between",
           borderBottom: "1px solid",
           borderColor: "divider",
-          bgcolor: "#ffffff",
+          bgcolor: "background.paper",
         }}
       >
         <Box

--- a/src/react/layouts/FullLayout.tsx
+++ b/src/react/layouts/FullLayout.tsx
@@ -173,7 +173,7 @@ export function FullLayout() {
           sx={{
             flex: 1,
             minWidth: 0,
-            bgcolor: "#ffffff",
+            bgcolor: "background.paper",
             px: { xs: 2, md: 3 },
             py: 3,
           }}

--- a/src/react/layouts/FullLayoutNavigation.tsx
+++ b/src/react/layouts/FullLayoutNavigation.tsx
@@ -118,6 +118,11 @@ export function buildNavSections(): NavSection[] {
           icon: <PsychologyAltOutlined fontSize="small" />,
         },
         {
+          label: "AI RAG Chat",
+          path: "/services/ai/rag-chat",
+          icon: <PsychologyAltOutlined fontSize="small" />,
+        },
+        {
           label: "AI RAG",
           path: "/services/ai/rag",
           icon: <TopicOutlined fontSize="small" />,

--- a/src/react/layouts/FullLayoutNavigation.tsx
+++ b/src/react/layouts/FullLayoutNavigation.tsx
@@ -1,4 +1,5 @@
 import {
+  alpha,
   Box,
   List,
   ListItemButton,
@@ -162,8 +163,8 @@ export function FullLayoutNavigation({
         height: "100%",
         display: "flex",
         flexDirection: "column",
-        bgcolor: "#ffffff",
-        color: "#1f2937",
+        bgcolor: "background.paper",
+        color: "text.primary",
       }}
     >
       <Box sx={{ flex: 1, overflowY: "auto", py: 2 }}>
@@ -184,11 +185,11 @@ export function FullLayoutNavigation({
                   px: 0,
                   py: 0.5,
                   justifyContent: "space-between",
-                  color: "#111827",
+                  color: "text.primary",
                   bgcolor: "transparent",
                   "&:hover": {
                     bgcolor: "transparent",
-                    color: "#2563eb",
+                    color: "primary.main",
                   },
                 }}
               >
@@ -218,7 +219,8 @@ export function FullLayoutNavigation({
                 ml: 0,
                 pl: collapsed ? 0 : 1.5,
                 pr: 0,
-                borderLeft: collapsed ? "none" : "1px solid rgba(148,163,184,0.45)",
+                borderLeft: collapsed ? "none" : "1px solid",
+                borderColor: "divider",
                 display: collapsed || expandedSections[section.title] ? "block" : "none",
               }}
             >
@@ -238,18 +240,18 @@ export function FullLayoutNavigation({
                       py: 0.25,
                       ml: -0.5,
                       justifyContent: collapsed ? "center" : "flex-start",
-                      color: active ? "#2563eb" : "#4b5563",
+                      color: active ? "primary.main" : "text.secondary",
                       "&.Mui-selected": {
                         bgcolor: "transparent",
-                        color: "#2563eb",
+                        color: "primary.main",
                         fontWeight: 700,
                       },
                       "&.Mui-selected:hover": {
-                        bgcolor: "rgba(37,99,235,0.06)",
+                        bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
                       },
                       "&:hover": {
-                        bgcolor: "rgba(37,99,235,0.06)",
-                        color: "#2563eb",
+                        bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
+                        color: "primary.main",
                       },
                     }}
                   >

--- a/src/react/layouts/FullLayoutUserMenu.tsx
+++ b/src/react/layouts/FullLayoutUserMenu.tsx
@@ -1,4 +1,5 @@
 import {
+  alpha,
   Avatar,
   Box,
   Button,
@@ -110,7 +111,7 @@ export function FullLayoutUserMenu({
                 display: "flex",
                 alignItems: "center",
                 gap: 1.5,
-                bgcolor: "rgba(37,99,235,0.04)",
+                bgcolor: (theme) => alpha(theme.palette.primary.main, 0.04),
                 borderBottom: "1px solid",
                 borderColor: "divider",
               }}

--- a/src/react/pages/LoginPage.tsx
+++ b/src/react/pages/LoginPage.tsx
@@ -2,17 +2,17 @@ import { useMemo, useState } from "react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import {
   Alert,
+  alpha,
   Box,
   Button,
   CircularProgress,
-  Container,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
+  Grid,
   IconButton,
   InputAdornment,
-  Paper,
   Stack,
   TextField,
   Typography,
@@ -118,82 +118,136 @@ export function LoginPage() {
     <Box
       sx={{
         minHeight: "100vh",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
         backgroundColor: "background.default",
       }}
     >
-      <Container maxWidth="sm">
-        <Paper elevation={10} sx={{ p: { xs: 3, sm: 5 }, borderRadius: 3 }}>
-          <Typography variant="h4" textAlign="center" sx={{ mb: 4 }}>
-            Studio One Platform
-          </Typography>
-
-          <Box component="form" onSubmit={submitLogin} noValidate>
-            <Stack spacing={2}>
-              <Controller
-                name="username"
-                control={loginForm.control}
-                render={({ field }) => (
-                  <TextField
-                    {...field}
-                    fullWidth
-                    label="아이디"
-                    error={!!loginForm.formState.errors.username}
-                    helperText={loginForm.formState.errors.username?.message}
-                  />
-                )}
-              />
-              <Controller
-                name="password"
-                control={loginForm.control}
-                render={({ field }) => (
-                  <TextField
-                    {...field}
-                    fullWidth
-                    label="비밀번호"
-                    type={showPassword ? "text" : "password"}
-                    error={!!loginForm.formState.errors.password}
-                    helperText={loginForm.formState.errors.password?.message}
-                    slotProps={{
-                      input: {
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            <IconButton
-                              onClick={() => setShowPassword((v) => !v)}
-                              edge="end"
-                            >
-                              {showPassword ? <VisibilityOff /> : <Visibility />}
-                            </IconButton>
-                          </InputAdornment>
-                        ),
-                      },
-                    }}
-                  />
-                )}
-              />
-              <Box sx={{ textAlign: "right" }}>
-                <Button
-                  variant="text"
-                  onClick={() => setResetOpen(true)}
-                  disabled={submitting}
-                >
-                  비밀번호 재설정
-                </Button>
-              </Box>
-              <Button type="submit" variant="contained" size="large" disabled={submitting}>
-                {submitting ? (
-                  <CircularProgress size={20} color="inherit" />
-                ) : (
-                  "로그인"
-                )}
-              </Button>
-              {loginError ? <Alert severity="error">{loginError}</Alert> : null}
+      <Grid container sx={{ minHeight: "100vh" }}>
+        <Grid
+          size={{ xs: false, md: 7 }}
+          sx={{
+            display: { xs: "none", md: "block" },
+            position: "relative",
+            backgroundImage: (theme) =>
+              `linear-gradient(${alpha(theme.palette.common.black, theme.palette.mode === "dark" ? 0.28 : 0.20)}, ${alpha(theme.palette.common.black, theme.palette.mode === "dark" ? 0.70 : 0.56)}), url(https://picsum.photos/1600/1200)`,
+            backgroundRepeat: "no-repeat",
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+          }}
+        >
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "flex-end",
+              p: 8,
+              color: "common.white",
+            }}
+          >
+            <Stack spacing={2} sx={{ maxWidth: 560 }}>
+              <Typography variant="h3" fontWeight={700}>
+                Studio One Platform
+              </Typography>
+              <Typography variant="h6" sx={{ opacity: 0.92, lineHeight: 1.6 }}>
+                운영 데이터와 서비스 흐름을 한 곳에서 관리합니다.
+              </Typography>
+              <Typography variant="body2" sx={{ opacity: 0.78 }}>
+                계정으로 로그인해 관리 콘솔을 계속 진행하세요.
+              </Typography>
             </Stack>
           </Box>
-        </Paper>
-      </Container>
+        </Grid>
+
+        <Grid
+          size={{ xs: 12, md: 5 }}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            px: { xs: 3, sm: 6 },
+            py: 6,
+            bgcolor: "background.paper",
+          }}
+        >
+          <Box sx={{ width: "100%", maxWidth: 420 }}>
+            <Stack spacing={3}>
+              <Box>
+                <Typography variant="h4" fontWeight={700}>
+                  로그인
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                  Studio One Platform에 접속합니다.
+                </Typography>
+              </Box>
+
+              <Box component="form" onSubmit={submitLogin} noValidate>
+                <Stack spacing={2}>
+                  <Controller
+                    name="username"
+                    control={loginForm.control}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        fullWidth
+                        label="아이디"
+                        autoComplete="username"
+                        error={!!loginForm.formState.errors.username}
+                        helperText={loginForm.formState.errors.username?.message}
+                      />
+                    )}
+                  />
+                  <Controller
+                    name="password"
+                    control={loginForm.control}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        fullWidth
+                        label="비밀번호"
+                        autoComplete="current-password"
+                        type={showPassword ? "text" : "password"}
+                        error={!!loginForm.formState.errors.password}
+                        helperText={loginForm.formState.errors.password?.message}
+                        slotProps={{
+                          input: {
+                            endAdornment: (
+                              <InputAdornment position="end">
+                                <IconButton
+                                  onClick={() => setShowPassword((v) => !v)}
+                                  edge="end"
+                                >
+                                  {showPassword ? <VisibilityOff /> : <Visibility />}
+                                </IconButton>
+                              </InputAdornment>
+                            ),
+                          },
+                        }}
+                      />
+                    )}
+                  />
+                  <Box sx={{ textAlign: "right" }}>
+                    <Button
+                      variant="text"
+                      onClick={() => setResetOpen(true)}
+                      disabled={submitting}
+                    >
+                      비밀번호 재설정
+                    </Button>
+                  </Box>
+                  <Button type="submit" variant="contained" size="large" disabled={submitting} fullWidth>
+                    {submitting ? (
+                      <CircularProgress size={20} color="inherit" />
+                    ) : (
+                      "로그인"
+                    )}
+                  </Button>
+                  {loginError ? <Alert severity="error">{loginError}</Alert> : null}
+                </Stack>
+              </Box>
+            </Stack>
+          </Box>
+        </Grid>
+      </Grid>
 
       <Dialog open={resetOpen} onClose={() => setResetOpen(false)} fullWidth maxWidth="xs">
         <DialogTitle>비밀번호 재설정</DialogTitle>

--- a/src/react/pages/admin/GroupsPage.tsx
+++ b/src/react/pages/admin/GroupsPage.tsx
@@ -19,11 +19,15 @@ import { PageableGridContent } from "@/react/components/ag-grid";
 import type { PageableGridContentHandle } from "@/react/components/ag-grid/types";
 import type { GroupDto } from "@/react/pages/admin/datasource";
 import { GroupsDataSource } from "@/react/pages/admin/datasource";
+import { reactGroupsApi } from "@/react/pages/admin/groups/api";
 import { GroupDialog } from "@/react/pages/admin/groups/GroupDialog";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
+import { useConfirm, useToast } from "@/react/feedback";
 
 export function GroupsPage() {
   const navigate = useNavigate();
+  const confirm = useConfirm();
+  const toast = useToast();
   const gridRef = useRef<PageableGridContentHandle<GroupDto>>(null);
   const dataSource = useMemo(() => new GroupsDataSource(), []);
   const [searchInput, setSearchInput] = useState("");
@@ -42,6 +46,7 @@ export function GroupsPage() {
           <Box
             component="button"
             type="button"
+            aria-label={`${params.value} 상세보기`}
             onClick={() => navigate(`/admin/groups/${params.data?.groupId}`)}
             sx={{
               border: 0,
@@ -67,7 +72,7 @@ export function GroupsPage() {
       },
       {
         field: "memberCount",
-        headerName: "맴버",
+        headerName: "멤버",
         filter: false,
         sortable: false,
         flex: 0.4,
@@ -91,26 +96,34 @@ export function GroupsPage() {
       },
       {
         colId: "actions",
-        headerName: "",
+        headerName: "작업",
         filter: false,
         sortable: false,
-        flex: 0.65,
-        minWidth: 132,
+        width: 112,
+        minWidth: 112,
+        maxWidth: 112,
+        pinned: "right",
+        cellStyle: { display: "flex", alignItems: "center", justifyContent: "center" },
         cellRenderer: (params: ICellRendererParams<GroupDto>) => (
           <Box sx={{ display: "flex", gap: 0.5, alignItems: "center", height: "100%" }}>
-            <Tooltip title="멤버 관리는 아직 연결되지 않았습니다.">
+            <Tooltip title="멤버 관리">
               <IconButton
                 size="small"
-                disabled
+                aria-label="멤버 관리"
+                onClick={() =>
+                  params.data?.groupId &&
+                  navigate(`/admin/groups/${params.data.groupId}`, { state: { openMembers: true } })
+                }
               >
                 <GroupOutlined fontSize="small" />
               </IconButton>
             </Tooltip>
-            <Tooltip title="그룹 삭제는 아직 연결되지 않았습니다.">
+            <Tooltip title="삭제">
               <IconButton
                 size="small"
                 color="error"
-                disabled
+                aria-label="삭제"
+                onClick={() => params.data && void handleDeleteGroup(params.data)}
               >
                 <DeleteOutlined fontSize="small" />
               </IconButton>
@@ -118,6 +131,7 @@ export function GroupsPage() {
             <Tooltip title="상세보기">
               <IconButton
                 size="small"
+                aria-label="상세보기"
                 onClick={() => navigate(`/admin/groups/${params.data?.groupId}`)}
               >
                 <ChevronRight fontSize="small" />
@@ -145,6 +159,26 @@ export function GroupsPage() {
     gridRef.current?.refresh();
   };
 
+  async function handleDeleteGroup(group: GroupDto) {
+    const ok = await confirm({
+      title: "그룹 삭제",
+      message: `${group.name} 그룹을 삭제하시겠습니까?`,
+      okText: "삭제",
+      cancelText: "취소",
+    });
+    if (!ok) {
+      return;
+    }
+
+    try {
+      await reactGroupsApi.deleteGroup(group.groupId);
+      toast.success("그룹이 삭제되었습니다.");
+      gridRef.current?.refresh();
+    } catch {
+      toast.error("그룹 삭제에 실패했습니다.");
+    }
+  }
+
   return (
     <Stack spacing={0.5}>
       <PageToolbar
@@ -157,8 +191,8 @@ export function GroupsPage() {
         onSearchValueChange={setSearchInput}
         onSearch={handleSearch}
         actions={
-          <Tooltip title="새로운 그룹을 생성합니다.">
-            <IconButton size="small" onClick={() => setCreateOpen(true)}>
+          <Tooltip title="그룹 생성">
+            <IconButton size="small" aria-label="그룹 생성" onClick={() => setCreateOpen(true)}>
               <GroupAddOutlined fontSize="small" />
             </IconButton>
           </Tooltip>

--- a/src/react/pages/admin/RolesPage.tsx
+++ b/src/react/pages/admin/RolesPage.tsx
@@ -21,10 +21,14 @@ import type { PageableGridContentHandle } from "@/react/components/ag-grid/types
 import type { RoleDto } from "@/react/pages/admin/datasource";
 import { RolesDataSource } from "@/react/pages/admin/datasource";
 import { RoleDialog } from "@/react/pages/admin/roles/RoleDialog";
+import { reactRolesApi } from "@/react/pages/admin/roles/api";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
+import { useConfirm, useToast } from "@/react/feedback";
 
 export function RolesPage() {
   const navigate = useNavigate();
+  const confirm = useConfirm();
+  const toast = useToast();
   const gridRef = useRef<PageableGridContentHandle<RoleDto>>(null);
   const dataSource = useMemo(() => new RolesDataSource(), []);
   const [searchInput, setSearchInput] = useState("");
@@ -43,6 +47,7 @@ export function RolesPage() {
           <Box
             component="button"
             type="button"
+            aria-label={`${params.value} 상세보기`}
             onClick={() => navigate(`/admin/roles/${params.data?.roleId}`)}
             sx={{
               border: 0,
@@ -84,31 +89,54 @@ export function RolesPage() {
       },
       {
         colId: "actions",
-        headerName: "",
+        headerName: "작업",
         filter: false,
         sortable: false,
-        flex: 0.85,
-        minWidth: 168,
+        width: 144,
+        minWidth: 144,
+        maxWidth: 144,
+        pinned: "right",
+        cellStyle: { display: "flex", alignItems: "center", justifyContent: "center" },
         cellRenderer: (params: ICellRendererParams<RoleDto>) => (
           <Box sx={{ display: "flex", gap: 0.5, alignItems: "center", height: "100%" }}>
-            <Tooltip title="롤 사용자 관리는 아직 연결되지 않았습니다.">
-              <IconButton size="small" disabled>
+            <Tooltip title="사용자 관리">
+              <IconButton
+                size="small"
+                aria-label="사용자 관리"
+                onClick={() =>
+                  params.data?.roleId &&
+                  navigate(`/admin/roles/${params.data.roleId}`, { state: { openUsers: true } })
+                }
+              >
                 <PersonOutlined fontSize="small" />
               </IconButton>
             </Tooltip>
-            <Tooltip title="롤 그룹 관리는 아직 연결되지 않았습니다.">
-              <IconButton size="small" disabled>
+            <Tooltip title="그룹 관리">
+              <IconButton
+                size="small"
+                aria-label="그룹 관리"
+                onClick={() =>
+                  params.data?.roleId &&
+                  navigate(`/admin/roles/${params.data.roleId}`, { state: { openGroups: true } })
+                }
+              >
                 <GroupOutlined fontSize="small" />
               </IconButton>
             </Tooltip>
-            <Tooltip title="롤 삭제는 아직 연결되지 않았습니다.">
-              <IconButton size="small" color="error" disabled>
+            <Tooltip title="삭제">
+              <IconButton
+                size="small"
+                color="error"
+                aria-label="삭제"
+                onClick={() => params.data && void handleDeleteRole(params.data)}
+              >
                 <DeleteOutlined fontSize="small" />
               </IconButton>
             </Tooltip>
             <Tooltip title="상세보기">
               <IconButton
                 size="small"
+                aria-label="상세보기"
                 onClick={() => navigate(`/admin/roles/${params.data?.roleId}`)}
               >
                 <ChevronRight fontSize="small" />
@@ -136,6 +164,26 @@ export function RolesPage() {
     gridRef.current?.refresh();
   };
 
+  async function handleDeleteRole(role: RoleDto) {
+    const ok = await confirm({
+      title: "역할 삭제",
+      message: `${role.name} 역할을 삭제하시겠습니까?`,
+      okText: "삭제",
+      cancelText: "취소",
+    });
+    if (!ok) {
+      return;
+    }
+
+    try {
+      await reactRolesApi.deleteRole(role.roleId);
+      toast.success("역할이 삭제되었습니다.");
+      gridRef.current?.refresh();
+    } catch {
+      toast.error("역할 삭제에 실패했습니다.");
+    }
+  }
+
   return (
     <Stack spacing={0.5}>
       <PageToolbar
@@ -148,8 +196,8 @@ export function RolesPage() {
         onSearchValueChange={setSearchInput}
         onSearch={handleSearch}
         actions={
-          <Tooltip title="새로운 역할을 생성합니다.">
-            <IconButton size="small" onClick={() => setCreateOpen(true)}>
+          <Tooltip title="역할 생성">
+            <IconButton size="small" aria-label="역할 생성" onClick={() => setCreateOpen(true)}>
               <AddOutlined fontSize="small" />
             </IconButton>
           </Tooltip>

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Avatar,
+  Box,
   Chip,
   Dialog,
   DialogTitle,
@@ -25,6 +26,77 @@ import type { UserDto } from "@/types/studio/user";
 import { useConfirm } from "@/react/feedback";
 import { API_BASE_URL } from "@/config/backend";
 import NO_AVATAR from "@/assets/images/users/no-avatar.png";
+
+function SelectionCheckbox({
+  checked,
+  indeterminate = false,
+  ariaLabel,
+  onChange,
+}: {
+  checked: boolean;
+  indeterminate?: boolean;
+  ariaLabel: string;
+  onChange: (checked: boolean) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked}
+      onChange={(event) => onChange(event.target.checked)}
+      onClick={(event) => event.stopPropagation()}
+      style={{
+        width: 16,
+        height: 16,
+        margin: 0,
+        accentColor: "#1565c0",
+        cursor: "pointer",
+      }}
+    />
+  );
+}
+
+function getDisplayedSelectionState(api: {
+  getLastDisplayedRowIndex: () => number;
+  getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+}) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  if (lastIndex < 0) {
+    return { displayedCount: 0, selectedCount: 0 };
+  }
+
+  let displayedCount = 0;
+  let selectedCount = 0;
+  for (let index = 0; index <= lastIndex; index += 1) {
+    const row = api.getDisplayedRowAtIndex(index);
+    if (!row) continue;
+    displayedCount += 1;
+    if (row.isSelected()) selectedCount += 1;
+  }
+  return { displayedCount, selectedCount };
+}
+
+function toggleDisplayedRows(
+  api: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  },
+  selected: boolean
+) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  for (let index = 0; index <= lastIndex; index += 1) {
+    api.getDisplayedRowAtIndex(index)?.setSelected(selected);
+  }
+}
 
 interface Props {
   open: boolean;
@@ -55,8 +127,71 @@ export function UserSearchDialog({
   const [query, setQuery] = useState("");
   const [hasSearched, setHasSearched] = useState(false);
 
+  function renderHeaderCheckbox(api?: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  }) {
+    const currentState = api
+      ? getDisplayedSelectionState(api)
+      : { displayedCount, selectedCount };
+    const allDisplayedSelected =
+      currentState.displayedCount > 0 &&
+      currentState.selectedCount === currentState.displayedCount;
+    const partiallySelected =
+      currentState.selectedCount > 0 &&
+      currentState.selectedCount < currentState.displayedCount;
+
+    return (
+      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+        <SelectionCheckbox
+          ariaLabel="전체 선택"
+          checked={allDisplayedSelected}
+          indeterminate={partiallySelected}
+          onChange={() => {
+            if (api) {
+              toggleDisplayedRows(api, !allDisplayedSelected);
+            }
+          }}
+        />
+      </Box>
+    );
+  }
+
   const columnDefs = useMemo<ColDef<UserDto>[]>(() => {
     const baseColumns: ColDef<UserDto>[] = [
+      {
+        colId: "rowSelect",
+        headerName: "",
+        width: 40,
+        minWidth: 40,
+        maxWidth: 40,
+        pinned: "left",
+        sortable: false,
+        resizable: false,
+        suppressMovable: true,
+        lockPosition: true,
+        cellClass: "selection-column-centered",
+        headerClass: "selection-column-centered",
+        headerComponent: (props: {
+          api: {
+            getLastDisplayedRowIndex: () => number;
+            getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+          };
+        }) => renderHeaderCheckbox(props.api),
+        cellRenderer: (params: ICellRendererParams<UserDto>) => {
+          if (!isMultiple) return null;
+          const checked = params.node.isSelected();
+          return (
+            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+              <SelectionCheckbox
+                ariaLabel="행 선택"
+                checked={checked}
+                onChange={(nextChecked) => params.node.setSelected(nextChecked)}
+              />
+            </Box>
+          );
+        },
+      },
       {
         field: "username",
         headerName: "아이디",
@@ -101,9 +236,9 @@ export function UserSearchDialog({
               fontSize: 11,
               ...(params.value
                 ? {
-                    bgcolor: "#2563eb",
-                    color: "#ffffff",
-                    borderColor: "#1d4ed8",
+                    bgcolor: "primary.main",
+                    color: "primary.contrastText",
+                    borderColor: "primary.dark",
                   }
                 : {}),
             }}
@@ -124,12 +259,8 @@ export function UserSearchDialog({
       },
     ];
 
-    if (isMultiple) {
-      return baseColumns;
-    }
-
     return [
-      ...baseColumns,
+      ...(isMultiple ? baseColumns : baseColumns.slice(1)),
       {
         colId: "select",
         headerName: "",
@@ -147,7 +278,7 @@ export function UserSearchDialog({
         ),
       },
     ];
-  }, [isMultiple, onClose, onSelect]);
+  }, [displayedCount, isMultiple, onClose, onSelect, selectedCount]);
 
   async function handleConfirmSelection() {
     const users = gridRef.current?.selectedRows() ?? [];
@@ -183,13 +314,16 @@ export function UserSearchDialog({
               listener: (event: SelectionChangedEvent<UserDto>) => {
                 const nextSelectedCount = event.api.getSelectedRows().length ?? 0;
                 setSelectedCount(nextSelectedCount);
+                setDisplayedCount(event.api.getDisplayedRowCount() ?? 0);
+                event.api.refreshHeader?.();
               },
             },
             {
               type: "paginationChanged",
-              listener: (event: PaginationChangedEvent<UserDto>) => {
+              listener: (event: PaginationChangedEvent<UserDto> & { api: { refreshHeader?: () => void } }) => {
                 const nextDisplayedCount = event.api.getDisplayedRowCount() ?? 0;
                 setDisplayedCount(nextDisplayedCount);
+                event.api.refreshHeader?.();
               },
             },
           ]
@@ -278,7 +412,17 @@ export function UserSearchDialog({
               datasource={dataSource}
               columns={columnDefs}
               events={gridEvents}
-              rowSelection={isMultiple ? "multiple" : undefined}
+              rowSelection={
+                isMultiple
+                  ? {
+                      mode: "multiRow",
+                      enableClickSelection: false,
+                      checkboxes: false,
+                      headerCheckbox: false,
+                    }
+                  : undefined
+              }
+              options={isMultiple ? { suppressRowClickSelection: true } : undefined}
             />
           ) : (
             <Stack

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -423,7 +423,6 @@ export function UserSearchDialog({
                     }
                   : undefined
               }
-              options={isMultiple ? { suppressRowClickSelection: true } : undefined}
             />
           ) : (
             <Stack

--- a/src/react/pages/admin/UserSearchDialog.tsx
+++ b/src/react/pages/admin/UserSearchDialog.tsx
@@ -60,6 +60,7 @@ function SelectionCheckbox({
         margin: 0,
         accentColor: "#1565c0",
         cursor: "pointer",
+        transform: ariaLabel === "행 선택" ? "translateY(2px)" : "none",
       }}
     />
   );
@@ -142,7 +143,7 @@ export function UserSearchDialog({
       currentState.selectedCount < currentState.displayedCount;
 
     return (
-      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+      <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
         <SelectionCheckbox
           ariaLabel="전체 선택"
           checked={allDisplayedSelected}
@@ -182,7 +183,7 @@ export function UserSearchDialog({
           if (!isMultiple) return null;
           const checked = params.node.isSelected();
           return (
-            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+            <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
               <SelectionCheckbox
                 ariaLabel="행 선택"
                 checked={checked}

--- a/src/react/pages/admin/UsersPage.tsx
+++ b/src/react/pages/admin/UsersPage.tsx
@@ -21,15 +21,21 @@ import type { PageableGridContentHandle } from "@/react/components/ag-grid/types
 import type { UserDto } from "@/types/studio/user";
 import { UsersDataSource } from "@/react/pages/admin/datasource";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
+import { UserDialog } from "@/react/pages/admin/users/UserDialog";
+import { reactUsersApi } from "@/react/pages/admin/users/api";
+import { useConfirm, useToast } from "@/react/feedback";
 import { API_BASE_URL } from "@/config/backend";
 import NO_AVATAR from "@/assets/images/users/no-avatar.png";
 
 export function UsersPage() {
   const navigate = useNavigate();
+  const confirm = useConfirm();
+  const toast = useToast();
   const gridRef = useRef<PageableGridContentHandle<UserDto>>(null);
   const dataSource = useMemo(() => new UsersDataSource(), []);
   const [searchInput, setSearchInput] = useState("");
   const [searchError, setSearchError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
 
   const columnDefs = useMemo<ColDef<UserDto>[]>(
     () => [
@@ -43,6 +49,7 @@ export function UsersPage() {
           <Box
             component="button"
             type="button"
+            aria-label={`${params.value} 상세보기`}
             onClick={() => navigate(`/admin/users/${params.data?.userId}`)}
             sx={{
               display: "inline-flex",
@@ -59,7 +66,8 @@ export function UsersPage() {
             }}
           >
             <Avatar
-              alt={String(params.value ?? "")}
+              alt=""
+              aria-hidden="true"
               src={
                 params.value
                   ? `${API_BASE_URL}/api/profile/${encodeURIComponent(String(params.value))}/avatar`
@@ -134,26 +142,34 @@ export function UsersPage() {
       },
       {
         colId: "actions",
-        headerName: "",
+        headerName: "작업",
         filter: false,
         sortable: false,
-        flex: 0.65,
-        minWidth: 132,
+        width: 112,
+        minWidth: 112,
+        maxWidth: 112,
+        pinned: "right",
+        cellStyle: { display: "flex", alignItems: "center", justifyContent: "center" },
         cellRenderer: (params: ICellRendererParams<UserDto>) => (
           <Box sx={{ display: "flex", gap: 0.5, alignItems: "center", height: "100%" }}>
-            <Tooltip title="권한 관리는 아직 연결되지 않았습니다.">
+            <Tooltip title="역할 관리">
               <IconButton
                 size="small"
-                disabled
+                aria-label="역할 관리"
+                onClick={() =>
+                  params.data?.userId &&
+                  navigate(`/admin/users/${params.data.userId}`, { state: { openRoles: true } })
+                }
               >
                 <ManageAccountsOutlined fontSize="small" />
               </IconButton>
             </Tooltip>
-            <Tooltip title="사용자 삭제는 아직 연결되지 않았습니다.">
+            <Tooltip title="삭제">
               <IconButton
                 size="small"
                 color="error"
-                disabled
+                aria-label="삭제"
+                onClick={() => params.data && void handleDeleteUser(params.data)}
               >
                 <DeleteOutlined fontSize="small" />
               </IconButton>
@@ -161,6 +177,7 @@ export function UsersPage() {
             <Tooltip title="상세보기">
               <IconButton
                 size="small"
+                aria-label="상세보기"
                 onClick={() => navigate(`/admin/users/${params.data?.userId}`)}
               >
                 <ChevronRight fontSize="small" />
@@ -188,6 +205,26 @@ export function UsersPage() {
     gridRef.current?.refresh();
   };
 
+  async function handleDeleteUser(user: UserDto) {
+    const ok = await confirm({
+      title: "사용자 삭제",
+      message: `${user.username} 사용자를 삭제하시겠습니까?`,
+      okText: "삭제",
+      cancelText: "취소",
+    });
+    if (!ok) {
+      return;
+    }
+
+    try {
+      await reactUsersApi.deleteUser(user.userId);
+      toast.success("사용자가 삭제되었습니다.");
+      gridRef.current?.refresh();
+    } catch {
+      toast.error("사용자 삭제에 실패했습니다.");
+    }
+  }
+
   return (
     <Stack spacing={0.5}>
       <PageToolbar
@@ -201,10 +238,11 @@ export function UsersPage() {
         onSearchValueChange={setSearchInput}
         onSearch={handleSearch}
         actions={
-          <Tooltip title="새로운 사용자를 생성합니다.">
+          <Tooltip title="사용자 생성">
             <IconButton
               size="small"
-              disabled
+              aria-label="사용자 생성"
+              onClick={() => setCreateOpen(true)}
             >
               <PersonAddAlt1Outlined fontSize="small" />
             </IconButton>
@@ -218,6 +256,11 @@ export function UsersPage() {
         ref={gridRef}
         datasource={dataSource}
         columns={columnDefs}
+      />
+      <UserDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => gridRef.current?.refresh()}
       />
     </Stack>
   );

--- a/src/react/pages/admin/UsersPage.tsx
+++ b/src/react/pages/admin/UsersPage.tsx
@@ -106,9 +106,9 @@ export function UsersPage() {
               fontSize: 11,
               ...(params.value
                 ? {
-                    bgcolor: "#2563eb",
-                    color: "#ffffff",
-                    borderColor: "#1d4ed8",
+                    bgcolor: "primary.main",
+                    color: "primary.contrastText",
+                    borderColor: "primary.dark",
                   }
                 : {}),
             }}

--- a/src/react/pages/admin/groups/GroupDetailPage.tsx
+++ b/src/react/pages/admin/groups/GroupDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   Accordion,
   AccordionDetails,
@@ -36,6 +36,7 @@ import type { GroupDto } from "@/react/pages/admin/datasource";
 
 export function GroupDetailPage() {
   const { groupId } = useParams<{ groupId: string }>();
+  const location = useLocation();
   const navigate = useNavigate();
   const toast = useToast();
   const propertiesEditorRef = useRef<PropertiesEditorHandle | null>(null);
@@ -89,6 +90,17 @@ export function GroupDetailPage() {
   useEffect(() => {
     loadGroup();
   }, [loadGroup]);
+
+  useEffect(() => {
+    const state = location.state as { openMembers?: boolean; openRoles?: boolean } | null;
+    if (state?.openMembers) {
+      setMembersOpen(true);
+      navigate(".", { replace: true, state: null });
+    } else if (state?.openRoles) {
+      setRolesOpen(true);
+      navigate(".", { replace: true, state: null });
+    }
+  }, [location.state, navigate]);
 
   useEffect(() => {
     if (!propertiesExpanded || !propertiesSectionRef.current) {

--- a/src/react/pages/admin/groups/GroupMembershipDialog.tsx
+++ b/src/react/pages/admin/groups/GroupMembershipDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Avatar,
   Box,
@@ -104,6 +104,77 @@ class GroupMemberSummariesDataSource implements AgGridCompatibleDataSource<Group
   }
 }
 
+function SelectionCheckbox({
+  checked,
+  indeterminate = false,
+  ariaLabel,
+  onChange,
+}: {
+  checked: boolean;
+  indeterminate?: boolean;
+  ariaLabel: string;
+  onChange: (checked: boolean) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked}
+      onChange={(event) => onChange(event.target.checked)}
+      onClick={(event) => event.stopPropagation()}
+      style={{
+        width: 16,
+        height: 16,
+        margin: 0,
+        accentColor: "#1565c0",
+        cursor: "pointer",
+      }}
+    />
+  );
+}
+
+function getDisplayedSelectionState(api: {
+  getLastDisplayedRowIndex: () => number;
+  getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+}) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  if (lastIndex < 0) {
+    return { displayedCount: 0, selectedCount: 0 };
+  }
+
+  let displayedCount = 0;
+  let selectedCount = 0;
+  for (let index = 0; index <= lastIndex; index += 1) {
+    const row = api.getDisplayedRowAtIndex(index);
+    if (!row) continue;
+    displayedCount += 1;
+    if (row.isSelected()) selectedCount += 1;
+  }
+  return { displayedCount, selectedCount };
+}
+
+function toggleDisplayedRows(
+  api: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  },
+  selected: boolean
+) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  for (let index = 0; index <= lastIndex; index += 1) {
+    api.getDisplayedRowAtIndex(index)?.setSelected(selected);
+  }
+}
+
 export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Props) {
   const toast = useToast();
   const confirm = useConfirm();
@@ -113,10 +184,74 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
   const [searchInput, setSearchInput] = useState("");
   const [gridKey, setGridKey] = useState(0);
   const [selectedCount, setSelectedCount] = useState(0);
+  const [displayedCount, setDisplayedCount] = useState(0);
   const dataSource = useMemo(() => new GroupMemberSummariesDataSource(groupId), [groupId]);
+
+  function renderHeaderCheckbox(api?: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  }) {
+    const currentState = api
+      ? getDisplayedSelectionState(api)
+      : { displayedCount, selectedCount };
+    const allDisplayedSelected =
+      currentState.displayedCount > 0 &&
+      currentState.selectedCount === currentState.displayedCount;
+    const partiallySelected =
+      currentState.selectedCount > 0 &&
+      currentState.selectedCount < currentState.displayedCount;
+
+    return (
+      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+        <SelectionCheckbox
+          ariaLabel="전체 선택"
+          checked={allDisplayedSelected}
+          indeterminate={partiallySelected}
+          onChange={() => {
+            if (api) {
+              toggleDisplayedRows(api, !allDisplayedSelected);
+            }
+          }}
+        />
+      </Box>
+    );
+  }
 
   const columnDefs = useMemo<ColDef<GroupMemberDto>[]>(
     () => [
+      {
+        colId: "rowSelect",
+        headerName: "",
+        width: 40,
+        minWidth: 40,
+        maxWidth: 40,
+        pinned: "left",
+        sortable: false,
+        resizable: false,
+        suppressMovable: true,
+        lockPosition: true,
+        cellClass: "selection-column-centered",
+        headerClass: "selection-column-centered",
+        headerComponent: (props: {
+          api: {
+            getLastDisplayedRowIndex: () => number;
+            getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+          };
+        }) => renderHeaderCheckbox(props.api),
+        cellRenderer: (params) => {
+          const checked = params.node.isSelected();
+
+          return (
+            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+              <SelectionCheckbox
+                ariaLabel="행 선택"
+                checked={checked}
+                onChange={(nextChecked) => params.node.setSelected(nextChecked)}
+              />
+            </Box>
+          );
+        },
+      },
       {
         field: "username",
         headerName: "아이디",
@@ -174,9 +309,9 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
               fontSize: 11,
               ...(params.value
                 ? {
-                    bgcolor: "#2563eb",
-                    color: "#ffffff",
-                    borderColor: "#1d4ed8",
+                    bgcolor: "primary.main",
+                    color: "primary.contrastText",
+                    borderColor: "primary.dark",
                   }
                 : {}),
             }}
@@ -185,7 +320,7 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
         cellStyle: { textAlign: "center" },
       },
     ],
-    []
+    [displayedCount, selectedCount]
   );
 
   const handleSearch = useCallback(() => {
@@ -302,11 +437,29 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
               events={[
                 {
                   type: "selectionChanged",
-                  listener: (event: SelectionChangedEvent<GroupMemberDto>) =>
-                    setSelectedCount(event.api.getSelectedRows().length ?? 0),
+                  listener: (event: SelectionChangedEvent<GroupMemberDto>) => {
+                    setSelectedCount(event.api.getSelectedRows().length ?? 0);
+                    setDisplayedCount(event.api.getDisplayedRowCount());
+                    event.api.refreshHeader?.();
+                  },
+                },
+                {
+                  type: "modelUpdated",
+                  listener: (event: {
+                    api: { getDisplayedRowCount: () => number; refreshHeader?: () => void };
+                  }) => {
+                    setDisplayedCount(event.api.getDisplayedRowCount());
+                    event.api.refreshHeader?.();
+                  },
                 },
               ]}
-              rowSelection="multiple"
+              rowSelection={{
+                mode: "multiRow",
+                enableClickSelection: false,
+                checkboxes: false,
+                headerCheckbox: false,
+              }}
+              options={{ suppressRowClickSelection: true }}
             />
           </Stack>
         </DialogContent>

--- a/src/react/pages/admin/groups/GroupMembershipDialog.tsx
+++ b/src/react/pages/admin/groups/GroupMembershipDialog.tsx
@@ -35,7 +35,7 @@ class GroupMemberSummariesDataSource implements AgGridCompatibleDataSource<Group
   error: unknown = null;
   dataItems: GroupMemberDto[] = [];
   total = 0;
-  pageSize = 20;
+  pageSize = 15;
   page = 0;
   private q = "";
 
@@ -460,7 +460,6 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
                 checkboxes: false,
                 headerCheckbox: false,
               }}
-              options={{ suppressRowClickSelection: true }}
             />
           </Stack>
         </DialogContent>

--- a/src/react/pages/admin/groups/GroupMembershipDialog.tsx
+++ b/src/react/pages/admin/groups/GroupMembershipDialog.tsx
@@ -137,6 +137,7 @@ function SelectionCheckbox({
         margin: 0,
         accentColor: "#1565c0",
         cursor: "pointer",
+        transform: ariaLabel === "행 선택" ? "translateY(2px)" : "none",
       }}
     />
   );
@@ -202,7 +203,7 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
       currentState.selectedCount < currentState.displayedCount;
 
     return (
-      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+      <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
         <SelectionCheckbox
           ariaLabel="전체 선택"
           checked={allDisplayedSelected}
@@ -242,7 +243,7 @@ export function GroupMembershipDialog({ open, onClose, groupId, groupName }: Pro
           const checked = params.node.isSelected();
 
           return (
-            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+            <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
               <SelectionCheckbox
                 ariaLabel="행 선택"
                 checked={checked}

--- a/src/react/pages/admin/groups/api.ts
+++ b/src/react/pages/admin/groups/api.ts
@@ -33,6 +33,8 @@ export const reactGroupsApi = {
     apiRequest<GroupDto>("put", `/api/mgmt/groups/${groupId}`, { data: payload }),
   createGroup: (payload: { name: string; description?: string }) =>
     apiRequest<GroupDto>("post", "/api/mgmt/groups", { data: payload }),
+  deleteGroup: (groupId: number) =>
+    apiRequest<void>("delete", `/api/mgmt/groups/${groupId}`),
   getMemberSummaries: (
     groupId: number,
     params?: { q?: string; page?: number; size?: number; sort?: string }

--- a/src/react/pages/admin/roles/RoleDetailPage.tsx
+++ b/src/react/pages/admin/roles/RoleDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   Alert,
   Box,
@@ -20,6 +20,7 @@ import { PageToolbar } from "@/react/components/page/PageToolbar";
 
 export function RoleDetailPage() {
   const { roleId } = useParams<{ roleId: string }>();
+  const location = useLocation();
   const navigate = useNavigate();
   const toast = useToast();
   const [role, setRole] = useState<RoleDto | null>(null);
@@ -47,6 +48,17 @@ export function RoleDetailPage() {
   useEffect(() => {
     loadRole();
   }, [loadRole]);
+
+  useEffect(() => {
+    const state = location.state as { openUsers?: boolean; openGroups?: boolean } | null;
+    if (state?.openUsers) {
+      setUsersOpen(true);
+      navigate(".", { replace: true, state: null });
+    } else if (state?.openGroups) {
+      setGroupsOpen(true);
+      navigate(".", { replace: true, state: null });
+    }
+  }, [location.state, navigate]);
 
   async function handleSave() {
     if (!roleId) return;

--- a/src/react/pages/admin/roles/RoleGrantedUsersDialog.tsx
+++ b/src/react/pages/admin/roles/RoleGrantedUsersDialog.tsx
@@ -238,6 +238,7 @@ function SelectionCheckbox({
         margin: 0,
         accentColor: "#1565c0",
         cursor: "pointer",
+        transform: ariaLabel === "행 선택" ? "translateY(2px)" : "none",
       }}
     />
   );
@@ -325,7 +326,7 @@ export function RoleGrantedUsersDialog({
       currentState.selectedCount < currentState.displayedCount;
 
     return (
-      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+      <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
         <SelectionCheckbox
           ariaLabel="전체 선택"
           checked={allDisplayedSelected}
@@ -355,7 +356,7 @@ export function RoleGrantedUsersDialog({
       currentState.selectedCount < currentState.displayedCount;
 
     return (
-      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+      <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
         <SelectionCheckbox
           ariaLabel="전체 선택"
           checked={allDisplayedSelected}
@@ -438,7 +439,7 @@ export function RoleGrantedUsersDialog({
         cellRenderer: (params: ICellRendererParams<UserDto>) => {
           const checked = params.node.isSelected();
           return (
-            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+            <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
               <SelectionCheckbox
                 ariaLabel="행 선택"
                 checked={checked}
@@ -477,7 +478,7 @@ export function RoleGrantedUsersDialog({
         cellRenderer: (params: ICellRendererParams<UserDto>) => {
           const checked = params.node.isSelected();
           return (
-            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+            <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
               <SelectionCheckbox
                 ariaLabel="행 선택"
                 checked={checked}

--- a/src/react/pages/admin/roles/RoleGrantedUsersDialog.tsx
+++ b/src/react/pages/admin/roles/RoleGrantedUsersDialog.tsx
@@ -195,14 +195,85 @@ function renderUserChip(params: ICellRendererParams<UserDto>) {
         fontSize: 11,
         ...(params.value
           ? {
-              bgcolor: "#2563eb",
-              color: "#ffffff",
-              borderColor: "#1d4ed8",
+              bgcolor: "primary.main",
+              color: "primary.contrastText",
+              borderColor: "primary.dark",
             }
           : {}),
       }}
     />
   );
+}
+
+function SelectionCheckbox({
+  checked,
+  indeterminate = false,
+  ariaLabel,
+  onChange,
+}: {
+  checked: boolean;
+  indeterminate?: boolean;
+  ariaLabel: string;
+  onChange: (checked: boolean) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked}
+      onChange={(event) => onChange(event.target.checked)}
+      onClick={(event) => event.stopPropagation()}
+      style={{
+        width: 16,
+        height: 16,
+        margin: 0,
+        accentColor: "#1565c0",
+        cursor: "pointer",
+      }}
+    />
+  );
+}
+
+function getDisplayedSelectionState(api: {
+  getLastDisplayedRowIndex: () => number;
+  getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+}) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  if (lastIndex < 0) {
+    return { displayedCount: 0, selectedCount: 0 };
+  }
+
+  let displayedCount = 0;
+  let selectedCount = 0;
+  for (let index = 0; index <= lastIndex; index += 1) {
+    const row = api.getDisplayedRowAtIndex(index);
+    if (!row) continue;
+    displayedCount += 1;
+    if (row.isSelected()) selectedCount += 1;
+  }
+  return { displayedCount, selectedCount };
+}
+
+function toggleDisplayedRows(
+  api: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  },
+  selected: boolean
+) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  for (let index = 0; index <= lastIndex; index += 1) {
+    api.getDisplayedRowAtIndex(index)?.setSelected(selected);
+  }
 }
 
 export function RoleGrantedUsersDialog({
@@ -226,6 +297,8 @@ export function RoleGrantedUsersDialog({
   const [hasSearchedCandidates, setHasSearchedCandidates] = useState(false);
   const [selectedCandidateCount, setSelectedCandidateCount] = useState(0);
   const [selectedGrantedCount, setSelectedGrantedCount] = useState(0);
+  const [candidateDisplayedCount, setCandidateDisplayedCount] = useState(0);
+  const [grantedDisplayedCount, setGrantedDisplayedCount] = useState(0);
 
   const grantedUserIds = useMemo(
     () => new Set(grantedUsers.map((user) => user.userId)),
@@ -236,6 +309,66 @@ export function RoleGrantedUsersDialog({
     () => new GrantedUsersDataSource(grantedUsers, grantedSearchInput),
     [grantedUsers, grantedSearchInput]
   );
+
+  function renderGrantedHeaderCheckbox(api?: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  }) {
+    const currentState = api
+      ? getDisplayedSelectionState(api)
+      : { displayedCount: grantedDisplayedCount, selectedCount: selectedGrantedCount };
+    const allDisplayedSelected =
+      currentState.displayedCount > 0 &&
+      currentState.selectedCount === currentState.displayedCount;
+    const partiallySelected =
+      currentState.selectedCount > 0 &&
+      currentState.selectedCount < currentState.displayedCount;
+
+    return (
+      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+        <SelectionCheckbox
+          ariaLabel="전체 선택"
+          checked={allDisplayedSelected}
+          indeterminate={partiallySelected}
+          onChange={() => {
+            if (api) {
+              toggleDisplayedRows(api, !allDisplayedSelected);
+            }
+          }}
+        />
+      </Box>
+    );
+  }
+
+  function renderCandidateHeaderCheckbox(api?: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  }) {
+    const currentState = api
+      ? getDisplayedSelectionState(api)
+      : { displayedCount: candidateDisplayedCount, selectedCount: selectedCandidateCount };
+    const allDisplayedSelected =
+      currentState.displayedCount > 0 &&
+      currentState.selectedCount === currentState.displayedCount;
+    const partiallySelected =
+      currentState.selectedCount > 0 &&
+      currentState.selectedCount < currentState.displayedCount;
+
+    return (
+      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+        <SelectionCheckbox
+          ariaLabel="전체 선택"
+          checked={allDisplayedSelected}
+          indeterminate={partiallySelected}
+          onChange={() => {
+            if (api) {
+              toggleDisplayedRows(api, !allDisplayedSelected);
+            }
+          }}
+        />
+      </Box>
+    );
+  }
 
   const userColumns = useMemo<ColDef<UserDto>[]>(
     () => [
@@ -281,12 +414,100 @@ export function RoleGrantedUsersDialog({
     []
   );
 
+  const grantedColumns = useMemo<ColDef<UserDto>[]>(
+    () => [
+      {
+        colId: "rowSelect",
+        headerName: "",
+        width: 40,
+        minWidth: 40,
+        maxWidth: 40,
+        pinned: "left",
+        sortable: false,
+        resizable: false,
+        suppressMovable: true,
+        lockPosition: true,
+        cellClass: "selection-column-centered",
+        headerClass: "selection-column-centered",
+        headerComponent: (props: {
+          api: {
+            getLastDisplayedRowIndex: () => number;
+            getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+          };
+        }) => renderGrantedHeaderCheckbox(props.api),
+        cellRenderer: (params: ICellRendererParams<UserDto>) => {
+          const checked = params.node.isSelected();
+          return (
+            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+              <SelectionCheckbox
+                ariaLabel="행 선택"
+                checked={checked}
+                onChange={(nextChecked) => params.node.setSelected(nextChecked)}
+              />
+            </Box>
+          );
+        },
+      },
+      ...userColumns,
+    ],
+    [grantedDisplayedCount, selectedGrantedCount, userColumns]
+  );
+
+  const candidateColumns = useMemo<ColDef<UserDto>[]>(
+    () => [
+      {
+        colId: "rowSelect",
+        headerName: "",
+        width: 40,
+        minWidth: 40,
+        maxWidth: 40,
+        pinned: "left",
+        sortable: false,
+        resizable: false,
+        suppressMovable: true,
+        lockPosition: true,
+        cellClass: "selection-column-centered",
+        headerClass: "selection-column-centered",
+        headerComponent: (props: {
+          api: {
+            getLastDisplayedRowIndex: () => number;
+            getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+          };
+        }) => renderCandidateHeaderCheckbox(props.api),
+        cellRenderer: (params: ICellRendererParams<UserDto>) => {
+          const checked = params.node.isSelected();
+          return (
+            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+              <SelectionCheckbox
+                ariaLabel="행 선택"
+                checked={checked}
+                onChange={(nextChecked) => params.node.setSelected(nextChecked)}
+              />
+            </Box>
+          );
+        },
+      },
+      ...userColumns,
+    ],
+    [candidateDisplayedCount, selectedCandidateCount, userColumns]
+  );
+
   const grantedEvents = useMemo(
     () => [
       {
         type: "selectionChanged",
-        listener: (event: SelectionChangedEvent<UserDto>) =>
-          setSelectedGrantedCount(event.api.getSelectedRows().length ?? 0),
+        listener: (event: SelectionChangedEvent<UserDto>) => {
+          setSelectedGrantedCount(event.api.getSelectedRows().length ?? 0);
+          setGrantedDisplayedCount(event.api.getDisplayedRowCount());
+          event.api.refreshHeader?.();
+        },
+      },
+      {
+        type: "modelUpdated",
+        listener: (event: { api: { getDisplayedRowCount: () => number; refreshHeader?: () => void } }) => {
+          setGrantedDisplayedCount(event.api.getDisplayedRowCount());
+          event.api.refreshHeader?.();
+        },
       },
     ],
     []
@@ -296,8 +517,18 @@ export function RoleGrantedUsersDialog({
     () => [
       {
         type: "selectionChanged",
-        listener: (event: SelectionChangedEvent<UserDto>) =>
-          setSelectedCandidateCount(event.api.getSelectedRows().length ?? 0),
+        listener: (event: SelectionChangedEvent<UserDto>) => {
+          setSelectedCandidateCount(event.api.getSelectedRows().length ?? 0);
+          setCandidateDisplayedCount(event.api.getDisplayedRowCount());
+          event.api.refreshHeader?.();
+        },
+      },
+      {
+        type: "modelUpdated",
+        listener: (event: { api: { getDisplayedRowCount: () => number; refreshHeader?: () => void } }) => {
+          setCandidateDisplayedCount(event.api.getDisplayedRowCount());
+          event.api.refreshHeader?.();
+        },
       },
     ],
     []
@@ -489,9 +720,15 @@ export function RoleGrantedUsersDialog({
                 key={candidateGridKey}
                 ref={candidatesGridRef}
                 datasource={candidatesDataSource}
-                columns={userColumns}
+                columns={candidateColumns}
                 events={candidateEvents}
-                rowSelection="multiple"
+                rowSelection={{
+                  mode: "multiRow",
+                  enableClickSelection: false,
+                  checkboxes: false,
+                  headerCheckbox: false,
+                }}
+                options={{ suppressRowClickSelection: true }}
                 height={GRID_HEIGHT}
               />
             ) : (
@@ -547,9 +784,15 @@ export function RoleGrantedUsersDialog({
                 key={grantedGridKey}
                 ref={grantedGridRef}
                 datasource={grantedDataSource}
-                columns={userColumns}
+                columns={grantedColumns}
                 events={grantedEvents}
-                rowSelection="multiple"
+                rowSelection={{
+                  mode: "multiRow",
+                  enableClickSelection: false,
+                  checkboxes: false,
+                  headerCheckbox: false,
+                }}
+                options={{ suppressRowClickSelection: true }}
                 height={GRID_HEIGHT}
               />
             )}

--- a/src/react/pages/admin/roles/RoleGrantedUsersDialog.tsx
+++ b/src/react/pages/admin/roles/RoleGrantedUsersDialog.tsx
@@ -729,7 +729,6 @@ export function RoleGrantedUsersDialog({
                   checkboxes: false,
                   headerCheckbox: false,
                 }}
-                options={{ suppressRowClickSelection: true }}
                 height={GRID_HEIGHT}
               />
             ) : (
@@ -793,7 +792,6 @@ export function RoleGrantedUsersDialog({
                   checkboxes: false,
                   headerCheckbox: false,
                 }}
-                options={{ suppressRowClickSelection: true }}
                 height={GRID_HEIGHT}
               />
             )}

--- a/src/react/pages/admin/roles/api.ts
+++ b/src/react/pages/admin/roles/api.ts
@@ -51,6 +51,8 @@ export const reactRolesApi = {
     apiRequest<RoleDto>("put", `/api/mgmt/roles/${roleId}`, { data: payload }),
   createRole: (payload: { name: string; description?: string }) =>
     apiRequest<RoleDto>("post", "/api/mgmt/roles", { data: payload }),
+  deleteRole: (roleId: number) =>
+    apiRequest<void>("delete", `/api/mgmt/roles/${roleId}`),
   searchUsers: (params?: { q?: string; page?: number; size?: number }) =>
     apiRequest<PageResponse<UserDto>>("get", "/api/mgmt/users", {
       params: {

--- a/src/react/pages/admin/users/UserDetailPage.tsx
+++ b/src/react/pages/admin/users/UserDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   Accordion,
   AccordionDetails,
@@ -43,6 +43,7 @@ import { UserRolesDialog } from "./UserRolesDialog";
 
 export function UserDetailPage() {
   const { userId } = useParams<{ userId: string }>();
+  const location = useLocation();
   const navigate = useNavigate();
   const toast = useToast();
   const confirm = useConfirm();
@@ -118,6 +119,13 @@ export function UserDetailPage() {
   useEffect(() => {
     loadUser();
   }, [loadUser]);
+
+  useEffect(() => {
+    if ((location.state as { openRoles?: boolean } | null)?.openRoles) {
+      setRolesOpen(true);
+      navigate(".", { replace: true, state: null });
+    }
+  }, [location.state, navigate]);
 
   useEffect(() => {
     if (!propertiesExpanded) {

--- a/src/react/pages/admin/users/UserDialog.tsx
+++ b/src/react/pages/admin/users/UserDialog.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+} from "@mui/material";
+import { useToast } from "@/react/feedback";
+import { reactUsersApi } from "./api";
+
+interface UserDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function UserDialog({ open, onClose, onCreated }: UserDialogProps) {
+  const toast = useToast();
+  const [username, setUsername] = useState("");
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const canSubmit =
+    username.trim().length > 0 &&
+    name.trim().length > 0 &&
+    email.trim().length > 0 &&
+    password.length >= 8;
+
+  function reset() {
+    setUsername("");
+    setName("");
+    setEmail("");
+    setPassword("");
+  }
+
+  async function handleCreate() {
+    if (!canSubmit) {
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await reactUsersApi.createUser({
+        username: username.trim(),
+        password,
+        name: name.trim(),
+        email: email.trim(),
+      });
+      toast.success("사용자가 생성되었습니다.");
+      reset();
+      onCreated();
+      onClose();
+    } catch {
+      toast.error("사용자 생성에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
+      <DialogTitle>사용자 생성</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="아이디"
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            size="small"
+            fullWidth
+            autoFocus
+          />
+          <TextField
+            label="이름"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            size="small"
+            fullWidth
+          />
+          <TextField
+            label="이메일"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            size="small"
+            type="email"
+            fullWidth
+          />
+          <TextField
+            label="초기 비밀번호"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            size="small"
+            type="password"
+            fullWidth
+            helperText="8자 이상 입력하세요."
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={onClose} disabled={loading}>
+          취소
+        </Button>
+        <Button variant="outlined" onClick={() => void handleCreate()} disabled={loading || !canSubmit}>
+          {loading ? <CircularProgress size={20} /> : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/admin/users/api.ts
+++ b/src/react/pages/admin/users/api.ts
@@ -3,6 +3,12 @@ import type { RoleDto } from "@/react/pages/admin/datasource";
 import type { UserDto, PasswordPolicyDto, ResetPasswordRequest } from "@/types/studio/user";
 
 export interface UserRoleDto { roleId: number; name: string; description?: string | null; }
+export interface CreateUserRequest {
+  username: string;
+  password: string;
+  name: string;
+  email: string;
+}
 
 export interface UserAvatarPresence {
   hasAvatar: boolean;
@@ -12,10 +18,14 @@ export interface UserAvatarPresence {
 }
 
 export const reactUsersApi = {
+  createUser: (payload: CreateUserRequest) =>
+    apiRequest<number>("post", "/api/mgmt/users", { data: payload }),
   getUser: (userId: number) =>
     apiRequest<UserDto>("get", `/api/mgmt/users/${userId}`),
   updateUser: (userId: number, payload: Partial<UserDto>) =>
     apiRequest<UserDto>("put", `/api/mgmt/users/${userId}`, { data: payload }),
+  deleteUser: (userId: number) =>
+    apiRequest<void>("delete", `/api/mgmt/users/${userId}`),
   getUserRoles: (userId: number) =>
     apiRequest<UserRoleDto[]>("get", `/api/mgmt/users/${userId}/roles`),
   getUserDirectRoles: (userId: number) =>

--- a/src/react/pages/ai/ChatPage.tsx
+++ b/src/react/pages/ai/ChatPage.tsx
@@ -17,7 +17,7 @@ import {
   Typography,
 } from "@mui/material";
 import {
-  EditNoteOutlined,
+  AddCommentOutlined,
   HistoryOutlined,
   SettingsOutlined,
   SyncOutlined,
@@ -112,6 +112,7 @@ export function ChatPage() {
   const providers = useMemo<ProviderInfo[]>(() => aiInfo?.providers ?? [], [aiInfo]);
   const selectedProvider = providers.find((item) => item.name === provider);
   const configurationMissing = !provider || !model;
+  const shouldShowConfigurationWarning = aiInfo !== null && configurationMissing;
   const serverMemoryEnabled = aiInfo?.chat?.memory?.enabled === true;
   const modelMenuOpen = Boolean(modelAnchorEl);
   const chatModeLabel = memoryEnabled ? "서버 메모리" : "클라이언트 누적 전송";
@@ -466,7 +467,7 @@ export function ChatPage() {
             <Tooltip title={memoryEnabled ? "새 대화 시작" : "대화 기억을 켜면 새 대화를 시작할 수 있습니다"}>
               <span>
                 <IconButton size="small" onClick={handleNewConversation} disabled={!memoryEnabled}>
-                  <EditNoteOutlined fontSize="small" />
+                  <AddCommentOutlined fontSize="small" />
                 </IconButton>
               </span>
             </Tooltip>
@@ -491,7 +492,7 @@ export function ChatPage() {
         }
       />
       {error ? <Alert severity="error">{error}</Alert> : null}
-      {configurationMissing ? (
+      {shouldShowConfigurationWarning ? (
         <Alert severity="warning">AI Chat을 사용하려면 Provider와 Model 설정이 필요합니다. 상단 설정 아이콘을 눌러 사용할 provider와 모델을 선택하거나 입력하세요.</Alert>
       ) : null}
 

--- a/src/react/pages/ai/ChatPage.tsx
+++ b/src/react/pages/ai/ChatPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   Alert,
+  alpha,
   Avatar,
   Box,
   Button,
@@ -31,7 +32,11 @@ import {
   SmartToyOutlined,
 } from "@mui/icons-material";
 import { reactAiApi } from "@/react/pages/ai/api";
-import type { AiInfoResponse, ChatMessageDto, ProviderInfo } from "@/types/studio/ai";
+import type {
+  AiInfoResponse,
+  ChatMessageDto,
+  ProviderInfo,
+} from "@/types/studio/ai";
 import { resolveAxiosError } from "@/utils/helpers";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
 
@@ -48,7 +53,9 @@ export function ChatPage() {
   const [model, setModel] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
   const [memoryEnabled, setMemoryEnabled] = useState(false);
-  const [conversationId, setConversationId] = useState(() => crypto.randomUUID());
+  const [conversationId, setConversationId] = useState(() =>
+    crypto.randomUUID(),
+  );
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -56,7 +63,10 @@ export function ChatPage() {
   const [error, setError] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
 
-  const providers = useMemo<ProviderInfo[]>(() => aiInfo?.providers ?? [], [aiInfo]);
+  const providers = useMemo<ProviderInfo[]>(
+    () => aiInfo?.providers ?? [],
+    [aiInfo],
+  );
   const selectedProvider = providers.find((item) => item.name === provider);
   const configurationMissing = !provider || !model;
   const serverMemoryEnabled = aiInfo?.chat?.memory?.enabled === true;
@@ -68,7 +78,9 @@ export function ChatPage() {
       .then((data) => {
         setAiInfo(data);
         setProvider(data.defaultProvider);
-        const match = data.providers.find((item) => item.name === data.defaultProvider);
+        const match = data.providers.find(
+          (item) => item.name === data.defaultProvider,
+        );
         setModel(match?.chat.model ?? "");
       })
       .catch((loadError) => setError(resolveAxiosError(loadError)));
@@ -114,11 +126,19 @@ export function ChatPage() {
         systemPrompt: systemPrompt.trim() || undefined,
         memory: memoryEnabled ? { enabled: true, conversationId } : undefined,
       });
-      const assistant = [...response.messages].reverse().find((item) => item.role === "assistant");
+      const assistant = [...response.messages]
+        .reverse()
+        .find((item) => item.role === "assistant");
       if (assistant) {
         setMessages((current) => [
           ...current,
-          { ...assistant, id: crypto.randomUUID(), model: response.model ?? model, metadata: response.metadata, createdAt: new Date().toISOString() },
+          {
+            ...assistant,
+            id: crypto.randomUUID(),
+            model: response.model ?? model,
+            metadata: response.metadata,
+            createdAt: new Date().toISOString(),
+          },
         ]);
       }
     } catch (sendError) {
@@ -126,7 +146,13 @@ export function ChatPage() {
       setError(message);
       setMessages((current) => [
         ...current,
-        { id: crypto.randomUUID(), role: "assistant", content: `오류: ${message}`, model, createdAt: new Date().toISOString() },
+        {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: `오류: ${message}`,
+          model,
+          createdAt: new Date().toISOString(),
+        },
       ]);
     } finally {
       setSending(false);
@@ -147,9 +173,13 @@ export function ChatPage() {
     if (!usage) return null;
 
     return (
-      <Typography variant="caption" color="text.secondary" sx={{ mt: 0.75, display: "block", fontSize: 11 }}>
-        tokens · input {usage.inputTokens ?? "-"} · output {usage.outputTokens ?? "-"} · total{" "}
-        {usage.totalTokens ?? "-"}
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ mt: 0.75, display: "block", fontSize: 11 }}
+      >
+        tokens · input {usage.inputTokens ?? "-"} · output{" "}
+        {usage.outputTokens ?? "-"} · total {usage.totalTokens ?? "-"}
       </Typography>
     );
   }
@@ -179,9 +209,19 @@ export function ChatPage() {
         label="Provider와 모델을 선택해 AI Chat 요청을 보냅니다."
         actions={
           <>
-            <Tooltip title={memoryEnabled ? "새 대화 시작" : "대화 기억을 켜면 새 대화를 시작할 수 있습니다"}>
+            <Tooltip
+              title={
+                memoryEnabled
+                  ? "새 대화 시작"
+                  : "대화 기억을 켜면 새 대화를 시작할 수 있습니다"
+              }
+            >
               <span>
-                <IconButton size="small" onClick={handleNewConversation} disabled={!memoryEnabled}>
+                <IconButton
+                  size="small"
+                  onClick={handleNewConversation}
+                  disabled={!memoryEnabled}
+                >
                   <EditNoteOutlined fontSize="small" />
                 </IconButton>
               </span>
@@ -197,8 +237,8 @@ export function ChatPage() {
       {error ? <Alert severity="error">{error}</Alert> : null}
       {configurationMissing ? (
         <Alert severity="warning">
-          AI Chat을 사용하려면 Provider와 Model 설정이 필요합니다. 상단 설정 아이콘을 눌러 사용할
-          provider와 모델을 선택하거나 입력하세요.
+          AI Chat을 사용하려면 Provider와 Model 설정이 필요합니다. 상단 설정
+          아이콘을 눌러 사용할 provider와 모델을 선택하거나 입력하세요.
         </Alert>
       ) : null}
       {memoryEnabled ? (
@@ -222,13 +262,15 @@ export function ChatPage() {
         <DialogContent>
           <Stack spacing={2}>
             <Alert severity="info">
-              Provider를 비우면 서버 기본 provider가 사용됩니다. System Prompt는 별도 systemPrompt
-              필드로 전송되며, 대화 메시지에는 사용자와 assistant 메시지만 유지됩니다.
+              Provider를 비우면 서버 기본 provider가 사용됩니다. System Prompt는
+              별도 systemPrompt 필드로 전송되며, 대화 메시지에는 사용자와
+              assistant 메시지만 유지됩니다.
             </Alert>
             {serverMemoryEnabled ? (
               <Alert severity="info">
-                서버가 conversationId 기반 대화 기억을 지원합니다. 켜면 이전 대화는 서버 메모리에서
-                이어지며, 클라이언트는 현재 턴 메시지만 전송합니다.
+                서버가 conversationId 기반 대화 기억을 지원합니다. 켜면 이전
+                대화는 서버 메모리에서 이어지며, 클라이언트는 현재 턴 메시지만
+                전송합니다.
               </Alert>
             ) : (
               <Alert severity="warning">
@@ -255,12 +297,23 @@ export function ChatPage() {
                   </MenuItem>
                 ))}
               </TextField>
-              <TextField label="Model" value={model} onChange={(event) => setModel(event.target.value)} fullWidth size="small" />
+              <TextField
+                label="Model"
+                value={model}
+                onChange={(event) => setModel(event.target.value)}
+                fullWidth
+                size="small"
+              />
             </Stack>
             {selectedProvider ? (
               <Typography variant="caption" color="text.secondary">
-                Embedding: {selectedProvider.embedding.enabled ? selectedProvider.embedding.model : "disabled"}
-                {aiInfo?.vector.available ? ` · Vector: ${aiInfo.vector.implementation}` : " · Vector: unavailable"}
+                Embedding:{" "}
+                {selectedProvider.embedding.enabled
+                  ? selectedProvider.embedding.model
+                  : "disabled"}
+                {aiInfo?.vector.available
+                  ? ` · Vector: ${aiInfo.vector.implementation}`
+                  : " · Vector: unavailable"}
               </Typography>
             ) : null}
             <TextField
@@ -272,11 +325,17 @@ export function ChatPage() {
               size="small"
               fullWidth
             />
-            <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={1}
+              alignItems={{ sm: "center" }}
+            >
               <Stack spacing={0} sx={{ flex: 1 }}>
                 <Typography variant="body2">대화 기억</Typography>
                 <Typography variant="caption" color="text.secondary">
-                  {memoryEnabled ? `사용 중 · ${conversationId}` : "사용하지 않음"}
+                  {memoryEnabled
+                    ? `사용 중 · ${conversationId}`
+                    : "사용하지 않음"}
                 </Typography>
               </Stack>
               <Switch
@@ -296,23 +355,36 @@ export function ChatPage() {
 
       <Paper
         elevation={0}
-        sx={{ minHeight: "calc(100vh - 170px)", display: "flex", flexDirection: "column" }}
+        sx={{
+          minHeight: "calc(100vh - 170px)",
+          display: "flex",
+          flexDirection: "column",
+        }}
       >
         <Box sx={{ flex: 1, overflowY: "auto", px: { xs: 1, md: 8 }, py: 3 }}>
           <Stack spacing={2}>
             {messages.length === 0 ? (
-              <Stack spacing={1} alignItems="center" justifyContent="center" sx={{ minHeight: 260 }}>
+              <Stack
+                spacing={1}
+                alignItems="center"
+                justifyContent="center"
+                sx={{ minHeight: 260 }}
+              >
                 <Avatar sx={{ bgcolor: "primary.main" }}>
                   <SmartToyOutlined />
                 </Avatar>
-                <Typography color="text.secondary">메시지를 입력해 AI와 대화를 시작하세요.</Typography>
+                <Typography color="text.secondary">
+                  메시지를 입력해 AI와 대화를 시작하세요.
+                </Typography>
               </Stack>
             ) : (
               messages.map((message, index) => (
                 <Stack
                   key={`${message.role}-${index}`}
                   direction="row"
-                  justifyContent={message.role === "user" ? "flex-end" : "flex-start"}
+                  justifyContent={
+                    message.role === "user" ? "flex-end" : "flex-start"
+                  }
                   sx={{
                     "& .user-message-actions": {
                       opacity: 0,
@@ -323,17 +395,36 @@ export function ChatPage() {
                     },
                   }}
                 >
-                  <Stack spacing={0.5} alignItems={message.role === "user" ? "flex-end" : "flex-start"}>
+                  <Stack
+                    spacing={0.5}
+                    alignItems={
+                      message.role === "user" ? "flex-end" : "flex-start"
+                    }
+                    sx={{ width: "100%" }}
+                  >
                     <Box
                       sx={{
-                        maxWidth: { xs: "92%", md: message.role === "user" ? "76%" : "72%" },
+                        maxWidth: {
+                          xs: "92%",
+                          md: message.role === "user" ? "86%" : "72%",
+                        },
                         px: message.role === "user" ? 1.75 : 2,
                         py: message.role === "user" ? 1 : 1.5,
-                        borderRadius: message.role === "user" ? 2 : "18px 18px 18px 4px",
-                        bgcolor: message.role === "user" ? "rgba(2, 132, 199, 0.10)" : "background.paper",
-                        color: message.role === "user" ? "info.main" : "text.primary",
+                        borderRadius:
+                          message.role === "user" ? 2 : "18px 18px 18px 4px",
+                        bgcolor:
+                          message.role === "user"
+                            ? (theme) => alpha(theme.palette.info.main, theme.palette.mode === "dark" ? 0.18 : 0.1)
+                            : "background.paper",
+                        color:
+                          message.role === "user"
+                            ? "info.main"
+                            : "text.primary",
                         border: "none",
-                        boxShadow: message.role === "user" ? "0 1px 2px rgba(15, 23, 42, 0.08)" : "none",
+                        boxShadow:
+                          message.role === "user"
+                            ? (theme) => `0 1px 2px ${alpha(theme.palette.common.black, theme.palette.mode === "dark" ? 0.28 : 0.08)}`
+                            : "none",
                       }}
                     >
                       {message.role === "assistant" ? (
@@ -341,10 +432,18 @@ export function ChatPage() {
                           Assistant{message.model ? ` · ${message.model}` : ""}
                         </Typography>
                       ) : null}
-                      <Typography sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: message.role === "assistant" ? 13 : 14 }}>
+                      <Typography
+                        sx={{
+                          whiteSpace: "pre-wrap",
+                          overflowWrap: "anywhere",
+                          fontSize: message.role === "assistant" ? 13 : 14,
+                        }}
+                      >
                         {message.content}
                       </Typography>
-                      {message.role === "assistant" ? renderTokenUsage(message.metadata) : null}
+                      {message.role === "assistant"
+                        ? renderTokenUsage(message.metadata)
+                        : null}
                     </Box>
                     {message.role === "user" ? (
                       <Stack
@@ -358,12 +457,22 @@ export function ChatPage() {
                           {formatMessageTime(message.createdAt)}
                         </Typography>
                         <Tooltip title="복사">
-                          <IconButton size="small" onClick={() => void handleCopyMessage(message.content)}>
+                          <IconButton
+                            size="small"
+                            onClick={() =>
+                              void handleCopyMessage(message.content)
+                            }
+                          >
                             <ContentCopyOutlined fontSize="inherit" />
                           </IconButton>
                         </Tooltip>
                         <Tooltip title="편집">
-                          <IconButton size="small" onClick={() => handleEditMessage(index, message.content)}>
+                          <IconButton
+                            size="small"
+                            onClick={() =>
+                              handleEditMessage(index, message.content)
+                            }
+                          >
                             <EditNoteOutlined fontSize="inherit" />
                           </IconButton>
                         </Tooltip>
@@ -402,7 +511,8 @@ export function ChatPage() {
             sx={{
               borderRadius: 3,
               bgcolor: "background.paper",
-              boxShadow: "0 8px 28px rgba(15, 23, 42, 0.08)",
+              boxShadow: (theme) =>
+                `0 8px 28px ${alpha(theme.palette.common.black, theme.palette.mode === "dark" ? 0.28 : 0.08)}`,
             }}
           >
             <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
@@ -411,7 +521,10 @@ export function ChatPage() {
                   value={input}
                   onChange={(event) => setInput(event.target.value)}
                   onKeyDown={(event) => {
-                    if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+                    if (
+                      event.key === "Enter" &&
+                      (event.ctrlKey || event.metaKey)
+                    ) {
                       void handleSend();
                     }
                   }}
@@ -446,7 +559,9 @@ export function ChatPage() {
                       <IconButton
                         color="primary"
                         onClick={() => void handleSend()}
-                        disabled={sending || !input.trim() || configurationMissing}
+                        disabled={
+                          sending || !input.trim() || configurationMissing
+                        }
                         sx={{
                           width: 40,
                           height: 40,
@@ -501,12 +616,16 @@ export function ChatPage() {
                       }}
                     >
                       <Box>
-                        <Typography variant="body2">{item.chat.model || item.name}</Typography>
+                        <Typography variant="body2">
+                          {item.chat.model || item.name}
+                        </Typography>
                         <Typography variant="caption" color="text.secondary">
                           {item.name}
                         </Typography>
                       </Box>
-                      {selected ? <CheckOutlined color="primary" fontSize="small" /> : null}
+                      {selected ? (
+                        <CheckOutlined color="primary" fontSize="small" />
+                      ) : null}
                     </Button>
                   );
                 })}
@@ -516,7 +635,12 @@ export function ChatPage() {
                   handleModelMenuClose();
                   setSettingsOpen(true);
                 }}
-                sx={{ justifyContent: "space-between", color: "text.primary", px: 1.5, py: 1 }}
+                sx={{
+                  justifyContent: "space-between",
+                  color: "text.primary",
+                  px: 1.5,
+                  py: 1,
+                }}
               >
                 <Box>
                   <Typography variant="body2">더 많은 모델</Typography>
@@ -524,11 +648,20 @@ export function ChatPage() {
                     provider와 model을 직접 설정합니다.
                   </Typography>
                 </Box>
-                <ExpandMoreOutlined fontSize="small" sx={{ transform: "rotate(-90deg)" }} />
+                <ExpandMoreOutlined
+                  fontSize="small"
+                  sx={{ transform: "rotate(-90deg)" }}
+                />
               </Button>
             </Stack>
           </Popover>
-          <Typography variant="caption" color="text.secondary" display="block" textAlign="center" sx={{ mt: 1 }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            display="block"
+            textAlign="center"
+            sx={{ mt: 1 }}
+          >
             AI는 실수할 수 있습니다. 중요한 결과는 다시 확인하세요.
           </Typography>
         </Box>

--- a/src/react/pages/ai/ChatPage.tsx
+++ b/src/react/pages/ai/ChatPage.tsx
@@ -1,13 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
-  alpha,
-  Avatar,
-  Box,
   Button,
-  Card,
-  CardContent,
-  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -15,7 +9,6 @@ import {
   IconButton,
   MenuItem,
   Paper,
-  Popover,
   Stack,
   Switch,
   TextField,
@@ -23,13 +16,9 @@ import {
   Typography,
 } from "@mui/material";
 import {
-  ArrowUpwardOutlined,
-  CheckOutlined,
-  ContentCopyOutlined,
   EditNoteOutlined,
-  ExpandMoreOutlined,
   SettingsOutlined,
-  SmartToyOutlined,
+  SyncOutlined,
 } from "@mui/icons-material";
 import { reactAiApi } from "@/react/pages/ai/api";
 import type {
@@ -39,13 +28,19 @@ import type {
 } from "@/types/studio/ai";
 import { resolveAxiosError } from "@/utils/helpers";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
+import type { ChatMessage, ConversationSummaryDto } from "@/react/pages/ai/components/chatTypes";
+import { ConversationSidebar } from "@/react/pages/ai/components/ConversationSidebar";
+import { ChatMessageList } from "@/react/pages/ai/components/ChatMessageList";
+import { ChatComposer } from "@/react/pages/ai/components/ChatComposer";
 
-type ChatMessage = ChatMessageDto & {
-  id?: string;
-  createdAt?: string;
-  model?: string;
-  metadata?: Record<string, unknown>;
-};
+const CHAT_INPUT_HISTORY_KEY = "ai_chat_input_history";
+
+function toRequestMessage(message: ChatMessage): ChatMessageDto {
+  return {
+    role: message.role,
+    content: message.content,
+  };
+}
 
 export function ChatPage() {
   const [aiInfo, setAiInfo] = useState<AiInfoResponse | null>(null);
@@ -53,24 +48,68 @@ export function ChatPage() {
   const [model, setModel] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
   const [memoryEnabled, setMemoryEnabled] = useState(false);
-  const [conversationId, setConversationId] = useState(() =>
-    crypto.randomUUID(),
-  );
+  const [conversationId, setConversationId] = useState<string>(() => crypto.randomUUID());
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [modelAnchorEl, setModelAnchorEl] = useState<HTMLElement | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [conversations, setConversations] = useState<ConversationSummaryDto[]>([]);
+  const [loadingConversations, setLoadingConversations] = useState(false);
+  const [inputHistory, setInputHistory] = useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw = window.localStorage.getItem(CHAT_INPUT_HISTORY_KEY);
+      return raw ? (JSON.parse(raw) as string[]) : [];
+    } catch {
+      return [];
+    }
+  });
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [compactMode, setCompactMode] = useState(true);
+  const activeStreamIdRef = useRef<string | null>(null);
+  const activeConversationLoadIdRef = useRef<string | null>(null);
 
-  const providers = useMemo<ProviderInfo[]>(
-    () => aiInfo?.providers ?? [],
-    [aiInfo],
-  );
+  const providers = useMemo<ProviderInfo[]>(() => aiInfo?.providers ?? [], [aiInfo]);
   const selectedProvider = providers.find((item) => item.name === provider);
   const configurationMissing = !provider || !model;
   const serverMemoryEnabled = aiInfo?.chat?.memory?.enabled === true;
   const modelMenuOpen = Boolean(modelAnchorEl);
+  const chatModeLabel = memoryEnabled ? "서버 메모리" : "클라이언트 누적 전송";
+  const chatModeDescription = memoryEnabled
+    ? "conversationId 기준으로 서버가 이전 대화를 이어갑니다."
+    : "클라이언트가 지금까지의 대화 메시지를 함께 전송합니다.";
+  const shouldShowSummary = messages.length >= 8;
+  const lastAssistantMessage = useMemo(
+    () => [...messages].reverse().find((message) => message.role === "assistant"),
+    [messages]
+  );
+  const regenerateConversationId =
+    lastAssistantMessage?.metadata?.conversationId ?? (memoryEnabled ? conversationId : undefined);
+  const canRegenerate = Boolean(regenerateConversationId && !sending && lastAssistantMessage);
+  const visibleMessages = useMemo(() => {
+    if (!compactMode || messages.length <= 6) {
+      return messages;
+    }
+    return messages.slice(-6);
+  }, [compactMode, messages]);
+  const collapsedMessageCount = Math.max(messages.length - visibleMessages.length, 0);
+  const summaryText = useMemo(() => {
+    if (!shouldShowSummary) {
+      return "";
+    }
+    const recentMessages = messages.slice(-6);
+    const lastUser = [...recentMessages].reverse().find((item) => item.role === "user")?.content;
+    const lastAssistant = [...recentMessages].reverse().find((item) => item.role === "assistant")?.content;
+    return [
+      `최근 메시지 ${recentMessages.length}개 기준`,
+      lastUser ? `사용자: ${lastUser.slice(0, 120)}` : "",
+      lastAssistant ? `Assistant: ${lastAssistant.slice(0, 160)}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+  }, [messages, shouldShowSummary]);
 
   useEffect(() => {
     reactAiApi
@@ -78,13 +117,31 @@ export function ChatPage() {
       .then((data) => {
         setAiInfo(data);
         setProvider(data.defaultProvider);
-        const match = data.providers.find(
-          (item) => item.name === data.defaultProvider,
-        );
+        const match = data.providers.find((item) => item.name === data.defaultProvider);
         setModel(match?.chat.model ?? "");
       })
       .catch((loadError) => setError(resolveAxiosError(loadError)));
   }, []);
+
+  useEffect(() => {
+    void loadConversations();
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(CHAT_INPUT_HISTORY_KEY, JSON.stringify(inputHistory.slice(0, 30)));
+  }, [inputHistory]);
+
+  async function loadConversations() {
+    setLoadingConversations(true);
+    try {
+      const list = await reactAiApi.listConversations();
+      setConversations(list);
+    } catch {
+      // ignore sidebar load failure
+    } finally {
+      setLoadingConversations(false);
+    }
+  }
 
   function handleProviderChange(nextProvider: string) {
     setProvider(nextProvider);
@@ -101,11 +158,51 @@ export function ChatPage() {
     handleModelMenuClose();
   }
 
+  async function handleOpenConversation(nextConversationId: string) {
+    activeStreamIdRef.current = null;
+    const loadId = crypto.randomUUID();
+    activeConversationLoadIdRef.current = loadId;
+    setSending(false);
+    try {
+      const detail = await reactAiApi.getConversation(nextConversationId);
+      if (activeConversationLoadIdRef.current !== loadId) return;
+      setConversationId(detail.conversationId);
+      setMessages(
+        (detail.messages ?? []).map((message) => ({
+          ...message,
+          id: message.messageId ?? crypto.randomUUID(),
+          createdAt: message.createdAt,
+        }))
+      );
+      setError(null);
+    } catch (loadError) {
+      if (activeConversationLoadIdRef.current !== loadId) return;
+      setError(resolveAxiosError(loadError));
+    } finally {
+      if (activeConversationLoadIdRef.current === loadId) {
+        activeConversationLoadIdRef.current = null;
+      }
+    }
+  }
+
+  async function handleDeleteConversation(targetConversationId: string) {
+    try {
+      await reactAiApi.deleteConversation(targetConversationId);
+      if (targetConversationId === conversationId) {
+        handleNewConversation();
+      }
+      await loadConversations();
+    } catch (deleteError) {
+      setError(resolveAxiosError(deleteError));
+    }
+  }
+
   async function handleSend() {
     const trimmed = input.trim();
-    if (!trimmed) {
+    if (!trimmed || sending || configurationMissing) {
       return;
     }
+
     const userMessage: ChatMessage = {
       id: crypto.randomUUID(),
       role: "user",
@@ -113,92 +210,205 @@ export function ChatPage() {
       createdAt: new Date().toISOString(),
     };
     const nextMessages: ChatMessage[] = [...messages, userMessage];
-    const requestMessages = memoryEnabled ? [userMessage] : nextMessages;
-    setMessages(nextMessages);
+    const requestMessages = (memoryEnabled ? [userMessage] : nextMessages).map(toRequestMessage);
+    const assistantMessageId = crypto.randomUUID();
+    const streamId = crypto.randomUUID();
+    activeStreamIdRef.current = streamId;
+    setInputHistory((current) => [trimmed, ...current.filter((item) => item !== trimmed)].slice(0, 30));
+    setHistoryIndex(-1);
+
+    setMessages([
+      ...nextMessages,
+      {
+        id: assistantMessageId,
+        role: "assistant",
+        content: "",
+        createdAt: new Date().toISOString(),
+        model,
+      },
+    ]);
     setInput("");
     setSending(true);
     setError(null);
+
     try {
-      const response = await reactAiApi.sendChat({
-        provider: provider || undefined,
-        model: model || undefined,
-        messages: requestMessages,
-        systemPrompt: systemPrompt.trim() || undefined,
-        memory: memoryEnabled ? { enabled: true, conversationId } : undefined,
-      });
-      const assistant = [...response.messages]
-        .reverse()
-        .find((item) => item.role === "assistant");
+      await reactAiApi.sendChatStream(
+        {
+          provider: provider || undefined,
+          model: model || undefined,
+          messages: requestMessages,
+          systemPrompt: systemPrompt.trim() || undefined,
+          memory: memoryEnabled ? { enabled: true, conversationId } : undefined,
+        },
+        {
+          onDelta: (payload) => {
+            if (activeStreamIdRef.current !== streamId) return;
+            setMessages((current) =>
+              current.map((message) =>
+                message.id === assistantMessageId
+                  ? { ...message, content: `${message.content}${payload.content ?? ""}` }
+                  : message
+              )
+            );
+          },
+          onUsage: (payload) => {
+            if (activeStreamIdRef.current !== streamId) return;
+            setMessages((current) =>
+              current.map((message) =>
+                message.id === assistantMessageId
+                  ? {
+                      ...message,
+                      metadata: {
+                        ...(message.metadata ?? {}),
+                        tokenUsage: payload,
+                      },
+                    }
+                  : message
+              )
+            );
+          },
+          onComplete: (payload) => {
+            if (activeStreamIdRef.current !== streamId) return;
+            if (payload.conversationId) {
+              setConversationId(payload.conversationId);
+            }
+            setMessages((current) =>
+              current.map((message) =>
+                message.id === assistantMessageId
+                  ? {
+                      ...message,
+                      model: payload.resolvedModel ?? model,
+                      metadata: {
+                        ...(message.metadata ?? {}),
+                        provider: payload.provider,
+                        resolvedModel: payload.resolvedModel,
+                        conversationId: payload.conversationId,
+                        latencyMs: payload.latencyMs,
+                        finishReason: payload.finishReason,
+                        fallbackUsed: payload.fallbackUsed,
+                      },
+                    }
+                  : message
+              )
+            );
+          },
+        }
+      );
+      if (activeStreamIdRef.current === streamId) {
+        await loadConversations();
+      }
+    } catch (sendError) {
+      if (activeStreamIdRef.current !== streamId) return;
+      const message = resolveAxiosError(sendError);
+      setError(message);
+      setMessages((current) =>
+        current.map((item) =>
+          item.id === assistantMessageId
+            ? {
+                ...item,
+                content: `오류: ${message}`,
+                metadata: { ...(item.metadata ?? {}), finishReason: "error" },
+              }
+            : item
+        )
+      );
+    } finally {
+      if (activeStreamIdRef.current === streamId) {
+        activeStreamIdRef.current = null;
+        setSending(false);
+      }
+    }
+  }
+
+  async function handleRegenerate() {
+    if (!canRegenerate || !regenerateConversationId) return;
+    const requestId = crypto.randomUUID();
+    activeStreamIdRef.current = requestId;
+    setSending(true);
+    try {
+      const response = await reactAiApi.regenerate({ conversationId: regenerateConversationId });
+      if (activeStreamIdRef.current !== requestId) return;
+      const assistant = [...response.messages].reverse().find((item) => item.role === "assistant");
       if (assistant) {
+        const nextConversationId = response.metadata?.conversationId ?? response.conversationId;
+        if (nextConversationId) {
+          setConversationId(nextConversationId);
+        }
         setMessages((current) => [
           ...current,
           {
             ...assistant,
             id: crypto.randomUUID(),
-            model: response.model ?? model,
-            metadata: response.metadata,
             createdAt: new Date().toISOString(),
+            metadata: nextConversationId
+              ? { ...(response.metadata ?? {}), conversationId: nextConversationId }
+              : response.metadata,
+            model: response.metadata?.resolvedModel ?? model,
           },
         ]);
       }
-    } catch (sendError) {
-      const message = resolveAxiosError(sendError);
-      setError(message);
-      setMessages((current) => [
-        ...current,
-        {
-          id: crypto.randomUUID(),
-          role: "assistant",
-          content: `오류: ${message}`,
-          model,
-          createdAt: new Date().toISOString(),
-        },
-      ]);
+      await loadConversations();
+    } catch (regenerateError) {
+      if (activeStreamIdRef.current !== requestId) return;
+      setError(resolveAxiosError(regenerateError));
     } finally {
-      setSending(false);
+      if (activeStreamIdRef.current === requestId) {
+        activeStreamIdRef.current = null;
+        setSending(false);
+      }
     }
   }
 
+  async function handleRetryLastUserMessage() {
+    const lastUser = [...messages].reverse().find((item) => item.role === "user");
+    if (!lastUser?.content) {
+      return;
+    }
+    setInput(lastUser.content);
+  }
+
   function handleNewConversation() {
+    activeStreamIdRef.current = null;
+    activeConversationLoadIdRef.current = null;
+    setSending(false);
     setConversationId(crypto.randomUUID());
     setMessages([]);
     setInput("");
     setError(null);
   }
 
-  function renderTokenUsage(metadata?: Record<string, unknown>) {
-    const usage = metadata?.tokenUsage as
-      | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-      | undefined;
-    if (!usage) return null;
-
-    return (
-      <Typography
-        variant="caption"
-        color="text.secondary"
-        sx={{ mt: 0.75, display: "block", fontSize: 11 }}
-      >
-        tokens · input {usage.inputTokens ?? "-"} · output{" "}
-        {usage.outputTokens ?? "-"} · total {usage.totalTokens ?? "-"}
-      </Typography>
-    );
-  }
-
-  function formatMessageTime(value?: string) {
-    if (!value) return "";
-    return new Date(value).toLocaleTimeString("ko-KR", {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  }
-
   async function handleCopyMessage(content: string) {
     await navigator.clipboard.writeText(content);
   }
 
-  function handleEditMessage(index: number, content: string) {
+  function handleEditMessage(messageId: string | undefined, content: string) {
     setInput(content);
-    setMessages((current) => current.slice(0, index));
+    setMessages((current) => {
+      const index = current.findIndex((message) => message.id === messageId);
+      return index >= 0 ? current.slice(0, index) : current;
+    });
+  }
+
+  function handleInputHistoryNavigation(direction: "prev" | "next") {
+    if (inputHistory.length === 0) {
+      return;
+    }
+
+    if (direction === "prev") {
+      const nextIndex = historyIndex + 1 >= inputHistory.length ? inputHistory.length - 1 : historyIndex + 1;
+      setHistoryIndex(nextIndex);
+      setInput(inputHistory[nextIndex] ?? "");
+      return;
+    }
+
+    const nextIndex = historyIndex - 1;
+    if (nextIndex < 0) {
+      setHistoryIndex(-1);
+      setInput("");
+      return;
+    }
+    setHistoryIndex(nextIndex);
+    setInput(inputHistory[nextIndex] ?? "");
   }
 
   return (
@@ -209,20 +419,17 @@ export function ChatPage() {
         label="Provider와 모델을 선택해 AI Chat 요청을 보냅니다."
         actions={
           <>
-            <Tooltip
-              title={
-                memoryEnabled
-                  ? "새 대화 시작"
-                  : "대화 기억을 켜면 새 대화를 시작할 수 있습니다"
-              }
-            >
+            <Tooltip title={memoryEnabled ? "새 대화 시작" : "대화 기억을 켜면 새 대화를 시작할 수 있습니다"}>
               <span>
-                <IconButton
-                  size="small"
-                  onClick={handleNewConversation}
-                  disabled={!memoryEnabled}
-                >
+                <IconButton size="small" onClick={handleNewConversation} disabled={!memoryEnabled}>
                   <EditNoteOutlined fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="답변 다시 생성">
+              <span>
+                <IconButton size="small" onClick={() => void handleRegenerate()} disabled={!canRegenerate}>
+                  <SyncOutlined fontSize="small" />
                 </IconButton>
               </span>
             </Tooltip>
@@ -236,436 +443,119 @@ export function ChatPage() {
       />
       {error ? <Alert severity="error">{error}</Alert> : null}
       {configurationMissing ? (
-        <Alert severity="warning">
-          AI Chat을 사용하려면 Provider와 Model 설정이 필요합니다. 상단 설정
-          아이콘을 눌러 사용할 provider와 모델을 선택하거나 입력하세요.
-        </Alert>
-      ) : null}
-      {memoryEnabled ? (
-        <Alert severity="info">
-          대화 기억 사용 중입니다. 새 대화를 시작하면 이전 대화와 분리됩니다.
-        </Alert>
+        <Alert severity="warning">AI Chat을 사용하려면 Provider와 Model 설정이 필요합니다. 상단 설정 아이콘을 눌러 사용할 provider와 모델을 선택하거나 입력하세요.</Alert>
       ) : null}
 
-      <Dialog
-        open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-        maxWidth="sm"
-        fullWidth
-        slotProps={{
-          paper: {
-            sx: { borderRadius: 3 },
-          },
-        }}
-      >
+      <Dialog open={settingsOpen} onClose={() => setSettingsOpen(false)} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
         <DialogTitle>AI 모델 설정</DialogTitle>
         <DialogContent>
           <Stack spacing={2}>
-            <Alert severity="info">
-              Provider를 비우면 서버 기본 provider가 사용됩니다. System Prompt는
-              별도 systemPrompt 필드로 전송되며, 대화 메시지에는 사용자와
-              assistant 메시지만 유지됩니다.
-            </Alert>
             {serverMemoryEnabled ? (
-              <Alert severity="info">
-                서버가 conversationId 기반 대화 기억을 지원합니다. 켜면 이전
-                대화는 서버 메모리에서 이어지며, 클라이언트는 현재 턴 메시지만
-                전송합니다.
-              </Alert>
+              <Alert severity="info">서버가 conversationId 기반 대화 기억을 지원합니다.</Alert>
             ) : (
-              <Alert severity="warning">
-                서버에서 대화 기억 기능이 비활성화되어 있습니다.
-              </Alert>
+              <Alert severity="warning">서버에서 대화 기억 기능이 비활성화되어 있습니다.</Alert>
             )}
             <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
-              <TextField
-                select
-                label="Provider"
-                value={provider}
-                onChange={(event) => handleProviderChange(event.target.value)}
-                fullWidth
-                size="small"
-              >
+              <TextField select label="Provider" value={provider} onChange={(event) => handleProviderChange(event.target.value)} fullWidth size="small">
                 {providers.map((item) => (
                   <MenuItem key={item.name} value={item.name}>
                     <Stack spacing={0}>
                       <Typography variant="body2">{item.name}</Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        chat: {item.chat.enabled ? item.chat.model : "disabled"}
-                      </Typography>
+                      <Typography variant="caption" color="text.secondary">chat: {item.chat.enabled ? item.chat.model : "disabled"}</Typography>
                     </Stack>
                   </MenuItem>
                 ))}
               </TextField>
-              <TextField
-                label="Model"
-                value={model}
-                onChange={(event) => setModel(event.target.value)}
-                fullWidth
-                size="small"
-              />
+              <TextField label="Model" value={model} onChange={(event) => setModel(event.target.value)} fullWidth size="small" />
             </Stack>
             {selectedProvider ? (
               <Typography variant="caption" color="text.secondary">
-                Embedding:{" "}
-                {selectedProvider.embedding.enabled
-                  ? selectedProvider.embedding.model
-                  : "disabled"}
-                {aiInfo?.vector.available
-                  ? ` · Vector: ${aiInfo.vector.implementation}`
-                  : " · Vector: unavailable"}
+                Embedding: {selectedProvider.embedding.enabled ? selectedProvider.embedding.model : "disabled"}
+                {aiInfo?.vector.available ? ` · Vector: ${aiInfo.vector.implementation}` : " · Vector: unavailable"}
               </Typography>
             ) : null}
-            <TextField
-              label="System Prompt"
-              value={systemPrompt}
-              onChange={(event) => setSystemPrompt(event.target.value)}
-              multiline
-              minRows={2}
-              size="small"
-              fullWidth
-            />
-            <Stack
-              direction={{ xs: "column", sm: "row" }}
-              spacing={1}
-              alignItems={{ sm: "center" }}
-            >
+            <TextField label="System Prompt" value={systemPrompt} onChange={(event) => setSystemPrompt(event.target.value)} multiline minRows={2} size="small" fullWidth />
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
               <Stack spacing={0} sx={{ flex: 1 }}>
                 <Typography variant="body2">대화 기억</Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {memoryEnabled
-                    ? `사용 중 · ${conversationId}`
-                    : "사용하지 않음"}
-                </Typography>
+                <Typography variant="caption" color="text.secondary">{memoryEnabled ? `사용 중 · ${conversationId}` : "사용하지 않음"}</Typography>
               </Stack>
-              <Switch
-                checked={memoryEnabled}
-                disabled={!serverMemoryEnabled}
-                onChange={(event) => setMemoryEnabled(event.target.checked)}
-              />
+              <Switch checked={memoryEnabled} disabled={!serverMemoryEnabled} onChange={(event) => setMemoryEnabled(event.target.checked)} />
             </Stack>
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button variant="outlined" onClick={() => setSettingsOpen(false)}>
-            닫기
-          </Button>
+          <Button variant="outlined" onClick={() => setSettingsOpen(false)}>닫기</Button>
         </DialogActions>
       </Dialog>
 
-      <Paper
-        elevation={0}
-        sx={{
-          minHeight: "calc(100vh - 170px)",
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        <Box sx={{ flex: 1, overflowY: "auto", px: { xs: 1, md: 8 }, py: 3 }}>
-          <Stack spacing={2}>
-            {messages.length === 0 ? (
-              <Stack
-                spacing={1}
-                alignItems="center"
-                justifyContent="center"
-                sx={{ minHeight: 260 }}
-              >
-                <Avatar sx={{ bgcolor: "primary.main" }}>
-                  <SmartToyOutlined />
-                </Avatar>
-                <Typography color="text.secondary">
-                  메시지를 입력해 AI와 대화를 시작하세요.
-                </Typography>
-              </Stack>
-            ) : (
-              messages.map((message, index) => (
-                <Stack
-                  key={`${message.role}-${index}`}
-                  direction="row"
-                  justifyContent={
-                    message.role === "user" ? "flex-end" : "flex-start"
-                  }
-                  sx={{
-                    "& .user-message-actions": {
-                      opacity: 0,
-                      transition: "opacity 120ms ease",
-                    },
-                    "&:hover .user-message-actions": {
-                      opacity: 1,
-                    },
-                  }}
-                >
-                  <Stack
-                    spacing={0.5}
-                    alignItems={
-                      message.role === "user" ? "flex-end" : "flex-start"
-                    }
-                    sx={{ width: "100%" }}
-                  >
-                    <Box
-                      sx={{
-                        maxWidth: {
-                          xs: "92%",
-                          md: message.role === "user" ? "86%" : "72%",
-                        },
-                        px: message.role === "user" ? 1.75 : 2,
-                        py: message.role === "user" ? 1 : 1.5,
-                        borderRadius:
-                          message.role === "user" ? 2 : "18px 18px 18px 4px",
-                        bgcolor:
-                          message.role === "user"
-                            ? (theme) => alpha(theme.palette.info.main, theme.palette.mode === "dark" ? 0.18 : 0.1)
-                            : "background.paper",
-                        color:
-                          message.role === "user"
-                            ? "info.main"
-                            : "text.primary",
-                        border: "none",
-                        boxShadow:
-                          message.role === "user"
-                            ? (theme) => `0 1px 2px ${alpha(theme.palette.common.black, theme.palette.mode === "dark" ? 0.28 : 0.08)}`
-                            : "none",
-                      }}
-                    >
-                      {message.role === "assistant" ? (
-                        <Typography variant="caption" color="text.secondary">
-                          Assistant{message.model ? ` · ${message.model}` : ""}
-                        </Typography>
-                      ) : null}
-                      <Typography
-                        sx={{
-                          whiteSpace: "pre-wrap",
-                          overflowWrap: "anywhere",
-                          fontSize: message.role === "assistant" ? 13 : 14,
-                        }}
-                      >
-                        {message.content}
-                      </Typography>
-                      {message.role === "assistant"
-                        ? renderTokenUsage(message.metadata)
-                        : null}
-                    </Box>
-                    {message.role === "user" ? (
-                      <Stack
-                        className="user-message-actions"
-                        direction="row"
-                        spacing={0.5}
-                        alignItems="center"
-                        sx={{ pr: 0.5 }}
-                      >
-                        <Typography variant="caption" color="text.secondary">
-                          {formatMessageTime(message.createdAt)}
-                        </Typography>
-                        <Tooltip title="복사">
-                          <IconButton
-                            size="small"
-                            onClick={() =>
-                              void handleCopyMessage(message.content)
-                            }
-                          >
-                            <ContentCopyOutlined fontSize="inherit" />
-                          </IconButton>
-                        </Tooltip>
-                        <Tooltip title="편집">
-                          <IconButton
-                            size="small"
-                            onClick={() =>
-                              handleEditMessage(index, message.content)
-                            }
-                          >
-                            <EditNoteOutlined fontSize="inherit" />
-                          </IconButton>
-                        </Tooltip>
-                      </Stack>
-                    ) : null}
-                  </Stack>
-                </Stack>
-              ))
-            )}
-            {sending ? (
-              <Stack direction="row" justifyContent="flex-start">
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 1,
-                    p: 1.5,
-                    borderRadius: 2,
-                    bgcolor: "background.paper",
-                    border: "1px solid",
-                    borderColor: "divider",
-                  }}
-                >
-                  <CircularProgress size={16} />
-                  <Typography variant="body2" color="text.secondary">
-                    응답 생성 중...
-                  </Typography>
-                </Box>
-              </Stack>
-            ) : null}
-          </Stack>
-        </Box>
-        <Box sx={{ px: { xs: 1, md: 6 }, pb: 2 }}>
-          <Card
-            variant="outlined"
-            sx={{
-              borderRadius: 3,
-              bgcolor: "background.paper",
-              boxShadow: (theme) =>
-                `0 8px 28px ${alpha(theme.palette.common.black, theme.palette.mode === "dark" ? 0.28 : 0.08)}`,
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ minHeight: 'calc(100vh - 170px)' }}>
+        <ConversationSidebar
+          conversationId={conversationId}
+          conversations={conversations}
+          loading={loadingConversations}
+          onOpen={(nextConversationId) => void handleOpenConversation(nextConversationId)}
+          onDelete={(targetConversationId) => void handleDeleteConversation(targetConversationId)}
+          onRefresh={() => void loadConversations()}
+        />
+        <Paper elevation={0} sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <ChatMessageList
+            messages={visibleMessages}
+            sending={sending}
+            collapsedMessageCount={collapsedMessageCount}
+            summaryText={summaryText}
+            summaryVisible={shouldShowSummary}
+            onToggleSummary={() => setCompactMode((current) => !current)}
+            onCopy={(content) => void handleCopyMessage(content)}
+            onEditUser={handleEditMessage}
+            onRegenerate={() => void handleRegenerate()}
+            onRetryLastUser={() => void handleRetryLastUserMessage()}
+          />
+          <ChatComposer
+            input={input}
+            sending={sending}
+            configurationMissing={configurationMissing}
+            model={model}
+            provider={provider}
+            conversationId={conversationId}
+            chatModeLabel={chatModeLabel}
+            chatModeDescription={chatModeDescription}
+            latencyMs={lastAssistantMessage?.metadata?.latencyMs}
+            inputHistory={inputHistory}
+            onInputChange={setInput}
+            onSubmit={() => void handleSend()}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+                void handleSend();
+                return;
+              }
+              if (event.key === 'ArrowUp' && !event.shiftKey && !input.trim()) {
+                event.preventDefault();
+                handleInputHistoryNavigation("prev");
+                return;
+              }
+              if (event.key === 'ArrowDown' && !event.shiftKey && historyIndex >= 0) {
+                event.preventDefault();
+                handleInputHistoryNavigation("next");
+              }
             }}
-          >
-            <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
-              <Stack spacing={1}>
-                <TextField
-                  value={input}
-                  onChange={(event) => setInput(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (
-                      event.key === "Enter" &&
-                      (event.ctrlKey || event.metaKey)
-                    ) {
-                      void handleSend();
-                    }
-                  }}
-                  placeholder="답글..."
-                  multiline
-                  minRows={2}
-                  maxRows={6}
-                  fullWidth
-                  variant="standard"
-                  InputProps={{ disableUnderline: true }}
-                />
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <Box sx={{ flex: 1 }} />
-                  <Tooltip title="모델 선택">
-                    <Button
-                      size="small"
-                      variant="text"
-                      endIcon={<ExpandMoreOutlined fontSize="small" />}
-                      onClick={(event) => setModelAnchorEl(event.currentTarget)}
-                      sx={{
-                        color: "text.primary",
-                        px: 1,
-                        minWidth: 0,
-                        "&:hover": { bgcolor: "action.hover" },
-                      }}
-                    >
-                      {model || "모델 설정"}
-                    </Button>
-                  </Tooltip>
-                  <Tooltip title="보내기">
-                    <span>
-                      <IconButton
-                        color="primary"
-                        onClick={() => void handleSend()}
-                        disabled={
-                          sending || !input.trim() || configurationMissing
-                        }
-                        sx={{
-                          width: 40,
-                          height: 40,
-                          bgcolor: "primary.main",
-                          color: "primary.contrastText",
-                          "&:hover": { bgcolor: "primary.dark" },
-                          "&.Mui-disabled": {
-                            bgcolor: "action.disabledBackground",
-                            color: "action.disabled",
-                          },
-                        }}
-                      >
-                        <ArrowUpwardOutlined fontSize="small" />
-                      </IconButton>
-                    </span>
-                  </Tooltip>
-                </Stack>
-              </Stack>
-            </CardContent>
-          </Card>
-          <Popover
-            open={modelMenuOpen}
-            anchorEl={modelAnchorEl}
-            onClose={handleModelMenuClose}
-            anchorOrigin={{ vertical: "top", horizontal: "right" }}
-            transformOrigin={{ vertical: "bottom", horizontal: "right" }}
-            PaperProps={{
-              sx: {
-                width: 360,
-                borderRadius: 2,
-                p: 1,
-                mb: 1,
-              },
+            onOpenModelMenu={(event) => setModelAnchorEl(event.currentTarget)}
+            modelMenuOpen={modelMenuOpen}
+            modelAnchorEl={modelAnchorEl}
+            providers={providers}
+            onCloseModelMenu={handleModelMenuClose}
+            onSelectProvider={(nextProvider) => handleModelSelect(nextProvider)}
+            onOpenSettings={() => {
+              handleModelMenuClose();
+              setSettingsOpen(true);
             }}
-          >
-            <Stack spacing={0.5}>
-              {providers
-                .filter((item) => item.chat.enabled)
-                .map((item) => {
-                  const selected = item.name === provider;
-                  return (
-                    <Button
-                      key={item.name}
-                      variant="text"
-                      onClick={() => handleModelSelect(item.name)}
-                      sx={{
-                        justifyContent: "space-between",
-                        textAlign: "left",
-                        color: "text.primary",
-                        px: 1.5,
-                        py: 1,
-                      }}
-                    >
-                      <Box>
-                        <Typography variant="body2">
-                          {item.chat.model || item.name}
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          {item.name}
-                        </Typography>
-                      </Box>
-                      {selected ? (
-                        <CheckOutlined color="primary" fontSize="small" />
-                      ) : null}
-                    </Button>
-                  );
-                })}
-              <Button
-                variant="text"
-                onClick={() => {
-                  handleModelMenuClose();
-                  setSettingsOpen(true);
-                }}
-                sx={{
-                  justifyContent: "space-between",
-                  color: "text.primary",
-                  px: 1.5,
-                  py: 1,
-                }}
-              >
-                <Box>
-                  <Typography variant="body2">더 많은 모델</Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    provider와 model을 직접 설정합니다.
-                  </Typography>
-                </Box>
-                <ExpandMoreOutlined
-                  fontSize="small"
-                  sx={{ transform: "rotate(-90deg)" }}
-                />
-              </Button>
-            </Stack>
-          </Popover>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            display="block"
-            textAlign="center"
-            sx={{ mt: 1 }}
-          >
-            AI는 실수할 수 있습니다. 중요한 결과는 다시 확인하세요.
-          </Typography>
-        </Box>
-      </Paper>
+            onSelectHistory={(value) => {
+              setInput(value);
+              setHistoryIndex(-1);
+            }}
+          />
+        </Paper>
+      </Stack>
     </Stack>
   );
 }

--- a/src/react/pages/ai/ChatPage.tsx
+++ b/src/react/pages/ai/ChatPage.tsx
@@ -6,6 +6,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Drawer,
   IconButton,
   MenuItem,
   Paper,
@@ -17,6 +18,7 @@ import {
 } from "@mui/material";
 import {
   EditNoteOutlined,
+  HistoryOutlined,
   SettingsOutlined,
   SyncOutlined,
 } from "@mui/icons-material";
@@ -24,7 +26,10 @@ import { reactAiApi } from "@/react/pages/ai/api";
 import type {
   AiInfoResponse,
   ChatMessageDto,
+  ChatStreamCompleteEventDto,
+  ChatStreamUsageEventDto,
   ProviderInfo,
+  TokenUsageDto,
 } from "@/types/studio/ai";
 import { resolveAxiosError } from "@/utils/helpers";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
@@ -34,6 +39,38 @@ import { ChatMessageList } from "@/react/pages/ai/components/ChatMessageList";
 import { ChatComposer } from "@/react/pages/ai/components/ChatComposer";
 
 const CHAT_INPUT_HISTORY_KEY = "ai_chat_input_history";
+
+function normalizeStreamUsage(payload: ChatStreamUsageEventDto): TokenUsageDto | undefined {
+  const usage = payload.metadata?.tokenUsage ?? payload;
+  const hasUsage =
+    usage.inputTokens !== undefined ||
+    usage.outputTokens !== undefined ||
+    usage.totalTokens !== undefined;
+
+  if (!hasUsage) return undefined;
+
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: usage.totalTokens ?? inputTokens + outputTokens,
+  };
+}
+
+function normalizeStreamComplete(payload: ChatStreamCompleteEventDto) {
+  const metadata = payload.metadata ?? {};
+
+  return {
+    provider: payload.provider ?? metadata.provider,
+    resolvedModel: payload.resolvedModel ?? metadata.resolvedModel ?? payload.model,
+    conversationId: payload.conversationId ?? metadata.conversationId,
+    latencyMs: payload.latencyMs ?? metadata.latencyMs,
+    finishReason: payload.finishReason ?? metadata.finishReason,
+    fallbackUsed: payload.fallbackUsed,
+    tokenUsage: metadata.tokenUsage,
+  };
+}
 
 function toRequestMessage(message: ChatMessage): ChatMessageDto {
   return {
@@ -52,6 +89,7 @@ export function ChatPage() {
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [conversationDrawerOpen, setConversationDrawerOpen] = useState(false);
   const [modelAnchorEl, setModelAnchorEl] = useState<HTMLElement | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -103,9 +141,9 @@ export function ChatPage() {
     const lastUser = [...recentMessages].reverse().find((item) => item.role === "user")?.content;
     const lastAssistant = [...recentMessages].reverse().find((item) => item.role === "assistant")?.content;
     return [
-      `최근 메시지 ${recentMessages.length}개 기준`,
-      lastUser ? `사용자: ${lastUser.slice(0, 120)}` : "",
-      lastAssistant ? `Assistant: ${lastAssistant.slice(0, 160)}` : "",
+      `최근 ${recentMessages.length}개 메시지`,
+      lastUser ? `질문: ${lastUser.slice(0, 120)}` : "",
+      lastAssistant ? `답변: ${lastAssistant.slice(0, 160)}` : "",
     ]
       .filter(Boolean)
       .join("\n");
@@ -119,6 +157,7 @@ export function ChatPage() {
         setProvider(data.defaultProvider);
         const match = data.providers.find((item) => item.name === data.defaultProvider);
         setModel(match?.chat.model ?? "");
+        setMemoryEnabled(data.chat?.memory?.enabled === true);
       })
       .catch((loadError) => setError(resolveAxiosError(loadError)));
   }, []);
@@ -174,6 +213,7 @@ export function ChatPage() {
           createdAt: message.createdAt,
         }))
       );
+      setConversationDrawerOpen(false);
       setError(null);
     } catch (loadError) {
       if (activeConversationLoadIdRef.current !== loadId) return;
@@ -246,13 +286,15 @@ export function ChatPage() {
             setMessages((current) =>
               current.map((message) =>
                 message.id === assistantMessageId
-                  ? { ...message, content: `${message.content}${payload.content ?? ""}` }
+                  ? { ...message, content: `${message.content}${payload.delta ?? payload.content ?? ""}` }
                   : message
               )
             );
           },
           onUsage: (payload) => {
             if (activeStreamIdRef.current !== streamId) return;
+            const tokenUsage = normalizeStreamUsage(payload);
+            if (!tokenUsage) return;
             setMessages((current) =>
               current.map((message) =>
                 message.id === assistantMessageId
@@ -260,7 +302,7 @@ export function ChatPage() {
                       ...message,
                       metadata: {
                         ...(message.metadata ?? {}),
-                        tokenUsage: payload,
+                        tokenUsage,
                       },
                     }
                   : message
@@ -269,23 +311,25 @@ export function ChatPage() {
           },
           onComplete: (payload) => {
             if (activeStreamIdRef.current !== streamId) return;
-            if (payload.conversationId) {
-              setConversationId(payload.conversationId);
+            const complete = normalizeStreamComplete(payload);
+            if (complete.conversationId) {
+              setConversationId(complete.conversationId);
             }
             setMessages((current) =>
               current.map((message) =>
                 message.id === assistantMessageId
                   ? {
                       ...message,
-                      model: payload.resolvedModel ?? model,
+                      model: complete.resolvedModel ?? model,
                       metadata: {
                         ...(message.metadata ?? {}),
-                        provider: payload.provider,
-                        resolvedModel: payload.resolvedModel,
-                        conversationId: payload.conversationId,
-                        latencyMs: payload.latencyMs,
-                        finishReason: payload.finishReason,
-                        fallbackUsed: payload.fallbackUsed,
+                        provider: complete.provider,
+                        resolvedModel: complete.resolvedModel,
+                        conversationId: complete.conversationId,
+                        latencyMs: complete.latencyMs,
+                        finishReason: complete.finishReason,
+                        fallbackUsed: complete.fallbackUsed,
+                        tokenUsage: message.metadata?.tokenUsage ?? complete.tokenUsage,
                       },
                     }
                   : message
@@ -426,6 +470,11 @@ export function ChatPage() {
                 </IconButton>
               </span>
             </Tooltip>
+            <Tooltip title="대화 목록">
+              <IconButton size="small" onClick={() => setConversationDrawerOpen(true)}>
+                <HistoryOutlined fontSize="small" />
+              </IconButton>
+            </Tooltip>
             <Tooltip title="답변 다시 생성">
               <span>
                 <IconButton size="small" onClick={() => void handleRegenerate()} disabled={!canRegenerate}>
@@ -489,16 +538,30 @@ export function ChatPage() {
         </DialogActions>
       </Dialog>
 
-      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ minHeight: 'calc(100vh - 170px)' }}>
+      <Drawer
+        anchor="right"
+        open={conversationDrawerOpen}
+        onClose={() => setConversationDrawerOpen(false)}
+        PaperProps={{
+          sx: {
+            width: { xs: "100%", sm: 380 },
+          },
+        }}
+      >
         <ConversationSidebar
+          drawer
           conversationId={conversationId}
           conversations={conversations}
           loading={loadingConversations}
           onOpen={(nextConversationId) => void handleOpenConversation(nextConversationId)}
           onDelete={(targetConversationId) => void handleDeleteConversation(targetConversationId)}
           onRefresh={() => void loadConversations()}
+          onClose={() => setConversationDrawerOpen(false)}
         />
-        <Paper elevation={0} sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+      </Drawer>
+
+      <Stack sx={{ height: 'calc(100vh - 170px)', minHeight: 0 }}>
+        <Paper elevation={0} sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <ChatMessageList
             messages={visibleMessages}
             sending={sending}
@@ -521,6 +584,7 @@ export function ChatPage() {
             chatModeLabel={chatModeLabel}
             chatModeDescription={chatModeDescription}
             latencyMs={lastAssistantMessage?.metadata?.latencyMs}
+            tokenUsage={lastAssistantMessage?.metadata?.tokenUsage}
             inputHistory={inputHistory}
             onInputChange={setInput}
             onSubmit={() => void handleSend()}

--- a/src/react/pages/ai/RagChatPage.tsx
+++ b/src/react/pages/ai/RagChatPage.tsx
@@ -1,0 +1,504 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  MenuItem,
+  Paper,
+  Stack,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { AddCommentOutlined, SettingsOutlined } from "@mui/icons-material";
+import { PageToolbar } from "@/react/components/page/PageToolbar";
+import { reactAiApi } from "@/react/pages/ai/api";
+import { ChatComposer } from "@/react/pages/ai/components/ChatComposer";
+import { ChatMessageList } from "@/react/pages/ai/components/ChatMessageList";
+import type { ChatMessage } from "@/react/pages/ai/components/chatTypes";
+import type { AiInfoResponse, ChatMessageDto, ProviderInfo, SearchResultDto } from "@/types/studio/ai";
+import { resolveAxiosError } from "@/utils/helpers";
+
+const RAG_CHAT_INPUT_HISTORY_KEY = "ai_rag_chat_input_history";
+
+function toRequestMessage(message: ChatMessage): ChatMessageDto {
+  return {
+    role: message.role,
+    content: message.content,
+  };
+}
+
+function numberOrUndefined(value: string) {
+  const nextValue = Number(value);
+  return Number.isFinite(nextValue) ? nextValue : undefined;
+}
+
+function metadataValue(metadata: Record<string, unknown> | undefined, keys: string[]) {
+  if (!metadata) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = metadata[key];
+    if (value != null && value !== "") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function formatMetadataValue(value: unknown) {
+  if (value == null || value === "") {
+    return "";
+  }
+  return typeof value === "object" ? JSON.stringify(value) : String(value);
+}
+
+function resultSourceName(row: SearchResultDto) {
+  const metadataName = metadataValue(row.metadata, [
+    "sourceName",
+    "fileName",
+    "filename",
+    "originalFilename",
+    "documentName",
+    "title",
+    "name",
+  ]);
+  if (metadataName != null) {
+    return formatMetadataValue(metadataName);
+  }
+
+  const objectType = metadataValue(row.metadata, ["objectType", "object_type"]);
+  const objectId = metadataValue(row.metadata, ["objectId", "object_id"]);
+  if (objectType != null && objectId != null) {
+    return `${formatMetadataValue(objectType)} #${formatMetadataValue(objectId)}`;
+  }
+
+  return row.documentId || "문서";
+}
+
+function resultChunkLabel(row: SearchResultDto) {
+  const page = metadataValue(row.metadata, ["page", "pageNumber", "page_number", "pageNo", "page_no"]);
+  if (page != null) {
+    return `p.${formatMetadataValue(page)}`;
+  }
+  const slide = metadataValue(row.metadata, ["slide", "slideNumber", "slide_number", "slideNo", "slide_no"]);
+  if (slide != null) {
+    return `slide ${formatMetadataValue(slide)}`;
+  }
+  const order = metadataValue(row.metadata, ["chunkOrder", "chunkIndex", "chunk_order", "chunk_index", "order", "index"]);
+  if (order != null) {
+    return `chunk #${formatMetadataValue(order)}`;
+  }
+  return formatMetadataValue(metadataValue(row.metadata, ["chunkId", "chunk_id", "id"]));
+}
+
+function toRagReferences(rows: SearchResultDto[]) {
+  return rows.slice(0, 5).map((row, index) => ({
+    index: index + 1,
+    title: resultSourceName(row),
+    chunk: resultChunkLabel(row),
+    score: row.score,
+    content: row.content,
+  }));
+}
+
+export function RagChatPage() {
+  const [aiInfo, setAiInfo] = useState<AiInfoResponse | null>(null);
+  const [provider, setProvider] = useState("");
+  const [model, setModel] = useState("");
+  const [systemPrompt, setSystemPrompt] = useState(
+    "제공된 RAG 문서 내용에 근거해서만 답변하세요. 문서에서 확인할 수 없는 내용은 확인할 수 없다고 답변하세요."
+  );
+  const [memoryEnabled, setMemoryEnabled] = useState(false);
+  const [conversationId, setConversationId] = useState<string>(() => crypto.randomUUID());
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [sending, setSending] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [modelAnchorEl, setModelAnchorEl] = useState<HTMLElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [topK, setTopK] = useState("2");
+  const [minScore, setMinScore] = useState("0.6");
+  const [debug, setDebug] = useState(false);
+  const [inputHistory, setInputHistory] = useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw = window.localStorage.getItem(RAG_CHAT_INPUT_HISTORY_KEY);
+      return raw ? (JSON.parse(raw) as string[]) : [];
+    } catch {
+      return [];
+    }
+  });
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const activeRequestIdRef = useRef<string | null>(null);
+
+  const providers = useMemo<ProviderInfo[]>(() => aiInfo?.providers ?? [], [aiInfo]);
+  const selectedProvider = providers.find((item) => item.name === provider);
+  const configurationMissing = !provider || !model;
+  const shouldShowConfigurationWarning = aiInfo !== null && configurationMissing;
+  const serverMemoryEnabled = aiInfo?.chat?.memory?.enabled === true;
+  const modelMenuOpen = Boolean(modelAnchorEl);
+  const lastAssistantMessage = useMemo(
+    () => [...messages].reverse().find((message) => message.role === "assistant"),
+    [messages]
+  );
+
+  useEffect(() => {
+    reactAiApi
+      .fetchProviders()
+      .then((data) => {
+        setAiInfo(data);
+        setProvider(data.defaultProvider);
+        const match = data.providers.find((item) => item.name === data.defaultProvider);
+        setModel(match?.chat.model ?? "");
+        setMemoryEnabled(data.chat?.memory?.enabled === true);
+      })
+      .catch((loadError) => setError(resolveAxiosError(loadError)));
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(RAG_CHAT_INPUT_HISTORY_KEY, JSON.stringify(inputHistory.slice(0, 30)));
+  }, [inputHistory]);
+
+  function handleProviderChange(nextProvider: string) {
+    setProvider(nextProvider);
+    const match = providers.find((item) => item.name === nextProvider);
+    setModel(match?.chat.model ?? "");
+  }
+
+  function handleModelMenuClose() {
+    setModelAnchorEl(null);
+  }
+
+  function handleModelSelect(nextProvider: string) {
+    handleProviderChange(nextProvider);
+    handleModelMenuClose();
+  }
+
+  async function submitRagQuestion(trimmed: string, baseMessages: ChatMessage[], appendUserMessage: boolean) {
+    if (!trimmed || sending || configurationMissing) {
+      return;
+    }
+
+    const userMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: trimmed,
+      createdAt: new Date().toISOString(),
+    };
+    const nextMessages = appendUserMessage ? [...baseMessages, userMessage] : baseMessages;
+    const requestMessages = (memoryEnabled ? [userMessage] : nextMessages).map(toRequestMessage);
+    const requestId = crypto.randomUUID();
+    activeRequestIdRef.current = requestId;
+    const numericTopK = numberOrUndefined(topK);
+    const numericMinScore = numberOrUndefined(minScore);
+
+    setMessages(nextMessages);
+    setInput("");
+    setSending(true);
+    setError(null);
+    setInput("");
+
+    try {
+      const referencesPromise = reactAiApi
+        .searchRag({
+          query: trimmed,
+          topK: numericTopK,
+          minScore: numericMinScore,
+          hybrid: true,
+        })
+        .then(toRagReferences)
+        .catch(() => []);
+      const response = await reactAiApi.sendRagChat({
+        chat: {
+          provider: provider || undefined,
+          model: model || undefined,
+          messages: requestMessages,
+          systemPrompt: systemPrompt.trim() || undefined,
+          memory: memoryEnabled ? { enabled: true, conversationId } : undefined,
+        },
+        ragQuery: trimmed,
+        ragTopK: numericTopK,
+        topK: numericTopK,
+        minScore: numericMinScore,
+        debug,
+      });
+      if (activeRequestIdRef.current !== requestId) return;
+
+      const assistant = [...(response.messages ?? [])].reverse().find((item) => item.role === "assistant");
+      const nextConversationId = response.metadata?.conversationId ?? response.conversationId;
+      const ragReferences = await referencesPromise;
+      if (nextConversationId) {
+        setConversationId(nextConversationId);
+      }
+      setMessages([
+        ...nextMessages,
+        {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: assistant?.content ?? "",
+          createdAt: new Date().toISOString(),
+          model: response.metadata?.resolvedModel ?? response.model ?? model,
+          metadata: nextConversationId
+            ? { ...(response.metadata ?? {}), conversationId: nextConversationId, ragReferences }
+            : { ...(response.metadata ?? {}), ragReferences },
+        },
+      ]);
+    } catch (sendError) {
+      if (activeRequestIdRef.current !== requestId) return;
+      const message = resolveAxiosError(sendError);
+      setError(message);
+      setMessages([
+        ...nextMessages,
+        {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: `오류: ${message}`,
+          createdAt: new Date().toISOString(),
+          metadata: { finishReason: "error" },
+        },
+      ]);
+    } finally {
+      if (activeRequestIdRef.current === requestId) {
+        activeRequestIdRef.current = null;
+        setSending(false);
+        setInput("");
+      }
+    }
+  }
+
+  async function handleSend() {
+    const trimmed = input.trim();
+    if (!trimmed || sending || configurationMissing) {
+      return;
+    }
+    setInputHistory((current) => [trimmed, ...current.filter((item) => item !== trimmed)].slice(0, 30));
+    setHistoryIndex(-1);
+    await submitRagQuestion(trimmed, messages, true);
+  }
+
+  function handleNewConversation() {
+    activeRequestIdRef.current = null;
+    setSending(false);
+    setConversationId(crypto.randomUUID());
+    setMessages([]);
+    setInput("");
+    setError(null);
+  }
+
+  async function handleCopyMessage(content: string) {
+    await navigator.clipboard.writeText(content);
+  }
+
+  function handleEditMessage(messageId: string | undefined, content: string) {
+    setInput(content);
+    setMessages((current) => {
+      const index = current.findIndex((message) => message.id === messageId);
+      return index >= 0 ? current.slice(0, index) : current;
+    });
+  }
+
+  function handleRetryLastUserMessage() {
+    const lastUser = [...messages].reverse().find((item) => item.role === "user");
+    if (lastUser?.content) {
+      setInput(lastUser.content);
+    }
+  }
+
+  async function handleRegenerate() {
+    if (sending) return;
+    const lastUserIndex = [...messages].map((message) => message.role).lastIndexOf("user");
+    if (lastUserIndex < 0) return;
+    const baseMessages = messages.slice(0, lastUserIndex + 1);
+    const lastUser = baseMessages[lastUserIndex];
+    await submitRagQuestion(lastUser.content, baseMessages, false);
+  }
+
+  function handleInputHistoryNavigation(direction: "prev" | "next") {
+    if (inputHistory.length === 0) return;
+
+    if (direction === "prev") {
+      const nextIndex = historyIndex + 1 >= inputHistory.length ? inputHistory.length - 1 : historyIndex + 1;
+      setHistoryIndex(nextIndex);
+      setInput(inputHistory[nextIndex] ?? "");
+      return;
+    }
+
+    const nextIndex = historyIndex - 1;
+    if (nextIndex < 0) {
+      setHistoryIndex(-1);
+      setInput("");
+      return;
+    }
+    setHistoryIndex(nextIndex);
+    setInput(inputHistory[nextIndex] ?? "");
+  }
+
+  return (
+    <Stack spacing={1}>
+      <PageToolbar
+        divider={true}
+        breadcrumbs={["서비스 관리", "AI", "RAG Chat"]}
+        label="RAG 검색 문맥을 기반으로 AI 답변을 생성합니다."
+        actions={
+          <>
+            <Tooltip title="새 RAG 대화 시작">
+              <IconButton size="small" aria-label="새 RAG 대화 시작" onClick={handleNewConversation}>
+                <AddCommentOutlined fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="설정">
+              <IconButton size="small" onClick={() => setSettingsOpen(true)}>
+                <SettingsOutlined fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </>
+        }
+      />
+
+      {error ? <Alert severity="error">{error}</Alert> : null}
+      {shouldShowConfigurationWarning ? (
+        <Alert severity="warning">AI RAG Chat을 사용하려면 Provider와 Model 설정이 필요합니다.</Alert>
+      ) : null}
+
+      <Dialog open={settingsOpen} onClose={() => setSettingsOpen(false)} maxWidth="sm" fullWidth slotProps={{ paper: { sx: { borderRadius: 3 } } }}>
+        <DialogTitle>AI RAG Chat 설정</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2}>
+            <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+              <TextField select label="Provider" value={provider} onChange={(event) => handleProviderChange(event.target.value)} fullWidth size="small">
+                {providers.map((item) => (
+                  <MenuItem key={item.name} value={item.name}>
+                    <Stack spacing={0}>
+                      <Typography variant="body2">{item.name}</Typography>
+                      <Typography variant="caption" color="text.secondary">chat: {item.chat.enabled ? item.chat.model : "disabled"}</Typography>
+                    </Stack>
+                  </MenuItem>
+                ))}
+              </TextField>
+              <TextField label="Model" value={model} onChange={(event) => setModel(event.target.value)} fullWidth size="small" />
+            </Stack>
+            {selectedProvider ? (
+              <Typography variant="caption" color="text.secondary">
+                Embedding: {selectedProvider.embedding.enabled ? selectedProvider.embedding.model : "disabled"}
+                {aiInfo?.vector.available ? ` · Vector: ${aiInfo.vector.implementation}` : " · Vector: unavailable"}
+              </Typography>
+            ) : null}
+            <TextField label="System Prompt" value={systemPrompt} onChange={(event) => setSystemPrompt(event.target.value)} multiline minRows={2} size="small" fullWidth />
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+              <TextField
+                label="topK"
+                value={topK}
+                onChange={(event) => setTopK(event.target.value)}
+                size="small"
+                type="number"
+                inputProps={{ min: 1, max: 20 }}
+                helperText="RAG 검색에서 사용할 최대 근거 수"
+                fullWidth
+              />
+              <TextField
+                label="minScore"
+                value={minScore}
+                onChange={(event) => setMinScore(event.target.value)}
+                size="small"
+                type="number"
+                inputProps={{ min: 0, max: 1, step: 0.05 }}
+                helperText="이 값보다 낮은 유사도 결과는 제외"
+                fullWidth
+              />
+            </Stack>
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+              <Stack spacing={0} sx={{ flex: 1 }}>
+                <Typography variant="body2">Debug 응답</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  RAG 검색과 답변 생성의 진단 metadata를 응답에 포함합니다.
+                </Typography>
+              </Stack>
+              <Switch checked={debug} onChange={(event) => setDebug(event.target.checked)} />
+            </Stack>
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+              <Stack spacing={0} sx={{ flex: 1 }}>
+                <Typography variant="body2">대화 기억</Typography>
+                <Typography variant="caption" color="text.secondary">{memoryEnabled ? `사용 중 · ${conversationId}` : "사용하지 않음"}</Typography>
+              </Stack>
+              <Switch checked={memoryEnabled} disabled={!serverMemoryEnabled} onChange={(event) => setMemoryEnabled(event.target.checked)} />
+            </Stack>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" onClick={() => setSettingsOpen(false)}>닫기</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Stack sx={{ height: "calc(100vh - 170px)", minHeight: 0 }}>
+        <Paper elevation={0} sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+          <ChatMessageList
+            messages={messages}
+            sending={sending}
+            onCopy={(content) => void handleCopyMessage(content)}
+            onEditUser={handleEditMessage}
+            onRegenerate={() => void handleRegenerate()}
+            onRetryLastUser={handleRetryLastUserMessage}
+            emptyTitle="내부 자료에 대해 질문해 보세요."
+            emptyDescription="등록된 내부 자료를 바탕으로 답변합니다."
+          />
+          <ChatComposer
+            input={input}
+            sending={sending}
+            configurationMissing={configurationMissing}
+            model={model}
+            provider={provider}
+            conversationId={conversationId}
+            chatModeLabel="RAG 문맥 답변"
+            chatModeDescription="입력한 질문으로 RAG 문맥을 검색하고 그 근거로 답변합니다."
+            latencyMs={lastAssistantMessage?.metadata?.latencyMs}
+            tokenUsage={lastAssistantMessage?.metadata?.tokenUsage}
+            inputHistory={inputHistory}
+            onInputChange={setInput}
+            onSubmit={() => void handleSend()}
+            onKeyDown={(event) => {
+              if (event.nativeEvent.isComposing) {
+                return;
+              }
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                void handleSend();
+                return;
+              }
+              if (event.key === "ArrowUp" && !event.shiftKey && !input.trim()) {
+                event.preventDefault();
+                handleInputHistoryNavigation("prev");
+                return;
+              }
+              if (event.key === "ArrowDown" && !event.shiftKey && historyIndex >= 0) {
+                event.preventDefault();
+                handleInputHistoryNavigation("next");
+              }
+            }}
+            onOpenModelMenu={(event) => setModelAnchorEl(event.currentTarget)}
+            modelMenuOpen={modelMenuOpen}
+            modelAnchorEl={modelAnchorEl}
+            providers={providers}
+            onCloseModelMenu={handleModelMenuClose}
+            onSelectProvider={(nextProvider) => handleModelSelect(nextProvider)}
+            onOpenSettings={() => {
+              handleModelMenuClose();
+              setSettingsOpen(true);
+            }}
+            onSelectHistory={(value) => {
+              setInput(value);
+              setHistoryIndex(-1);
+            }}
+            settingsMenuLabel="AI RAG Chat 설정"
+            settingsMenuDescription="provider, model, RAG 검색 조건을 설정합니다."
+          />
+        </Paper>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/RagChatPage.tsx
+++ b/src/react/pages/ai/RagChatPage.tsx
@@ -21,7 +21,7 @@ import { reactAiApi } from "@/react/pages/ai/api";
 import { ChatComposer } from "@/react/pages/ai/components/ChatComposer";
 import { ChatMessageList } from "@/react/pages/ai/components/ChatMessageList";
 import type { ChatMessage } from "@/react/pages/ai/components/chatTypes";
-import type { AiInfoResponse, ChatMessageDto, ProviderInfo, SearchResultDto } from "@/types/studio/ai";
+import type { AiInfoResponse, ChatMessageDto, ProviderInfo } from "@/types/studio/ai";
 import { resolveAxiosError } from "@/utils/helpers";
 
 const RAG_CHAT_INPUT_HISTORY_KEY = "ai_rag_chat_input_history";
@@ -36,75 +36,6 @@ function toRequestMessage(message: ChatMessage): ChatMessageDto {
 function numberOrUndefined(value: string) {
   const nextValue = Number(value);
   return Number.isFinite(nextValue) ? nextValue : undefined;
-}
-
-function metadataValue(metadata: Record<string, unknown> | undefined, keys: string[]) {
-  if (!metadata) {
-    return undefined;
-  }
-  for (const key of keys) {
-    const value = metadata[key];
-    if (value != null && value !== "") {
-      return value;
-    }
-  }
-  return undefined;
-}
-
-function formatMetadataValue(value: unknown) {
-  if (value == null || value === "") {
-    return "";
-  }
-  return typeof value === "object" ? JSON.stringify(value) : String(value);
-}
-
-function resultSourceName(row: SearchResultDto) {
-  const metadataName = metadataValue(row.metadata, [
-    "sourceName",
-    "fileName",
-    "filename",
-    "originalFilename",
-    "documentName",
-    "title",
-    "name",
-  ]);
-  if (metadataName != null) {
-    return formatMetadataValue(metadataName);
-  }
-
-  const objectType = metadataValue(row.metadata, ["objectType", "object_type"]);
-  const objectId = metadataValue(row.metadata, ["objectId", "object_id"]);
-  if (objectType != null && objectId != null) {
-    return `${formatMetadataValue(objectType)} #${formatMetadataValue(objectId)}`;
-  }
-
-  return row.documentId || "문서";
-}
-
-function resultChunkLabel(row: SearchResultDto) {
-  const page = metadataValue(row.metadata, ["page", "pageNumber", "page_number", "pageNo", "page_no"]);
-  if (page != null) {
-    return `p.${formatMetadataValue(page)}`;
-  }
-  const slide = metadataValue(row.metadata, ["slide", "slideNumber", "slide_number", "slideNo", "slide_no"]);
-  if (slide != null) {
-    return `slide ${formatMetadataValue(slide)}`;
-  }
-  const order = metadataValue(row.metadata, ["chunkOrder", "chunkIndex", "chunk_order", "chunk_index", "order", "index"]);
-  if (order != null) {
-    return `chunk #${formatMetadataValue(order)}`;
-  }
-  return formatMetadataValue(metadataValue(row.metadata, ["chunkId", "chunk_id", "id"]));
-}
-
-function toRagReferences(rows: SearchResultDto[]) {
-  return rows.slice(0, 5).map((row, index) => ({
-    index: index + 1,
-    title: resultSourceName(row),
-    chunk: resultChunkLabel(row),
-    score: row.score,
-    content: row.content,
-  }));
 }
 
 export function RagChatPage() {
@@ -205,15 +136,6 @@ export function RagChatPage() {
     setInput("");
 
     try {
-      const referencesPromise = reactAiApi
-        .searchRag({
-          query: trimmed,
-          topK: numericTopK,
-          minScore: numericMinScore,
-          hybrid: true,
-        })
-        .then(toRagReferences)
-        .catch(() => []);
       const response = await reactAiApi.sendRagChat({
         chat: {
           provider: provider || undefined,
@@ -232,7 +154,6 @@ export function RagChatPage() {
 
       const assistant = [...(response.messages ?? [])].reverse().find((item) => item.role === "assistant");
       const nextConversationId = response.metadata?.conversationId ?? response.conversationId;
-      const ragReferences = await referencesPromise;
       if (nextConversationId) {
         setConversationId(nextConversationId);
       }
@@ -245,8 +166,8 @@ export function RagChatPage() {
           createdAt: new Date().toISOString(),
           model: response.metadata?.resolvedModel ?? response.model ?? model,
           metadata: nextConversationId
-            ? { ...(response.metadata ?? {}), conversationId: nextConversationId, ragReferences }
-            : { ...(response.metadata ?? {}), ragReferences },
+            ? { ...(response.metadata ?? {}), conversationId: nextConversationId }
+            : response.metadata,
         },
       ]);
     } catch (sendError) {

--- a/src/react/pages/ai/RagChunkSimulationDialog.tsx
+++ b/src/react/pages/ai/RagChunkSimulationDialog.tsx
@@ -1,0 +1,321 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import type { ColDef } from "ag-grid-community";
+import { GridContent } from "@/react/components/ag-grid";
+import { reactAiApi } from "@/react/pages/ai/api";
+import type {
+  RagChunkConfigResponseDto,
+  RagChunkPreviewItemDto,
+} from "@/types/studio/ai";
+import { resolveAxiosError } from "@/utils/helpers";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+function chunkStrategyHint(strategy: string) {
+  switch (strategy) {
+    case "fixed-size":
+      return "고정 길이 기준으로 단순하게 나눕니다. 빠르지만 문단 구조를 덜 반영합니다.";
+    case "recursive":
+      return "문단, 문장, 공백 순서로 가능한 자연스럽게 나눕니다. 일반 문서에 적합합니다.";
+    case "structure-based":
+      return "제목, 섹션 같은 문서 구조를 우선 반영해 나눕니다. 구조화 문서에 적합합니다.";
+    default:
+      return "서버가 지원하는 청킹 전략을 선택합니다.";
+  }
+}
+
+function chunkStrategyUsesSizing(strategy: string) {
+  return ["fixed-size", "recursive", "structure-based"].includes(strategy.trim().toLowerCase());
+}
+
+function optionalNumber(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const numberValue = Number(trimmed);
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+}
+
+function ContentPreview({
+  title,
+  content,
+  metadata,
+}: {
+  title: string;
+  content?: string | null;
+  metadata?: Record<string, unknown>;
+}) {
+  return (
+    <Box sx={{ border: 1, borderColor: "divider", borderRadius: 2, p: 1.25 }}>
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">{title}</Typography>
+        <Box
+          component="pre"
+          sx={{
+            m: 0,
+            minHeight: 120,
+            maxHeight: 260,
+            overflow: "auto",
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+            borderRadius: 2,
+            bgcolor: "action.hover",
+            p: 1,
+            fontFamily: (theme) => theme.typography.fontFamily,
+            fontSize: 12,
+            lineHeight: 1.7,
+          }}
+        >
+          {content?.trim() || "Chunk row를 선택하면 전체 내용이 여기에 표시됩니다."}
+        </Box>
+        {metadata ? (
+          <Box
+            component="pre"
+            sx={{
+              m: 0,
+              maxHeight: 160,
+              overflow: "auto",
+              whiteSpace: "pre-wrap",
+              overflowWrap: "anywhere",
+              color: "text.secondary",
+              fontSize: 12,
+            }}
+          >
+            {JSON.stringify(metadata, null, 2)}
+          </Box>
+        ) : null}
+      </Stack>
+    </Box>
+  );
+}
+
+export function RagChunkSimulationDialog({ open, onClose }: Props) {
+  const [config, setConfig] = useState<RagChunkConfigResponseDto | null>(null);
+  const [strategy, setStrategy] = useState("");
+  const [maxSize, setMaxSize] = useState("");
+  const [overlap, setOverlap] = useState("");
+  const [text, setText] = useState("");
+  const [rows, setRows] = useState<RagChunkPreviewItemDto[]>([]);
+  const [selectedRow, setSelectedRow] = useState<RagChunkPreviewItemDto | null>(null);
+  const [summary, setSummary] = useState<{
+    totalChunks: number;
+    totalChars: number;
+    strategy: string;
+    maxSize: number;
+    overlap: number;
+    unit: string;
+    warnings: string[];
+  } | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const usesSizing = chunkStrategyUsesSizing(strategy);
+  const textLength = text.trim().length;
+  const effectiveMaxSize = (usesSizing ? optionalNumber(maxSize) : undefined) ?? config?.chunking.maxSize ?? 0;
+  const singleChunkLikely =
+    usesSizing && textLength > 0 && effectiveMaxSize > 0 && textLength <= effectiveMaxSize;
+
+  const loadConfig = useCallback(async () => {
+    setError(null);
+    try {
+      const response = await reactAiApi.getRagChunkConfig();
+      setConfig(response);
+      const defaultStrategy = response.chunking.previewStrategy || response.chunking.strategy || "";
+      setStrategy((current) => current || defaultStrategy);
+      setMaxSize((current) => current || String(response.chunking.maxSize));
+      setOverlap((current) => current || String(response.chunking.overlap));
+    } catch (loadError) {
+      setError(resolveAxiosError(loadError));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open || config) {
+      return;
+    }
+    void loadConfig();
+  }, [config, loadConfig, open]);
+
+  async function handlePreview() {
+    const previewText = text.trim();
+    if (!previewText) {
+      setError("시뮬레이션할 텍스트를 입력하세요.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await reactAiApi.previewRagChunks({
+        text: previewText,
+        strategy: strategy || undefined,
+        maxSize: usesSizing ? optionalNumber(maxSize) : undefined,
+        overlap: usesSizing ? optionalNumber(overlap) : undefined,
+      });
+      setRows(response.chunks ?? []);
+      setSelectedRow(null);
+      setSummary({
+        totalChunks: response.totalChunks,
+        totalChars: response.totalChars,
+        strategy: response.strategy,
+        maxSize: response.maxSize,
+        overlap: response.overlap,
+        unit: response.unit,
+        warnings: response.warnings ?? [],
+      });
+    } catch (previewError) {
+      setError(resolveAxiosError(previewError));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const columns = useMemo<ColDef<RagChunkPreviewItemDto>[]>(
+    () => [
+      { field: "chunkOrder", headerName: "순서", width: 80, filter: false },
+      { field: "contentLength", headerName: "길이", width: 90, filter: false },
+      { field: "chunkType", headerName: "유형", width: 120, filter: false },
+      { field: "headingPath", headerName: "위치", width: 180, filter: false },
+      { field: "content", headerName: "콘텐츠", flex: 1, minWidth: 420, filter: false },
+    ],
+    []
+  );
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>청킹 시뮬레이션</DialogTitle>
+      <DialogContent>
+        <Stack spacing={1.5} sx={{ pt: 0.5 }}>
+          <Alert severity="info">
+            입력 텍스트를 현재 서버 청킹 설정으로 나누어 봅니다. 이 작업은 embedding, vector 저장, 색인 job 생성을 수행하지 않습니다.
+          </Alert>
+          {error ? <Alert severity="error">{error}</Alert> : null}
+          <Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+            <TextField
+              select
+              label="청킹 전략"
+              value={strategy}
+              onChange={(event) => setStrategy(event.target.value)}
+              size="small"
+              fullWidth
+              helperText={chunkStrategyHint(strategy)}
+            >
+              {(config?.chunking.availableStrategies ?? ["fixed-size", "recursive", "structure-based"]).map((item) => (
+                <MenuItem key={item} value={item}>
+                  {item}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              label="Chunk 크기"
+              value={maxSize}
+              onChange={(event) => setMaxSize(event.target.value)}
+              size="small"
+              fullWidth
+              disabled={!usesSizing}
+              helperText={usesSizing ? "Chunk 하나의 최대 길이입니다." : "선택한 전략에는 적용되지 않습니다."}
+            />
+            <TextField
+              label="겹침"
+              value={overlap}
+              onChange={(event) => setOverlap(event.target.value)}
+              size="small"
+              fullWidth
+              disabled={!usesSizing}
+              helperText={usesSizing ? "앞뒤 Chunk 사이에 다시 포함할 중복 길이입니다." : "선택한 전략에는 적용되지 않습니다."}
+            />
+          </Stack>
+          <Typography variant="caption" color="text.secondary">
+            제한:{" "}
+            {config
+              ? `${config.limits.maxInputChars.toLocaleString()}자 / ${config.limits.maxPreviewChunks}개`
+              : "-"}
+          </Typography>
+          <TextField
+            label="텍스트"
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+            placeholder="청킹 결과를 확인할 텍스트를 입력하세요."
+            multiline
+            minRows={8}
+            maxRows={8}
+            size="small"
+            fullWidth
+            slotProps={{
+              input: {
+                sx: {
+                  alignItems: "flex-start",
+                  "& textarea": {
+                    overflow: "auto !important",
+                  },
+                },
+              },
+            }}
+          />
+          <Typography variant="caption" color="text.secondary">
+            입력 길이: {textLength.toLocaleString()}자 · 현재 Chunk 크기 기준:{" "}
+            {effectiveMaxSize ? `${effectiveMaxSize.toLocaleString()}자` : "-"}
+          </Typography>
+          {singleChunkLikely ? (
+            <Alert severity="info">
+              현재 입력 길이가 Chunk 크기보다 작습니다. recursive 전략도 기준 크기를 넘지 않으면 단일 Chunk로 생성될 수 있습니다.
+            </Alert>
+          ) : null}
+          {summary ? (
+            <Stack direction="row" spacing={0.75} flexWrap="wrap">
+              <Chip size="small" label={`총 ${summary.totalChunks} chunks`} />
+              <Chip size="small" label={`${summary.totalChars.toLocaleString()} chars`} />
+              <Chip size="small" label={summary.strategy} />
+              <Chip size="small" label={`size ${summary.maxSize}`} />
+              <Chip size="small" label={`overlap ${summary.overlap}`} />
+              <Chip size="small" label={summary.unit} />
+            </Stack>
+          ) : null}
+          {summary?.warnings?.length ? <Alert severity="warning">{summary.warnings.join(" ")}</Alert> : null}
+          <GridContent<RagChunkPreviewItemDto>
+            columns={columns}
+            rowData={rows}
+            loading={loading}
+            height={260}
+            events={[
+              {
+                type: "rowClicked",
+                listener: (event) => {
+                  setSelectedRow((event as { data?: RagChunkPreviewItemDto }).data ?? null);
+                },
+              },
+            ]}
+          />
+          <ContentPreview
+            title={selectedRow ? `선택한 Chunk 전체 내용 · #${selectedRow.chunkOrder ?? "-"}` : "선택한 Chunk 전체 내용"}
+            content={selectedRow?.content}
+            metadata={selectedRow?.metadata}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+        <Button variant="contained" disabled={loading || !text.trim()} onClick={() => void handlePreview()}>
+          {loading ? "실행 중" : "시뮬레이션 실행"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/react/pages/ai/RagJobDetailPage.tsx
+++ b/src/react/pages/ai/RagJobDetailPage.tsx
@@ -1,0 +1,1301 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  alpha,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  Divider,
+  Drawer,
+  IconButton,
+  Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  AccountTreeOutlined,
+  CloseOutlined,
+  ContentCopyOutlined,
+  DataObjectOutlined,
+  ExpandMoreOutlined,
+  ImageOutlined,
+  KeyboardArrowLeftOutlined,
+  KeyboardArrowRightOutlined,
+  RefreshOutlined,
+  ReplayOutlined,
+  SearchOutlined,
+  WarningAmberOutlined,
+} from "@mui/icons-material";
+import type { ColDef, GridOptions } from "ag-grid-community";
+import { GridContent } from "@/react/components/ag-grid";
+import { PageToolbar } from "@/react/components/page/PageToolbar";
+import { reactAiApi } from "@/react/pages/ai/api";
+import type {
+  RagIndexChunkDto,
+  RagIndexJobDto,
+  RagIndexJobLogDto,
+  RagIndexJobStatus,
+  VectorSearchResultDto,
+} from "@/types/studio/ai";
+import { resolveAxiosError } from "@/utils/helpers";
+
+function statusColor(status?: RagIndexJobStatus) {
+  if (status === "SUCCEEDED") return "success";
+  if (status === "WARNING") return "warning";
+  if (status === "FAILED" || status === "CANCELLED") return "error";
+  if (status === "RUNNING" || status === "PENDING") return "info";
+  return "default";
+}
+
+function LogLevelCell(params: { value?: string | null }) {
+  const level = String(params.value ?? "-").toUpperCase();
+  const isError = ["ERROR", "FAILED", "FAIL"].includes(level);
+  const isWarning = ["WARN", "WARNING"].includes(level);
+  const color = isError ? "error.main" : isWarning ? "warning.main" : "text.secondary";
+
+  return (
+    <Stack direction="row" spacing={0.5} alignItems="center" sx={{ height: "100%", color }}>
+      {isError || isWarning ? <WarningAmberOutlined sx={{ fontSize: 16 }} /> : null}
+      <Typography variant="body2" fontWeight={700} color="inherit" noWrap>
+        {level}
+      </Typography>
+    </Stack>
+  );
+}
+
+function formatDateTime(value?: string) {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function formatValue(value: unknown) {
+  if (value == null || value === "") {
+    return "-";
+  }
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function sourceDisplayName(job?: RagIndexJobDto | null) {
+  if (!job) {
+    return "-";
+  }
+  return job.sourceName || job.documentId || `${job.objectType} #${job.objectId}` || job.jobId;
+}
+
+function metadataValue(metadata: Record<string, unknown> | undefined, keys: string[]) {
+  if (!metadata) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = metadata[key];
+    if (value != null && value !== "") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function chunkingDisplay(job: RagIndexJobDto, chunks: RagIndexChunkDto[]) {
+  const chunkMetadata = chunks.find((chunk) => chunk.metadata)?.metadata;
+  const strategy =
+    job.chunkingStrategy ??
+    metadataValue(chunkMetadata, ["strategy", "chunkingStrategy", "chunking_strategy"]);
+  const maxSize =
+    job.chunkMaxSize ??
+    metadataValue(chunkMetadata, ["maxSize", "chunkMaxSize", "max_size"]);
+  const overlap =
+    job.chunkOverlap ??
+    metadataValue(chunkMetadata, ["overlap", "chunkOverlap", "chunk_overlap"]);
+  const unit = job.chunkUnit ?? metadataValue(chunkMetadata, ["chunkUnit", "chunk_unit", "unit"]);
+
+  if (strategy == null || strategy === "") {
+    return "-";
+  }
+
+  const options = [
+    maxSize != null && maxSize !== "" ? `크기 ${formatValue(maxSize)}` : null,
+    overlap != null && overlap !== "" ? `겹침 ${formatValue(overlap)}` : null,
+    unit != null && unit !== "" ? formatValue(unit) : null,
+  ].filter(Boolean);
+
+  return options.length > 0 ? `${formatValue(strategy)} (${options.join(" / ")})` : formatValue(strategy);
+}
+
+const INDEX_STEPS = [
+  { key: "PENDING", label: "대기" },
+  { key: "EXTRACTING", label: "추출" },
+  { key: "CHUNKING", label: "청킹" },
+  { key: "EMBEDDING", label: "임베딩" },
+  { key: "INDEXING", label: "색인" },
+  { key: "COMPLETED", label: "완료" },
+] as const;
+
+function activeStepIndex(job: RagIndexJobDto) {
+  if (job.status === "SUCCEEDED" || job.status === "WARNING") {
+    return INDEX_STEPS.length - 1;
+  }
+  if (job.status === "PENDING") {
+    return 0;
+  }
+  const current = job.currentStep ?? "PENDING";
+  return Math.max(
+    0,
+    INDEX_STEPS.findIndex((step) => step.key === current)
+  );
+}
+
+function isTerminalSuccess(status: RagIndexJobStatus) {
+  return status === "SUCCEEDED" || status === "WARNING";
+}
+
+function isTerminalFailure(status: RagIndexJobStatus) {
+  return status === "FAILED" || status === "CANCELLED";
+}
+
+function describeChunk(chunk?: RagIndexChunkDto) {
+  if (!chunk) return "";
+
+  return [
+    `Chunk: ${chunk.chunkOrder != null ? `#${chunk.chunkOrder}` : chunk.chunkId}`,
+    chunk.headingPath ? `위치: ${chunk.headingPath}` : null,
+    chunk.score != null ? `점수: ${chunk.score}` : null,
+    chunk.page != null ? `페이지: ${chunk.page}` : null,
+    chunk.sourceRef ? `출처: ${chunk.sourceRef}` : null,
+    chunk.content ? `내용: ${chunk.content.slice(0, 500)}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function metadataText(chunk: RagIndexChunkDto | null | undefined, keys: string[]) {
+  return formatValue(metadataValue(chunk?.metadata, keys));
+}
+
+function chunkLength(chunk?: RagIndexChunkDto | null) {
+  const metadataLength = metadataValue(chunk?.metadata, ["chunkLength", "contentLength", "length"]);
+  if (typeof metadataLength === "number") {
+    return metadataLength;
+  }
+  if (typeof metadataLength === "string" && metadataLength.trim()) {
+    const parsed = Number(metadataLength);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return chunk?.content?.length ?? 0;
+}
+
+function chunkLengthRatio(chunk: RagIndexChunkDto | null | undefined, maxSize: number) {
+  const length = chunkLength(chunk);
+  return maxSize > 0 ? length / maxSize : 0;
+}
+
+function isShortChunk(chunk: RagIndexChunkDto | null | undefined, maxSize: number) {
+  const length = chunkLength(chunk);
+  if (length <= 0) {
+    return false;
+  }
+  return length < 40 || chunkLengthRatio(chunk, maxSize) < 0.15;
+}
+
+function chunkRowId(chunk?: RagIndexChunkDto | null) {
+  if (!chunk) {
+    return "";
+  }
+  return chunk.chunkId || `${chunk.documentId}:${chunk.chunkOrder ?? ""}:${chunk.sourceRef ?? ""}`;
+}
+
+function metadataNumber(chunk: RagIndexChunkDto | null | undefined, keys: string[]) {
+  return numberValue(metadataValue(chunk?.metadata, keys));
+}
+
+function compactText(value: unknown, maxLength = 72) {
+  const text = formatValue(value).replace(/\s+/g, " ").trim();
+  if (!text || text === "-") {
+    return "-";
+  }
+  return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+}
+
+function chunkPosition(chunk?: RagIndexChunkDto | null) {
+  const slideNumber = chunkSlideNumber(chunk);
+  const pageNumber = chunkPageNumber(chunk);
+  const slide = slideNumber != null ? `Slide ${slideNumber}` : null;
+  const page = pageNumber != null ? `Page ${pageNumber}` : null;
+  const sourceRef = metadataValue(chunk?.metadata, ["sourceRef", "sourceRefs"]);
+  const heading = chunk?.headingPath ?? metadataValue(chunk?.metadata, ["section"]);
+  return [slide, page, compactText(sourceRef ?? chunk?.sourceRef ?? heading, 64)]
+    .filter((value) => value && value !== "-")
+    .join(" · ") || "-";
+}
+
+function isPresentationChunk(chunk?: RagIndexChunkDto | null) {
+  const values = [
+    metadataValue(chunk?.metadata, ["sourceFormat", "format", "fileType", "contentType"]),
+    metadataValue(chunk?.metadata, ["filename", "fileName", "sourceName"]),
+    chunk?.sourceRef,
+  ];
+  return values.some((value) => typeof value === "string" && /\.(pptx?|odp)$/i.test(value))
+    || values.some((value) => typeof value === "string" && /powerpoint|presentation|pptx?|odp/i.test(value));
+}
+
+function chunkSlideNumber(chunk?: RagIndexChunkDto | null) {
+  return (
+    numberValue(chunk?.slide) ??
+    metadataNumber(chunk, ["slide", "slideNumber", "slide_number", "slideNo", "slide_no"])
+  );
+}
+
+function chunkPageNumber(chunk?: RagIndexChunkDto | null) {
+  return (
+    numberValue(chunk?.page) ??
+    metadataNumber(chunk, ["page", "pageNumber", "page_number", "pageNo", "page_no"])
+  );
+}
+
+function chunkPageDisplay(chunk?: RagIndexChunkDto | null) {
+  const slide = chunkSlideNumber(chunk);
+  if (slide != null && isPresentationChunk(chunk)) {
+    return `Slide ${slide}`;
+  }
+  const page = chunkPageNumber(chunk);
+  if (page != null) {
+    return page;
+  }
+  if (slide != null) {
+    return `Slide ${slide}`;
+  }
+  return "-";
+}
+
+function findChunkById(chunks: RagIndexChunkDto[], chunkId: unknown) {
+  if (typeof chunkId !== "string" || !chunkId) {
+    return null;
+  }
+  return chunks.find((chunk) => chunk.chunkId === chunkId) ?? null;
+}
+
+function numberValue(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function chunkSizeLimit(job: RagIndexJobDto | null, chunks: RagIndexChunkDto[]) {
+  const metadata = chunks.find((chunk) => chunk.metadata)?.metadata;
+  return (
+    numberValue(job?.chunkMaxSize) ??
+    numberValue(metadataValue(metadata, ["maxSize", "chunkMaxSize", "max_size"])) ??
+    800
+  );
+}
+
+function chunkImageUrl(chunk?: RagIndexChunkDto | null) {
+  const value = metadataValue(chunk?.metadata, [
+    "thumbnailUrl",
+    "thumbnail_url",
+    "imageUrl",
+    "image_url",
+    "previewUrl",
+    "preview_url",
+    "sourceImageUrl",
+    "source_image_url",
+  ]);
+  return typeof value === "string" && /^https?:\/\//i.test(value) ? value : undefined;
+}
+
+function chunkSearchQuery(chunk: RagIndexChunkDto) {
+  return chunk.content.replace(/\s+/g, " ").trim().slice(0, 500);
+}
+
+function StatItem({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <Box sx={{ minWidth: 0 }}>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Box
+        sx={{
+          minHeight: 24,
+          display: "flex",
+          alignItems: "center",
+          overflow: "hidden",
+          typography: "body2",
+          fontWeight: 700,
+          whiteSpace: "nowrap",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {value}
+      </Box>
+    </Box>
+  );
+}
+
+function StatusChip({ status }: { status: RagIndexJobStatus }) {
+  return (
+    <Chip
+      size="small"
+      color={statusColor(status)}
+      label={status}
+      sx={{
+        height: 20,
+        borderRadius: 1,
+        "& .MuiChip-label": {
+          px: 0.75,
+          fontSize: 11,
+          fontWeight: 700,
+          lineHeight: "20px",
+        },
+      }}
+    />
+  );
+}
+
+function ChunkLengthCell({ chunk, maxSize }: { chunk?: RagIndexChunkDto; maxSize: number }) {
+  const value = chunkLength(chunk);
+  const rawRatio = maxSize > 0 ? Math.round((value / maxSize) * 100) : 0;
+  const ratio = Math.min(100, rawRatio);
+  const short = isShortChunk(chunk, maxSize);
+  const color = short ? "warning.main" : rawRatio > 100 ? "error.main" : "primary.main";
+
+  return (
+    <Stack spacing={0} justifyContent="center" sx={{ height: "100%" }}>
+      <Stack direction="row" spacing={0} alignItems="center">
+        <Typography variant="caption" sx={{ lineHeight: 1 }}>
+          {value.toLocaleString()}
+        </Typography>
+        {short ? (
+          <Tooltip title="청크 길이가 너무 짧습니다. 검색 품질 확인이 필요합니다.">
+            <WarningAmberOutlined color="warning" sx={{ fontSize: 15 }} />
+          </Tooltip>
+        ) : null}
+      </Stack>
+      <Box
+        sx={{
+          width: "100%",
+          height: 4,
+          bgcolor: "action.hover",
+          borderRadius: 1,
+          overflow: "hidden",
+        }}
+      >
+        <Box
+          sx={{
+            width: `${Math.max(3, ratio)}%`,
+            height: "100%",
+            bgcolor: color,
+          }}
+        />
+      </Box>
+    </Stack>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <Box sx={{ display: "grid", gridTemplateColumns: "96px minmax(0, 1fr)", gap: 1, alignItems: "start" }}>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ minWidth: 0, overflowWrap: "anywhere" }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+function LinkButton({
+  label,
+  value,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  value: unknown;
+  disabled?: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <DetailRow
+      label={label}
+      value={
+        <Button
+          size="small"
+          variant="text"
+          disabled={disabled || value == null || value === ""}
+          onClick={onClick}
+          sx={{ minWidth: 0, justifyContent: "flex-start", p: 0, textTransform: "none" }}
+        >
+          {formatValue(value)}
+        </Button>
+      }
+    />
+  );
+}
+
+function ChunkInspector({
+  job,
+  chunk,
+  chunks,
+  onSelectChunk,
+  onClose,
+}: {
+  job: RagIndexJobDto;
+  chunk: RagIndexChunkDto | null;
+  chunks: RagIndexChunkDto[];
+  onSelectChunk: (chunk: RagIndexChunkDto) => void;
+  onClose?: () => void;
+}) {
+  const [searchingSimilar, setSearchingSimilar] = useState(false);
+  const [similarResults, setSimilarResults] = useState<VectorSearchResultDto[]>([]);
+  const [similarError, setSimilarError] = useState<string | null>(null);
+  const inspectorRef = useRef<HTMLDivElement | null>(null);
+  const similarResultsRef = useRef<HTMLDivElement | null>(null);
+  const currentIndex = chunks.findIndex((item) => chunkRowId(item) === chunkRowId(chunk));
+  const previousChunk =
+    findChunkById(chunks, metadataValue(chunk?.metadata, ["previousChunkId", "previous_chunk_id"])) ??
+    (currentIndex > 0 ? chunks[currentIndex - 1] : null);
+  const nextChunk =
+    findChunkById(chunks, metadataValue(chunk?.metadata, ["nextChunkId", "next_chunk_id"])) ??
+    (currentIndex >= 0 && currentIndex < chunks.length - 1 ? chunks[currentIndex + 1] : null);
+  const parentChunk = findChunkById(chunks, chunk?.parentChunkId ?? metadataValue(chunk?.metadata, ["parentChunkId"]));
+  const chunkTitle = chunk
+    ? `#${chunk.chunkOrder ?? "-"} ${chunk.chunkType ?? "chunk"}`
+    : "청킹 조각을 선택하세요";
+  const thumbnailUrl = chunkImageUrl(chunk);
+  const imageCaption = chunk?.chunkType === "image-caption";
+
+  useEffect(() => {
+    setSimilarResults([]);
+    setSimilarError(null);
+  }, [chunk?.chunkId]);
+
+  async function handleSimilarSearch() {
+    if (!chunk) {
+      return;
+    }
+    setSearchingSimilar(true);
+    setSimilarError(null);
+    try {
+      const results = await reactAiApi.searchVector({
+        query: chunkSearchQuery(chunk),
+        topK: 5,
+        hybrid: true,
+        objectType: job.objectType,
+        objectId: job.objectId,
+      });
+      setSimilarResults(results);
+      requestAnimationFrame(() => {
+        similarResultsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    } catch (searchError) {
+      setSimilarError(resolveAxiosError(searchError));
+      requestAnimationFrame(() => {
+        similarResultsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    } finally {
+      setSearchingSimilar(false);
+    }
+  }
+
+  const drawerLayout = Boolean(onClose);
+
+  useEffect(() => {
+    if (drawerLayout) {
+      requestAnimationFrame(() => {
+        inspectorRef.current?.scrollTo({ top: 0 });
+      });
+    }
+  }, [chunk?.chunkId, drawerLayout]);
+
+  return (
+    <Box
+      sx={{
+        border: drawerLayout ? 0 : "1px solid",
+        borderColor: "divider",
+        borderRadius: drawerLayout ? 0 : 1,
+        p: drawerLayout ? 0 : 1.5,
+        minHeight: drawerLayout ? 0 : 500,
+        height: drawerLayout ? "100%" : "auto",
+        overflow: drawerLayout ? "hidden" : "visible",
+        bgcolor: "background.paper",
+        boxSizing: "border-box",
+        display: drawerLayout ? "flex" : "block",
+        flexDirection: "column",
+      }}
+    >
+      <Stack spacing={drawerLayout ? 0 : 1.5} sx={{ height: drawerLayout ? "100%" : "auto" }}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          spacing={1}
+          sx={{
+            minHeight: drawerLayout ? 56 : "auto",
+            flexShrink: 0,
+            bgcolor: "background.paper",
+            px: drawerLayout ? 2 : 0,
+          }}
+        >
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="subtitle1" fontWeight={700} noWrap>
+              선택한 청킹 조각
+            </Typography>
+            <Typography variant="caption" color="text.secondary" noWrap>
+              {chunkTitle}
+            </Typography>
+          </Box>
+          <Stack direction="row" spacing={0.5}>
+            <Tooltip title="유사 청크 검색 테스트">
+              <span>
+                <IconButton size="small" disabled={!chunk?.content || searchingSimilar} onClick={() => void handleSimilarSearch()}>
+                  {searchingSimilar ? <CircularProgress size={16} /> : <SearchOutlined fontSize="small" />}
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="본문 복사">
+              <span>
+                <IconButton
+                  size="small"
+                  disabled={!chunk?.content}
+                  onClick={() => {
+                    if (chunk?.content) {
+                      void navigator.clipboard.writeText(chunk.content);
+                    }
+                  }}
+                >
+                  <ContentCopyOutlined fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            {onClose ? (
+              <Tooltip title="닫기">
+                <IconButton size="small" onClick={onClose}>
+                  <CloseOutlined fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            ) : null}
+          </Stack>
+        </Stack>
+        {drawerLayout ? <Divider /> : null}
+
+        {chunk ? (
+          <Box
+            ref={inspectorRef}
+            sx={{
+              p: drawerLayout ? 2 : 0,
+              flex: drawerLayout ? 1 : "initial",
+              overflow: drawerLayout ? "auto" : "visible",
+              minHeight: 0,
+            }}
+          >
+            <Stack spacing={drawerLayout ? 2 : 1.5}>
+            <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+              <Chip size="small" label={`#${chunk.chunkOrder ?? "-"}`} />
+              <Chip size="small" label={chunk.chunkType ?? "chunk"} />
+              <Chip size="small" label={`${chunkLength(chunk).toLocaleString()}자`} />
+              {chunk.page != null ? <Chip size="small" label={`page ${chunk.page}`} /> : null}
+              {chunk.slide != null ? <Chip size="small" label={`slide ${chunk.slide}`} /> : null}
+            </Stack>
+
+            <Stack direction="row" spacing={0.5}>
+              <Tooltip title="이전 Chunk로 이동">
+                <span>
+                  <IconButton size="small" disabled={!previousChunk} onClick={() => previousChunk && onSelectChunk(previousChunk)}>
+                    <KeyboardArrowLeftOutlined fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Tooltip title="Parent Chunk로 이동">
+                <span>
+                  <IconButton size="small" disabled={!parentChunk} onClick={() => parentChunk && onSelectChunk(parentChunk)}>
+                    <AccountTreeOutlined fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Tooltip title="다음 Chunk로 이동">
+                <span>
+                  <IconButton size="small" disabled={!nextChunk} onClick={() => nextChunk && onSelectChunk(nextChunk)}>
+                    <KeyboardArrowRightOutlined fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Stack>
+
+            <Divider />
+
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "1fr", xl: "minmax(0, 1.2fr) minmax(220px, 0.8fr)" },
+                gap: 1.5,
+              }}
+            >
+              <Stack spacing={0.75}>
+                <Typography variant="subtitle2">본문</Typography>
+                {imageCaption ? (
+                  thumbnailUrl ? (
+                    <Box
+                      component="img"
+                      src={thumbnailUrl}
+                      alt="청킹 이미지 썸네일"
+                      sx={{
+                        width: "100%",
+                        maxHeight: 160,
+                        objectFit: "cover",
+                        borderRadius: 1,
+                        border: "1px solid",
+                        borderColor: "divider",
+                      }}
+                    />
+                  ) : (
+                    <Stack
+                      direction="row"
+                      spacing={1}
+                      alignItems="center"
+                      sx={{ p: 1, borderRadius: 1, bgcolor: "action.hover", color: "text.secondary" }}
+                    >
+                      <ImageOutlined fontSize="small" />
+                      <Typography variant="caption">image-caption Chunk입니다. 응답 metadata에 thumbnail URL은 없습니다.</Typography>
+                    </Stack>
+                  )
+                ) : null}
+                <Box
+                  component="pre"
+                  sx={{
+                    m: 0,
+                    p: 1,
+                    minHeight: 220,
+                    maxHeight: 420,
+                    overflow: "auto",
+                    whiteSpace: "pre-wrap",
+                    overflowWrap: "anywhere",
+                    bgcolor: "action.hover",
+                    borderRadius: 1,
+                    fontFamily: (theme) => theme.typography.fontFamily,
+                    fontSize: 12,
+                    lineHeight: 1.7,
+                  }}
+                >
+                  {chunk.content?.trim() || "본문이 없습니다."}
+                </Box>
+              </Stack>
+
+              <Stack spacing={1.25}>
+                <Stack spacing={0.75}>
+                  <Typography variant="subtitle2">출처</Typography>
+                  <DetailRow label="위치" value={chunkPosition(chunk)} />
+                  <DetailRow label="headingPath" value={compactText(chunk.headingPath, 90)} />
+                  <DetailRow label="sourceRef" value={compactText(chunk.sourceRef, 90)} />
+                  <DetailRow label="page" value={formatValue(chunk.page)} />
+                  <DetailRow label="slide" value={formatValue(chunk.slide)} />
+                  <DetailRow label="sourceFormat" value={metadataText(chunk, ["sourceFormat"])} />
+                  <DetailRow label="blockIds" value={metadataText(chunk, ["blockIds"])} />
+                </Stack>
+
+                <Stack spacing={0.75}>
+                  <Typography variant="subtitle2">연결</Typography>
+                  <LinkButton
+                    label="parent"
+                    value={chunk.parentChunkId ?? metadataValue(chunk.metadata, ["parentChunkId"])}
+                    disabled={!parentChunk}
+                    onClick={() => parentChunk && onSelectChunk(parentChunk)}
+                  />
+                  <LinkButton
+                    label="previous"
+                    value={metadataValue(chunk.metadata, ["previousChunkId", "previous_chunk_id"])}
+                    disabled={!previousChunk}
+                    onClick={() => previousChunk && onSelectChunk(previousChunk)}
+                  />
+                  <LinkButton
+                    label="next"
+                    value={metadataValue(chunk.metadata, ["nextChunkId", "next_chunk_id"])}
+                    disabled={!nextChunk}
+                    onClick={() => nextChunk && onSelectChunk(nextChunk)}
+                  />
+                </Stack>
+
+                <Stack spacing={0.75}>
+                  <Typography variant="subtitle2">임베딩</Typography>
+                  <DetailRow label="provider" value={metadataText(chunk, ["embeddingProvider"])} />
+                  <DetailRow label="profile" value={metadataText(chunk, ["embeddingProfileId"])} />
+                  <DetailRow label="model" value={metadataText(chunk, ["embeddingModel"])} />
+                  <DetailRow label="dimension" value={metadataText(chunk, ["embeddingDimension"])} />
+                  <DetailRow label="indexedAt" value={formatDateTime(chunk.indexedAt ?? (metadataValue(chunk.metadata, ["indexedAt"]) as string | undefined))} />
+                </Stack>
+              </Stack>
+            </Box>
+
+            <Box ref={similarResultsRef} sx={{ scrollMarginTop: 16 }}>
+              {similarError ? <Alert severity="error">{similarError}</Alert> : null}
+            </Box>
+            {similarResults.length > 0 ? (
+              <Box sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1, p: 1 }}>
+                <Stack spacing={0.75}>
+                  <Typography variant="subtitle2">유사 검색 테스트 결과</Typography>
+                  {similarResults.slice(0, 5).map((result, index) => (
+                    <Stack
+                      key={`${result.id}-${index}`}
+                      direction="row"
+                      spacing={1}
+                      alignItems="center"
+                      sx={{ minWidth: 0 }}
+                    >
+                      <Chip size="small" variant="outlined" label={`${index + 1}`} />
+                      <Typography variant="caption" color="text.secondary" sx={{ width: 64 }}>
+                        {typeof result.score === "number" ? result.score.toFixed(4) : "-"}
+                      </Typography>
+                      <Typography variant="caption" noWrap sx={{ minWidth: 0 }}>
+                        {compactText(result.content, 120)}
+                      </Typography>
+                    </Stack>
+                  ))}
+                </Stack>
+              </Box>
+            ) : null}
+
+            <Accordion variant="outlined" disableGutters sx={{ "&:before": { display: "none" } }}>
+              <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <DataObjectOutlined fontSize="small" color="action" />
+                  <Typography variant="body2" fontWeight={700}>
+                    Raw Metadata
+                  </Typography>
+                </Stack>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Box
+                  component="pre"
+                  sx={{
+                    m: 0,
+                    maxHeight: 180,
+                    overflow: "auto",
+                    whiteSpace: "pre-wrap",
+                    overflowWrap: "anywhere",
+                    color: "text.secondary",
+                    fontSize: 12,
+                  }}
+                >
+                  {chunk.metadata ? JSON.stringify(chunk.metadata, null, 2) : "metadata가 없습니다."}
+                </Box>
+              </AccordionDetails>
+            </Accordion>
+            </Stack>
+          </Box>
+        ) : (
+          <Box
+            ref={inspectorRef}
+            sx={{
+              minHeight: 320,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "text.secondary",
+              textAlign: "center",
+              bgcolor: "action.hover",
+              borderRadius: 1,
+              px: 2,
+              flex: drawerLayout ? 1 : "initial",
+              overflow: drawerLayout ? "auto" : "visible",
+            }}
+          >
+            <Typography variant="body2">
+              색인 결과 row를 선택하면 본문, 출처, 연결 관계, 임베딩 정보를 확인할 수 있습니다.
+            </Typography>
+          </Box>
+        )}
+      </Stack>
+    </Box>
+  );
+}
+
+export function RagJobDetailPage() {
+  const { jobId = "" } = useParams();
+  const navigate = useNavigate();
+  const summaryRef = useRef<HTMLDivElement | null>(null);
+  const chunksRef = useRef<HTMLDivElement | null>(null);
+  const logsRef = useRef<HTMLDivElement | null>(null);
+  const [job, setJob] = useState<RagIndexJobDto | null>(null);
+  const [logs, setLogs] = useState<RagIndexJobLogDto[]>([]);
+  const [chunks, setChunks] = useState<RagIndexChunkDto[]>([]);
+  const [selectedChunk, setSelectedChunk] = useState<RagIndexChunkDto | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [mutating, setMutating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const selectedChunkIndex = useMemo(
+    () => chunks.findIndex((chunk) => chunkRowId(chunk) === chunkRowId(selectedChunk)),
+    [chunks, selectedChunk]
+  );
+
+  const selectChunkByOffset = useCallback(
+    (offset: number) => {
+      if (chunks.length === 0 || selectedChunkIndex < 0) {
+        return;
+      }
+      const nextIndex = Math.min(chunks.length - 1, Math.max(0, selectedChunkIndex + offset));
+      const nextChunk = chunks[nextIndex];
+      if (nextChunk && nextIndex !== selectedChunkIndex) {
+        setSelectedChunk(nextChunk);
+      }
+    },
+    [chunks, selectedChunkIndex]
+  );
+
+  useEffect(() => {
+    if (!selectedChunk) {
+      return undefined;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      const target = event.target as HTMLElement | null;
+      const tagName = target?.tagName?.toLowerCase();
+      if (tagName === "input" || tagName === "textarea" || target?.isContentEditable) {
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        selectChunkByOffset(-1);
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        selectChunkByOffset(1);
+      }
+      if (event.key === "Escape") {
+        setSelectedChunk(null);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectChunkByOffset, selectedChunk]);
+
+  function scrollToSection(section: "summary" | "chunks" | "logs") {
+    const refs = {
+      summary: summaryRef,
+      chunks: chunksRef,
+      logs: logsRef,
+    };
+
+    window.setTimeout(() => {
+      refs[section].current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 0);
+  }
+
+  const loadDetail = useCallback(async () => {
+    if (!jobId) {
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const jobResponse = await reactAiApi.getRagJob(jobId);
+      setJob(jobResponse);
+
+      const [logsResult, chunksResult] = await Promise.allSettled([
+        reactAiApi.getRagJobLogs(jobResponse.jobId),
+        reactAiApi.getRagJobChunks(jobResponse.jobId, 200),
+      ]);
+      setLogs(logsResult.status === "fulfilled" ? logsResult.value : []);
+      setChunks(chunksResult.status === "fulfilled" ? chunksResult.value : []);
+    } catch (loadError) {
+      setError(resolveAxiosError(loadError));
+    } finally {
+      setLoading(false);
+    }
+  }, [jobId]);
+
+  useEffect(() => {
+    void loadDetail();
+  }, [loadDetail]);
+
+  async function handleRetry() {
+    if (!job) {
+      return;
+    }
+    setMutating(true);
+    setError(null);
+    try {
+      const response = await reactAiApi.retryRagJob(job.jobId);
+      setJob(response);
+      await loadDetail();
+    } catch (retryError) {
+      setError(resolveAxiosError(retryError));
+    } finally {
+      setMutating(false);
+    }
+  }
+
+  async function handleCancel() {
+    if (!job) {
+      return;
+    }
+    setMutating(true);
+    setError(null);
+    try {
+      const response = await reactAiApi.cancelRagJob(job.jobId);
+      setJob(response);
+      await loadDetail();
+    } catch (cancelError) {
+      setError(resolveAxiosError(cancelError));
+    } finally {
+      setMutating(false);
+    }
+  }
+
+  const effectiveChunkSize = useMemo(() => chunkSizeLimit(job, chunks), [chunks, job]);
+
+  const chunkColumns = useMemo<ColDef<RagIndexChunkDto>[]>(
+    () => [
+      {
+        field: "chunkOrder",
+        headerName: "순서",
+        sortable: true,
+        width: 76,
+        minWidth: 76,
+        maxWidth: 82,
+        filter: false,
+        tooltipValueGetter: (params) => describeChunk(params.data),
+      },
+      {
+        field: "chunkType",
+        headerName: "유형",
+        sortable: true,
+        width: 112,
+        minWidth: 96,
+        filter: false,
+        tooltipValueGetter: (params) => describeChunk(params.data),
+      },
+      {
+        field: "headingPath",
+        headerName: "위치",
+        sortable: false,
+        flex: 1,
+        minWidth: 140,
+        filter: false,
+        valueGetter: (params) => chunkPosition(params.data),
+        tooltipValueGetter: (params) => describeChunk(params.data),
+      },
+      {
+        field: "page",
+        headerName: "페이지",
+        sortable: true,
+        width: 86,
+        minWidth: 78,
+        maxWidth: 104,
+        filter: false,
+        valueGetter: (params) => chunkPageDisplay(params.data),
+        tooltipValueGetter: (params) => describeChunk(params.data),
+      },
+      {
+        colId: "length",
+        headerName: "길이",
+        sortable: true,
+        width: 82,
+        minWidth: 78,
+        maxWidth: 96,
+        filter: false,
+        valueGetter: (params) => chunkLength(params.data),
+        tooltipValueGetter: (params) => describeChunk(params.data),
+        cellRenderer: (params: { data?: RagIndexChunkDto }) => (
+          <ChunkLengthCell chunk={params.data} maxSize={effectiveChunkSize} />
+        ),
+      },
+      {
+        field: "chunkId",
+        headerName: "Chunk ID",
+        sortable: true,
+        flex: 1,
+        minWidth: 180,
+        filter: false,
+        tooltipValueGetter: (params) => describeChunk(params.data),
+      },
+    ],
+    [effectiveChunkSize]
+  );
+
+  const chunkGridOptions = useMemo<GridOptions<RagIndexChunkDto>>(
+    () => ({
+      getRowId: (params) => chunkRowId(params.data),
+      rowClassRules: {
+        "rag-chunk-row-selected": (params) => chunkRowId(params.data) === chunkRowId(selectedChunk),
+        "rag-chunk-row-short": (params) => isShortChunk(params.data, effectiveChunkSize),
+      },
+    }),
+    [effectiveChunkSize, selectedChunk]
+  );
+
+  const logColumns = useMemo<ColDef<RagIndexJobLogDto>[]>(
+    () => [
+      {
+        field: "level",
+        headerName: "레벨",
+        width: 110,
+        filter: false,
+        cellRenderer: LogLevelCell,
+      },
+      { field: "step", headerName: "단계", width: 130, filter: false },
+      { field: "code", headerName: "코드", width: 170, filter: false },
+      { field: "message", headerName: "메시지", flex: 1, minWidth: 260, filter: false },
+      {
+        field: "createdAt",
+        headerName: "일시",
+        width: 190,
+        filter: false,
+        valueFormatter: (params) => formatDateTime(params.value as string | undefined),
+      },
+    ],
+    []
+  );
+
+  return (
+    <Stack spacing={2}>
+      <PageToolbar
+        divider={true}
+        breadcrumbs={["서비스 관리", "AI", "RAG", sourceDisplayName(job)]}
+        label="색인 작업의 상태, 로그, Chunk를 확인합니다."
+        previous
+        onPrevious={() => navigate("/services/ai/rag")}
+        onRefresh={() => void loadDetail()}
+        actions={
+          <Stack direction="row" spacing={1}>
+            <Tooltip title="실패 또는 완료된 작업을 서버 retry 엔드포인트로 다시 실행합니다.">
+              <span>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<ReplayOutlined />}
+                  disabled={!job || mutating || job.status === "PENDING" || job.status === "RUNNING"}
+                  onClick={() => void handleRetry()}
+                >
+                  재시도
+                </Button>
+              </span>
+            </Tooltip>
+            <Button
+              size="small"
+              variant="outlined"
+              color="warning"
+              disabled={!job || mutating || (job.status !== "PENDING" && job.status !== "RUNNING")}
+              onClick={() => void handleCancel()}
+            >
+              취소
+            </Button>
+          </Stack>
+        }
+      />
+
+      {error ? <Alert severity="error">{error}</Alert> : null}
+      {loading && !job ? (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <CircularProgress size={18} />
+          <Typography variant="body2" color="text.secondary">
+            작업 정보를 불러오는 중입니다.
+          </Typography>
+        </Stack>
+      ) : null}
+
+      {job ? (
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", lg: "minmax(0, 1fr) 200px" },
+            gap: { xs: 0, lg: 3 },
+          }}
+        >
+          <Stack spacing={2}>
+            <Container maxWidth="md" disableGutters>
+              <Box ref={summaryRef} sx={{ scrollMarginTop: 56 }}>
+                <Box
+                  sx={{
+                    display: "grid",
+                    gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+                    gap: 1.25,
+                  }}
+                >
+                  <StatItem label="문서/파일명" value={sourceDisplayName(job)} />
+                  <StatItem label="상태" value={<StatusChip status={job.status} />} />
+                  <StatItem label="단계" value={job.currentStep ?? "-"} />
+                  <StatItem label="객체" value={`${job.objectType} #${job.objectId}`} />
+                  <StatItem label="Chunk" value={job.chunkCount.toLocaleString()} />
+                  <StatItem label="소요" value={job.durationMs ? `${job.durationMs.toLocaleString()}ms` : "-"} />
+                  <StatItem label="청킹 전략" value={chunkingDisplay(job, chunks)} />
+                </Box>
+                <Box sx={{ mt: 3, overflowX: "auto", pb: 0.5 }}>
+                  <Stepper activeStep={activeStepIndex(job)} alternativeLabel sx={{ minWidth: 620 }}>
+                    {INDEX_STEPS.map((step, index) => (
+                      <Step
+                        key={step.key}
+                        completed={isTerminalSuccess(job.status) || index < activeStepIndex(job)}
+                      >
+                        <StepLabel error={isTerminalFailure(job.status) && index === activeStepIndex(job)}>
+                          {step.label}
+                        </StepLabel>
+                      </Step>
+                    ))}
+                  </Stepper>
+                </Box>
+              </Box>
+            </Container>
+
+            <Container maxWidth={false} disableGutters>
+              <Box ref={chunksRef} sx={{ scrollMarginTop: 56 }}>
+                <Stack spacing={1.25}>
+                  <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                    <Typography variant="subtitle1">색인 결과</Typography>
+                    <Tooltip title="Chunk 목록 새로고침">
+                      <IconButton size="small" onClick={() => void loadDetail()}>
+                        <RefreshOutlined fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                  <Box
+                    sx={{
+                      minWidth: 0,
+                      "& .ag-row.rag-chunk-row-selected": {
+                        bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1),
+                      },
+                      "& .ag-row.rag-chunk-row-selected:hover": {
+                        bgcolor: (theme) => alpha(theme.palette.primary.main, 0.14),
+                      },
+                      "& .ag-row.rag-chunk-row-selected .ag-cell": {
+                        fontWeight: 600,
+                      },
+                      "& .ag-row.rag-chunk-row-short:not(.rag-chunk-row-selected)": {
+                        bgcolor: (theme) => alpha(theme.palette.warning.main, 0.08),
+                      },
+                      "& .ag-row.rag-chunk-row-short:not(.rag-chunk-row-selected):hover": {
+                        bgcolor: (theme) => alpha(theme.palette.warning.main, 0.12),
+                      },
+                    }}
+                  >
+                    <GridContent<RagIndexChunkDto>
+                      columns={chunkColumns}
+                      options={chunkGridOptions}
+                      rowData={chunks}
+                      height={640}
+                      loading={loading}
+                      events={[
+                        {
+                          type: "rowClicked",
+                          listener: (event) => {
+                            setSelectedChunk((event as { data?: RagIndexChunkDto }).data ?? null);
+                          },
+                        },
+                      ]}
+                    />
+                  </Box>
+                  <Drawer
+                    anchor="right"
+                    open={Boolean(selectedChunk)}
+                    variant="persistent"
+                    onClose={() => setSelectedChunk(null)}
+                    PaperProps={{
+                      sx: {
+                        width: { xs: "78vw", sm: 520, lg: 600, xl: 680 },
+                        maxWidth: "100vw",
+                        p: 0,
+                        bgcolor: "background.paper",
+                        borderLeft: "1px solid",
+                        borderColor: "divider",
+                        boxShadow: 8,
+                        overflow: "hidden",
+                      },
+                    }}
+                  >
+                    <ChunkInspector
+                      job={job}
+                      chunk={selectedChunk}
+                      chunks={chunks}
+                      onSelectChunk={setSelectedChunk}
+                      onClose={() => setSelectedChunk(null)}
+                    />
+                  </Drawer>
+                  <Box ref={logsRef} sx={{ scrollMarginTop: 56 }}>
+                    <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Typography variant="subtitle1">실패·경고 로그</Typography>
+                        <Chip size="small" variant="outlined" label={`${logs.length.toLocaleString()}건`} />
+                      </Stack>
+                      <Tooltip title="로그 새로고침">
+                        <IconButton size="small" onClick={() => void loadDetail()}>
+                          <RefreshOutlined fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </Stack>
+                    <GridContent<RagIndexJobLogDto> columns={logColumns} rowData={logs} height={220} />
+                  </Box>
+                </Stack>
+              </Box>
+            </Container>
+
+          </Stack>
+
+          <Box
+            component="aside"
+            sx={{
+              display: { xs: "none", lg: "block" },
+              position: "sticky",
+              top: 16,
+              alignSelf: "start",
+              borderLeft: "1px solid",
+              borderColor: "divider",
+              pl: 2,
+              py: 1,
+            }}
+          >
+            <Typography variant="caption" color="text.secondary" fontWeight={700} sx={{ letterSpacing: 0.2 }}>
+              Contents
+            </Typography>
+            <Stack spacing={0.5} sx={{ mt: 1 }}>
+              {[
+                ["summary", "상태 요약"],
+                ["chunks", "색인 결과"],
+                ["logs", "실패·경고 로그"],
+              ].map(([key, label]) => (
+                <Button
+                  key={String(key)}
+                  size="small"
+                  variant="text"
+                  sx={{
+                    justifyContent: "flex-start",
+                    color: "text.secondary",
+                    fontWeight: 400,
+                    borderLeft: "2px solid transparent",
+                    pl: 1,
+                  }}
+                  onClick={() => scrollToSection(key as "summary" | "chunks" | "logs")}
+                >
+                  {label}
+                </Button>
+              ))}
+            </Stack>
+          </Box>
+        </Box>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/RagJobListPage.tsx
+++ b/src/react/pages/ai/RagJobListPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Alert,
@@ -101,6 +101,7 @@ export function RagJobListPage() {
   const [documentId, setDocumentId] = useState("");
   const [indexText, setIndexText] = useState("");
   const [forceReindex, setForceReindex] = useState(false);
+  const selectedJobIdRef = useRef<string | null>(null);
 
   const objectTypeOptions = useMemo<ObjectTypeOption[]>(
     () =>
@@ -114,6 +115,11 @@ export function RagJobListPage() {
   );
 
   const selectedObjectType = objectTypeOptions.find((item) => item.value === objectType) ?? null;
+
+  const setCurrentSelectedJob = useCallback((job: RagIndexJobDto | null) => {
+    selectedJobIdRef.current = job?.jobId ?? null;
+    setSelectedJob(job);
+  }, []);
 
   const filteredJobs = useMemo(() => {
     const keyword = search.trim().toLowerCase();
@@ -180,9 +186,9 @@ export function RagJobListPage() {
 
   useEffect(() => {
     if (selectedJob && !jobs.some((job) => job.jobId === selectedJob.jobId)) {
-      setSelectedJob(null);
+      setCurrentSelectedJob(null);
     }
-  }, [jobs, selectedJob]);
+  }, [jobs, selectedJob, setCurrentSelectedJob]);
 
   const openDetail = useCallback((jobId: string) => {
     navigate(`/services/ai/rag/jobs/${encodeURIComponent(jobId)}`);
@@ -478,7 +484,7 @@ export function RagJobListPage() {
             rowSelection={{
               mode: "singleRow",
               checkboxes: false,
-              enableClickSelection: true,
+              enableClickSelection: false,
             }}
             rowData={displayedJobs}
             loading={loading}
@@ -490,26 +496,26 @@ export function RagJobListPage() {
                 return;
               }
               if (selected) {
-                setSelectedJob(row);
-              } else if (selectedJob?.jobId === row.jobId) {
-                setSelectedJob(null);
+                setCurrentSelectedJob(row);
+              } else if (selectedJobIdRef.current === row.jobId) {
+                setCurrentSelectedJob(null);
               }
             }}
             events={[
               {
                 type: "rowClicked",
                 listener: (event) => {
-                  const typedEvent = event as {
-                    data?: RagIndexJobRow;
-                    node?: { setSelected?: (selected: boolean) => void };
-                  };
-                  const row = typedEvent.data;
-                  if (row) {
-                    const nextSelected = selectedJob?.jobId !== row.jobId;
-                    typedEvent.node?.setSelected?.(nextSelected);
-                    setSelectedJob(nextSelected ? row : null);
-                  }
-                },
+	                  const typedEvent = event as {
+	                    data?: RagIndexJobRow;
+	                    node?: { setSelected?: (selected: boolean) => void };
+	                  };
+	                  const row = typedEvent.data;
+	                  if (row) {
+	                    const nextSelected = selectedJobIdRef.current !== row.jobId;
+	                    typedEvent.node?.setSelected?.(nextSelected);
+	                    setCurrentSelectedJob(nextSelected ? row : null);
+	                  }
+	                },
               },
               {
                 type: "rowDoubleClicked",

--- a/src/react/pages/ai/RagJobListPage.tsx
+++ b/src/react/pages/ai/RagJobListPage.tsx
@@ -1,0 +1,627 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Alert,
+  alpha,
+  Autocomplete,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  IconButton,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  AddOutlined,
+  CancelOutlined,
+  CheckCircleOutline,
+  ChevronRight,
+  ErrorOutline,
+  HourglassEmptyOutlined,
+  HubOutlined,
+  WarningAmberOutlined,
+} from "@mui/icons-material";
+import type { ColDef, GridOptions, ICellRendererParams } from "ag-grid-community";
+import { GridContent } from "@/react/components/ag-grid";
+import { PageToolbar } from "@/react/components/page/PageToolbar";
+import { RagChunkSimulationDialog } from "@/react/pages/ai/RagChunkSimulationDialog";
+import { RagSearchValidationPanel } from "@/react/pages/ai/RagSearchValidationPanel";
+import { reactAiApi } from "@/react/pages/ai/api";
+import { reactObjectTypeApi } from "@/react/pages/objecttype/api";
+import type { RagIndexJobDto, RagIndexJobStatus } from "@/types/studio/ai";
+import type { ObjectTypeDto } from "@/types/studio/objecttype";
+import { resolveAxiosError } from "@/utils/helpers";
+
+type RagJobStatusFilter = RagIndexJobStatus | "";
+type SourceMode = "attachment" | "text";
+type RagIndexJobRow = RagIndexJobDto & { __selected?: boolean };
+type ObjectTypeOption = {
+  value: string;
+  label: string;
+  code: string;
+  name: string;
+};
+
+function statusColor(status?: RagIndexJobStatus) {
+  if (status === "SUCCEEDED") return "success";
+  if (status === "WARNING") return "warning";
+  if (status === "FAILED" || status === "CANCELLED") return "error";
+  if (status === "RUNNING" || status === "PENDING") return "info";
+  return "default";
+}
+
+function statusIcon(status?: RagIndexJobStatus) {
+  if (status === "SUCCEEDED") return <CheckCircleOutline fontSize="small" />;
+  if (status === "WARNING") return <WarningAmberOutlined fontSize="small" />;
+  if (status === "FAILED") return <ErrorOutline fontSize="small" />;
+  if (status === "CANCELLED") return <CancelOutlined fontSize="small" />;
+  if (status === "RUNNING" || status === "PENDING") return <HourglassEmptyOutlined fontSize="small" />;
+  return undefined;
+}
+
+function formatDateTime(value?: string) {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function sourceDisplayName(job: RagIndexJobDto) {
+  return job.sourceName || job.documentId || `${job.objectType} #${job.objectId}` || job.jobId;
+}
+
+export function RagJobListPage() {
+  const navigate = useNavigate();
+  const [jobs, setJobs] = useState<RagIndexJobDto[]>([]);
+  const [total, setTotal] = useState(0);
+  const [status, setStatus] = useState<RagJobStatusFilter>("");
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [chunkSimulationOpen, setChunkSimulationOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedJob, setSelectedJob] = useState<RagIndexJobDto | null>(null);
+  const [objectTypes, setObjectTypes] = useState<ObjectTypeDto[]>([]);
+  const [sourceMode, setSourceMode] = useState<SourceMode>("attachment");
+  const [objectType, setObjectType] = useState("");
+  const [objectId, setObjectId] = useState("");
+  const [documentId, setDocumentId] = useState("");
+  const [indexText, setIndexText] = useState("");
+  const [forceReindex, setForceReindex] = useState(false);
+
+  const objectTypeOptions = useMemo<ObjectTypeOption[]>(
+    () =>
+      objectTypes.map((item) => ({
+        value: String(item.objectType),
+        label: `${item.code} #${item.objectType}`,
+        code: item.code,
+        name: item.name,
+      })),
+    [objectTypes]
+  );
+
+  const selectedObjectType = objectTypeOptions.find((item) => item.value === objectType) ?? null;
+
+  const filteredJobs = useMemo(() => {
+    const keyword = search.trim().toLowerCase();
+    if (!keyword) {
+      return jobs;
+    }
+    return jobs.filter((job) =>
+      [
+        sourceDisplayName(job),
+        job.jobId,
+        job.objectType,
+        job.objectId,
+        job.documentId,
+        job.sourceType,
+        job.status,
+        job.currentStep,
+      ]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(keyword))
+    );
+  }, [jobs, search]);
+
+  const displayedJobs = useMemo<RagIndexJobRow[]>(
+    () => filteredJobs.map((job) => ({ ...job, __selected: job.jobId === selectedJob?.jobId })),
+    [filteredJobs, selectedJob?.jobId]
+  );
+
+  const loadJobs = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await reactAiApi.listRagJobs({
+        status,
+        offset: 0,
+        limit: 100,
+        sort: "createdAt",
+        direction: "desc",
+      });
+      setJobs(response.items ?? []);
+      setTotal(response.total ?? 0);
+    } catch (loadError) {
+      setError(resolveAxiosError(loadError));
+    } finally {
+      setLoading(false);
+    }
+  }, [status]);
+
+  const loadObjectTypes = useCallback(async () => {
+    try {
+      const response = await reactObjectTypeApi.list({ status: "ACTIVE" });
+      setObjectTypes(response);
+    } catch {
+      setObjectTypes([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadJobs();
+  }, [loadJobs]);
+
+  useEffect(() => {
+    void loadObjectTypes();
+  }, [loadObjectTypes]);
+
+  useEffect(() => {
+    if (selectedJob && !jobs.some((job) => job.jobId === selectedJob.jobId)) {
+      setSelectedJob(null);
+    }
+  }, [jobs, selectedJob]);
+
+  const openDetail = useCallback((jobId: string) => {
+    navigate(`/services/ai/rag/jobs/${encodeURIComponent(jobId)}`);
+  }, [navigate]);
+
+  const gridOptions = useMemo<GridOptions<RagIndexJobRow>>(
+    () => ({
+      getRowId: (params) => params.data.jobId,
+      rowClassRules: {
+        "rag-job-row-selected": (params) => Boolean(params.data?.__selected),
+      },
+    }),
+    []
+  );
+
+  function resetCreateForm() {
+    setSourceMode("attachment");
+    setObjectType("");
+    setObjectId("");
+    setDocumentId("");
+    setIndexText("");
+    setForceReindex(false);
+  }
+
+  async function handleCreateJob() {
+    if (!objectType.trim() || !objectId.trim()) {
+      setError("객체 유형과 객체 ID를 입력하세요.");
+      return;
+    }
+    if (sourceMode === "text" && !indexText.trim()) {
+      setError("텍스트 색인은 색인할 텍스트가 필요합니다.");
+      return;
+    }
+
+    setCreating(true);
+    setError(null);
+    try {
+      const job = await reactAiApi.createRagJob({
+        objectType: objectType.trim(),
+        objectId: objectId.trim(),
+        documentId: documentId.trim() || undefined,
+        sourceType: sourceMode === "attachment" ? "attachment" : undefined,
+        text: sourceMode === "text" ? indexText.trim() : undefined,
+        forceReindex,
+      });
+      setCreateOpen(false);
+      resetCreateForm();
+      await loadJobs();
+      openDetail(job.jobId);
+    } catch (createError) {
+      setError(resolveAxiosError(createError));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  const columns = useMemo<ColDef<RagIndexJobRow>[]>(
+    () => [
+      {
+        field: "status",
+        headerName: "상태",
+        width: 132,
+        filter: false,
+        cellRenderer: (params: { value?: RagIndexJobStatus }) => (
+          <Chip
+            size="small"
+            color={statusColor(params.value)}
+            icon={statusIcon(params.value)}
+            label={params.value ?? "-"}
+            sx={{
+              fontWeight: params.value === "FAILED" ? 700 : 500,
+              "& .MuiChip-icon": { ml: 0.75 },
+            }}
+          />
+        ),
+      },
+      {
+        colId: "sourceName",
+        headerName: "문서/파일명",
+        flex: 1.2,
+        minWidth: 280,
+        filter: false,
+        valueGetter: (params) => (params.data ? sourceDisplayName(params.data) : "-"),
+        cellRenderer: (params: ICellRendererParams<RagIndexJobRow>) => {
+          const row = params.data;
+          if (!row) {
+            return "-";
+          }
+          return (
+            <Box
+              component="button"
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                openDetail(row.jobId);
+              }}
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                border: 0,
+                p: 0,
+                maxWidth: "100%",
+                bgcolor: "transparent",
+                color: "primary.main",
+                cursor: "pointer",
+                font: "inherit",
+                textAlign: "left",
+                "&:hover": { textDecoration: "underline" },
+              }}
+            >
+              <Typography variant="body2" noWrap>
+                {sourceDisplayName(row)}
+              </Typography>
+            </Box>
+          );
+        },
+      },
+      { field: "objectType", headerName: "객체 유형", width: 120, filter: false },
+      { field: "objectId", headerName: "객체 ID", width: 110, filter: false },
+      { field: "sourceType", headerName: "소스", width: 110, filter: false },
+      { field: "currentStep", headerName: "단계", width: 130, filter: false },
+      { field: "chunkCount", headerName: "Chunk", width: 90, filter: false, type: "numericColumn" },
+      { field: "warningCount", headerName: "경고", width: 90, filter: false, type: "numericColumn" },
+      {
+        field: "createdAt",
+        headerName: "생성일시",
+        width: 190,
+        filter: false,
+        valueFormatter: (params) => formatDateTime(params.value as string | undefined),
+      },
+      {
+        field: "durationMs",
+        headerName: "소요",
+        width: 100,
+        filter: false,
+        valueFormatter: (params) =>
+          typeof params.value === "number" ? `${params.value.toLocaleString()}ms` : "-",
+      },
+      {
+        field: "errorMessage",
+        headerName: "오류",
+        flex: 0.8,
+        minWidth: 180,
+        filter: false,
+        tooltipField: "errorMessage",
+      },
+      {
+        colId: "actions",
+        headerName: "",
+        filter: false,
+        sortable: false,
+        width: 64,
+        cellRenderer: (params: ICellRendererParams<RagIndexJobRow>) => (
+          <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+            <Tooltip title="상세보기">
+              <IconButton
+                size="small"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  if (params.data) {
+                    openDetail(params.data.jobId);
+                  }
+                }}
+              >
+                <ChevronRight fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        ),
+      },
+    ],
+    [openDetail]
+  );
+
+  return (
+    <Stack spacing={0.5}>
+      <PageToolbar
+        divider={false}
+        breadcrumbs={["서비스 관리", "AI", "RAG"]}
+        label="색인 작업을 조회하고 문서 단위로 상세 진단을 확인합니다."
+        searchPlaceholder="문서명, jobId, 객체 ID"
+        searchValue={search}
+        onSearchValueChange={setSearch}
+        onSearch={setSearch}
+        onRefresh={() => void loadJobs()}
+        actions={
+          <>
+            <Tooltip title="청킹 시뮬레이션을 실행합니다. 색인 전 텍스트가 어떤 Chunk로 나뉘는지 확인합니다.">
+              <IconButton
+                size="small"
+                color="primary"
+                aria-label="청킹 시뮬레이션"
+                onClick={() => setChunkSimulationOpen(true)}
+              >
+                <HubOutlined fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="새 색인 작업을 생성합니다. 생성 후 상세 화면으로 이동합니다.">
+              <IconButton
+                size="small"
+                color="primary"
+                aria-label="새 색인 작업"
+                onClick={() => setCreateOpen(true)}
+              >
+                <AddOutlined fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </>
+        }
+      />
+
+      {error ? <Alert severity="error">{error}</Alert> : null}
+
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+        <Typography variant="caption" color="text.secondary">
+          상태
+        </Typography>
+        <Select
+          value={status}
+          onChange={(event) => setStatus(event.target.value as RagJobStatusFilter)}
+          size="small"
+          displayEmpty
+          renderValue={(selected) => (selected ? String(selected) : "전체")}
+          sx={{ minWidth: 140, height: 32, "& .MuiSelect-select": { py: 0.5, fontSize: 13 } }}
+        >
+          <MenuItem value="">전체</MenuItem>
+          {(["PENDING", "RUNNING", "SUCCEEDED", "WARNING", "FAILED", "CANCELLED"] as RagIndexJobStatus[]).map(
+            (item) => (
+              <MenuItem key={item} value={item}>
+                {item}
+              </MenuItem>
+            )
+          )}
+        </Select>
+        <Typography variant="caption" color="text.secondary">
+          표시 {filteredJobs.length.toLocaleString()}건 / 전체 {total.toLocaleString()}건
+        </Typography>
+      </Stack>
+
+      <Box>
+        <Box
+          sx={{
+            "& .ag-row.rag-job-row-selected": {
+              bgcolor: (theme) =>
+                theme.palette.mode === "dark"
+                  ? alpha(theme.palette.primary.main, 0.26)
+                  : alpha(theme.palette.primary.main, 0.14),
+              boxShadow: (theme) => `inset 4px 0 0 ${theme.palette.primary.main}`,
+            },
+            "& .ag-row.rag-job-row-selected:hover": {
+              bgcolor: (theme) =>
+                theme.palette.mode === "dark"
+                  ? alpha(theme.palette.primary.main, 0.34)
+                  : alpha(theme.palette.primary.main, 0.2),
+            },
+            "& .ag-row.rag-job-row-selected .ag-cell": {
+              bgcolor: (theme) =>
+                theme.palette.mode === "dark"
+                  ? `${alpha(theme.palette.primary.main, 0.26)} !important`
+                  : `${alpha(theme.palette.primary.main, 0.14)} !important`,
+              fontWeight: 600,
+            },
+            "& .ag-row.ag-row-selected .ag-cell": {
+              bgcolor: (theme) =>
+                theme.palette.mode === "dark"
+                  ? `${alpha(theme.palette.primary.main, 0.26)} !important`
+                  : `${alpha(theme.palette.primary.main, 0.14)} !important`,
+              fontWeight: 600,
+            },
+            "& .ag-row.rag-job-row-selected:hover .ag-cell": {
+              bgcolor: (theme) =>
+                theme.palette.mode === "dark"
+                  ? `${alpha(theme.palette.primary.main, 0.34)} !important`
+                  : `${alpha(theme.palette.primary.main, 0.2)} !important`,
+            },
+            "& .ag-row.ag-row-selected:hover .ag-cell": {
+              bgcolor: (theme) =>
+                theme.palette.mode === "dark"
+                  ? `${alpha(theme.palette.primary.main, 0.34)} !important`
+                  : `${alpha(theme.palette.primary.main, 0.2)} !important`,
+            },
+            "& .ag-row.rag-job-row-selected .ag-cell:first-of-type": {
+              boxShadow: (theme) => `inset 4px 0 0 ${theme.palette.primary.main}`,
+            },
+            "& .ag-row.ag-row-selected .ag-cell:first-of-type": {
+              boxShadow: (theme) => `inset 4px 0 0 ${theme.palette.primary.main}`,
+            },
+          }}
+        >
+          <GridContent<RagIndexJobRow>
+            columns={columns}
+            options={gridOptions}
+            rowSelection={{
+              mode: "singleRow",
+              checkboxes: false,
+              enableClickSelection: true,
+            }}
+            rowData={displayedJobs}
+            loading={loading}
+            height={560}
+            onRowSelected={(event) => {
+              const row = (event as { data?: RagIndexJobRow; node?: { isSelected?: () => boolean } }).data;
+              const selected = (event as { node?: { isSelected?: () => boolean } }).node?.isSelected?.();
+              if (!row) {
+                return;
+              }
+              if (selected) {
+                setSelectedJob(row);
+              } else if (selectedJob?.jobId === row.jobId) {
+                setSelectedJob(null);
+              }
+            }}
+            events={[
+              {
+                type: "rowClicked",
+                listener: (event) => {
+                  const typedEvent = event as {
+                    data?: RagIndexJobRow;
+                    node?: { setSelected?: (selected: boolean) => void };
+                  };
+                  const row = typedEvent.data;
+                  if (row) {
+                    const nextSelected = selectedJob?.jobId !== row.jobId;
+                    typedEvent.node?.setSelected?.(nextSelected);
+                    setSelectedJob(nextSelected ? row : null);
+                  }
+                },
+              },
+              {
+                type: "rowDoubleClicked",
+                listener: (event) => {
+                  const row = (event as { data?: RagIndexJobRow }).data;
+                  if (row) {
+                    openDetail(row.jobId);
+                  }
+                },
+              },
+            ]}
+          />
+        </Box>
+      </Box>
+
+      <RagSearchValidationPanel job={selectedJob} />
+
+      <Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="md" fullWidth>
+        <DialogTitle>새 색인 작업</DialogTitle>
+        <DialogContent>
+          <Stack spacing={1.5} sx={{ pt: 0.5 }}>
+            <Alert severity="info">
+              색인 작업은 생성 즉시 비동기로 실행됩니다. 생성 후 상세 화면에서 진행 상태, 로그, Chunk를 확인합니다.
+            </Alert>
+            <TextField
+              select
+              label="색인 소스"
+              value={sourceMode}
+              onChange={(event) => setSourceMode(event.target.value as SourceMode)}
+              size="small"
+              fullWidth
+            >
+              <MenuItem value="attachment">Attachment 파일</MenuItem>
+              <MenuItem value="text">직접 입력 텍스트</MenuItem>
+            </TextField>
+            <Autocomplete
+              options={objectTypeOptions}
+              value={selectedObjectType}
+              onChange={(_, value) => setObjectType(value?.value ?? "")}
+              getOptionLabel={(option) => option.label}
+              renderOption={(props, option) => (
+                <li {...props} key={option.value}>
+                  <Stack spacing={0}>
+                    <Typography variant="body2">{option.label}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {option.name}
+                    </Typography>
+                  </Stack>
+                </li>
+              )}
+              renderInput={(params) => (
+                <TextField {...params} label="객체 유형" size="small" placeholder="객체 유형 선택" />
+              )}
+            />
+            <TextField
+              label={sourceMode === "attachment" ? "객체 ID / Attachment ID" : "객체 ID"}
+              value={objectId}
+              onChange={(event) => setObjectId(event.target.value)}
+              size="small"
+              fullWidth
+              helperText={
+                sourceMode === "attachment"
+                  ? "비워둔 documentId 대신 이 값을 attachmentId로 사용합니다."
+                  : "직접 입력 텍스트를 연결할 객체 ID입니다."
+              }
+            />
+            <TextField
+              label="Document ID"
+              value={documentId}
+              onChange={(event) => setDocumentId(event.target.value)}
+              size="small"
+              fullWidth
+              helperText="선택 사항입니다. 비워두면 서버가 객체 ID를 기준으로 설정합니다."
+            />
+            {sourceMode === "text" ? (
+              <TextField
+                label="색인할 텍스트"
+                value={indexText}
+                onChange={(event) => setIndexText(event.target.value)}
+                size="small"
+                fullWidth
+                multiline
+                minRows={6}
+              />
+            ) : null}
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={forceReindex}
+                  onChange={(event) => setForceReindex(event.target.checked)}
+                />
+              }
+              label="강제 재색인"
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateOpen(false)}>취소</Button>
+          <Button
+            variant="contained"
+            onClick={() => void handleCreateJob()}
+            disabled={creating}
+            startIcon={creating ? <CircularProgress size={16} color="inherit" /> : undefined}
+          >
+            {creating ? "생성 중" : "생성"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <RagChunkSimulationDialog
+        open={chunkSimulationOpen}
+        onClose={() => setChunkSimulationOpen(false)}
+      />
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/RagPage.tsx
+++ b/src/react/pages/ai/RagPage.tsx
@@ -1,67 +1,775 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Autocomplete,
+  Badge,
   Box,
   Button,
   Card,
   CardContent,
   Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  IconButton,
   MenuItem,
+  Select,
   Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  Switch,
+  Tab,
+  Tabs,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
-import type { ColDef } from "ag-grid-community";
+import {
+  ArticleOutlined,
+  CheckBoxOutlineBlankOutlined,
+  CheckBoxOutlined,
+  ChevronRightOutlined,
+  ExpandMoreOutlined,
+  HubOutlined,
+  InfoOutlined,
+  PlayArrowOutlined,
+  ReplayOutlined,
+  SearchOutlined,
+  StorageOutlined,
+} from "@mui/icons-material";
+import type { ColDef, GridOptions, ICellRendererParams } from "ag-grid-community";
 import { GridContent } from "@/react/components/ag-grid";
+import { PageToolbar } from "@/react/components/page/PageToolbar";
 import { reactAiApi } from "@/react/pages/ai/api";
+import { reactFilesApi } from "@/react/pages/files/api";
+import { reactObjectTypeApi } from "@/react/pages/objecttype/api";
 import type {
   AiInfoResponse,
   ChatMessageDto,
+  ChatResponseMetadataDto,
   ProviderInfo,
+  RagChunkConfigResponseDto,
+  RagChunkPreviewItemDto,
+  RagIndexChunkDto,
+  RagIndexChunkPageResponseDto,
+  RagIndexJobDto,
+  RagIndexJobLogDto,
+  RagIndexJobStatus,
+  SearchResultDto,
+  TokenUsageDto,
   VectorSearchResultDto,
 } from "@/types/studio/ai";
+import type { ObjectTypeDto } from "@/types/studio/objecttype";
 import { resolveAxiosError } from "@/utils/helpers";
-import { PageToolbar } from "@/react/components/page/PageToolbar";
+
+type ValidationTab = "vector" | "rag" | "chat";
+type RagJobStatusFilter = RagIndexJobStatus | "";
+type ObjectTypeOption = {
+  value: string;
+  label: string;
+  name: string;
+  code: string;
+  objectType: number;
+};
+type ConfirmedScope = {
+  objectType: string;
+  objectId: string;
+  attachmentId?: string;
+};
+
+function formatValue(value: unknown) {
+  if (value == null || value === "") {
+    return "-";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function chunkStrategyHint(strategy: string) {
+  switch (strategy) {
+    case "fixed-size":
+      return "고정 길이 기준으로 단순하게 나눕니다. 빠르지만 문단 구조를 덜 반영합니다.";
+    case "recursive":
+      return "문단, 문장, 공백 순서로 가능한 자연스럽게 나눕니다. 일반 문서에 적합합니다.";
+    case "structure-based":
+      return "제목, 섹션 같은 문서 구조를 우선 반영해 나눕니다. 구조화 문서에 적합합니다.";
+    default:
+      return "서버가 지원하는 청킹 전략을 선택합니다.";
+  }
+}
+
+function chunkStrategyUsesSizing(strategy: string) {
+  return ["fixed-size", "recursive", "structure-based"].includes(strategy.trim().toLowerCase());
+}
+
+function pickMetadataValue(metadata: Record<string, unknown> | undefined, keys: string[]) {
+  if (!metadata) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    const value = metadata[key];
+    if (value != null && value !== "") {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function getChunkOrder(metadata: Record<string, unknown> | undefined) {
+  return pickMetadataValue(metadata, [
+    "chunkOrder",
+    "chunkIndex",
+    "chunk_order",
+    "chunk_index",
+    "chunkNo",
+    "chunk_no",
+    "order",
+    "index",
+  ]);
+}
+
+function getChunkId(metadata: Record<string, unknown> | undefined) {
+  return pickMetadataValue(metadata, ["chunkId", "chunk_id", "chunkIdentifier", "id"]);
+}
+
+function formatChunkValue(metadata: Record<string, unknown> | undefined) {
+  const order = getChunkOrder(metadata);
+  if (order != null) {
+    return `#${formatValue(order)}`;
+  }
+
+  const id = getChunkId(metadata);
+  if (id != null) {
+    return formatValue(id);
+  }
+  return "-";
+}
+
+function formatChunkTooltip(metadata: Record<string, unknown> | undefined) {
+  const order = getChunkOrder(metadata);
+  const id = getChunkId(metadata);
+  if (order != null && id != null) {
+    return `순서: ${formatValue(order)} / Chunk ID: ${formatValue(id)}`;
+  }
+  if (order != null) {
+    return `순서: ${formatValue(order)}`;
+  }
+  if (id != null) {
+    return `Chunk ID: ${formatValue(id)}`;
+  }
+  return "Chunk 정보 없음";
+}
+
+function chunkRowKey(row?: RagIndexChunkDto | null) {
+  if (!row) {
+    return "";
+  }
+  return row.chunkId || `${row.documentId}:${row.chunkOrder ?? ""}:${row.sourceRef ?? ""}`;
+}
+
+function formatTokenUsage(usage?: TokenUsageDto) {
+  if (!usage) {
+    return "토큰 정보 없음";
+  }
+  return `입력 ${usage.inputTokens.toLocaleString()} / 출력 ${usage.outputTokens.toLocaleString()} / 합계 ${usage.totalTokens.toLocaleString()}`;
+}
+
+function buildVisibleRagContext(rows: SearchResultDto[], limit: number) {
+  const maxChars = 6000;
+  const chunks = rows.slice(0, Math.max(1, limit)).map((row, index) => {
+    const content = row.content?.trim() || "";
+    return `[화면 RAG 후보 ${index + 1}] documentId=${row.documentId} score=${formatValue(row.score)}\n${content}`;
+  });
+  const context = chunks.join("\n\n").trim();
+  return context.length > maxChars ? `${context.slice(0, maxChars)}\n...` : context;
+}
+
+function extractRagDiagnostics(metadata?: ChatResponseMetadataDto | null) {
+  if (!metadata) {
+    return null;
+  }
+
+  const diagnostics: Record<string, unknown> = {};
+  const retrieval = metadata.ragDiagnostics;
+  const context = metadata.ragContextDiagnostics;
+  if (retrieval && typeof retrieval === "object") {
+    diagnostics.retrieval = retrieval;
+  }
+  if (context && typeof context === "object") {
+    diagnostics.context = context;
+  }
+  return Object.keys(diagnostics).length > 0 ? diagnostics : null;
+}
+
+function formatDateTime(value?: string) {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function statusColor(status?: RagIndexJobStatus) {
+  if (status === "SUCCEEDED") return "success";
+  if (status === "WARNING") return "warning";
+  if (status === "FAILED" || status === "CANCELLED") return "error";
+  if (status === "RUNNING" || status === "PENDING") return "info";
+  return "default";
+}
+
+function isPositiveIntegerText(value?: string | null) {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const numberValue = Number(trimmed);
+  return Number.isInteger(numberValue) && numberValue > 0;
+}
+
+function inferAttachmentIdFromJob(job: RagIndexJobDto) {
+  if (job.sourceType !== "attachment") {
+    return undefined;
+  }
+  if (isPositiveIntegerText(job.documentId)) {
+    return job.documentId;
+  }
+  if (job.objectType === "attachment" && isPositiveIntegerText(job.objectId)) {
+    return job.objectId;
+  }
+  return undefined;
+}
+
+function JobSelectionToggle({
+  checked,
+  onToggle,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <IconButton
+      type="button"
+      size="small"
+      aria-label={checked ? "작업 선택 해제" : "작업 선택"}
+      onClick={(event) => {
+        event.stopPropagation();
+        onToggle();
+      }}
+      sx={{
+        width: 28,
+        height: 28,
+        p: 0,
+        color: checked ? "primary.main" : "text.secondary",
+      }}
+    >
+      {checked ? <CheckBoxOutlined fontSize="small" /> : <CheckBoxOutlineBlankOutlined fontSize="small" />}
+    </IconButton>
+  );
+}
+
+function ErrorMessageCell(params: { value?: string }) {
+  const value = params.value?.trim();
+  if (!value) {
+    return "-";
+  }
+  return (
+    <Tooltip title={value} placement="top-start">
+      <Typography variant="body2" noWrap sx={{ maxWidth: "100%" }}>
+        {value}
+      </Typography>
+    </Tooltip>
+  );
+}
+
+function StatusMetric({
+  label,
+  value,
+  tone = "default",
+}: {
+  label: string;
+  value: React.ReactNode;
+  tone?: "default" | "success" | "warning";
+}) {
+  const color =
+    tone === "success" ? "success.main" : tone === "warning" ? "warning.main" : "text.primary";
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderColor: "divider",
+        borderRadius: 2,
+        p: 1.25,
+        minHeight: 76,
+      }}
+    >
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="subtitle2" color={color} sx={{ mt: 0.5 }} noWrap>
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+function SummaryStatusCard({
+  title,
+  value,
+  hint,
+}: {
+  title: string;
+  value: React.ReactNode;
+  hint?: React.ReactNode;
+}) {
+  return (
+    <Box
+      sx={{
+        borderRadius: 2,
+        bgcolor: "action.hover",
+        px: 1.25,
+        py: 1,
+      }}
+    >
+      <Stack spacing={0.25}>
+        <Typography variant="caption" color="text.secondary" fontWeight={700}>
+          {title}
+        </Typography>
+        <Typography variant="body2" fontWeight={700} noWrap>
+          {value}
+        </Typography>
+        {hint ? (
+          <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.4 }}>
+            {hint}
+          </Typography>
+        ) : null}
+      </Stack>
+    </Box>
+  );
+}
+
+function SearchResultDetail({
+  title,
+  content,
+  metadata,
+}: {
+  title: string;
+  content?: string | null;
+  metadata?: Record<string, unknown>;
+}) {
+  return (
+    <Box sx={{ border: 1, borderColor: "divider", borderRadius: 2, p: 1.25 }}>
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">{title}</Typography>
+        <Box
+          component="pre"
+          sx={{
+            m: 0,
+            maxHeight: 260,
+            overflow: "auto",
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+            borderRadius: 2,
+            bgcolor: "action.hover",
+            p: 1,
+            fontFamily: (theme) => theme.typography.fontFamily,
+            fontSize: 12,
+            lineHeight: 1.7,
+          }}
+        >
+          {content?.trim() || "검색 결과 row를 선택하면 전체 콘텐츠가 여기에 표시됩니다."}
+        </Box>
+        {metadata ? (
+          <Box
+            component="pre"
+            sx={{
+              m: 0,
+              maxHeight: 180,
+              overflow: "auto",
+              whiteSpace: "pre-wrap",
+              overflowWrap: "anywhere",
+              color: "text.secondary",
+              fontSize: 12,
+            }}
+          >
+            {JSON.stringify(metadata, null, 2)}
+          </Box>
+        ) : null}
+      </Stack>
+    </Box>
+  );
+}
 
 export function RagPage() {
+  const statusSectionRef = useRef<HTMLDivElement | null>(null);
+  const targetSectionRef = useRef<HTMLDivElement | null>(null);
+  const jobsSectionRef = useRef<HTMLDivElement | null>(null);
+  const validationSectionRef = useRef<HTMLDivElement | null>(null);
+  const chunksSectionRef = useRef<HTMLDivElement | null>(null);
+  const diagnosticsSectionRef = useRef<HTMLDivElement | null>(null);
+  const selectedJobIdRef = useRef<string | null>(null);
+  const jobLogsCacheRef = useRef(new Map<string, RagIndexJobLogDto[]>());
+  const objectMetadataCacheRef = useRef(new Map<string, Record<string, unknown>>());
+  const chunksPageCacheRef = useRef(new Map<string, RagIndexChunkPageResponseDto>());
   const [aiInfo, setAiInfo] = useState<AiInfoResponse | null>(null);
   const [provider, setProvider] = useState("");
+  const [objectTypes, setObjectTypes] = useState<ObjectTypeDto[]>([]);
   const [model, setModel] = useState("");
   const [query, setQuery] = useState("");
-  const [topK, setTopK] = useState("3");
+  const [topK, setTopK] = useState("5");
+  const [minScore, setMinScore] = useState("");
   const [objectType, setObjectType] = useState("");
   const [objectId, setObjectId] = useState("");
-  const [debug, setDebug] = useState(false);
+  const [attachmentId, setAttachmentId] = useState("");
+  const [documentId, setDocumentId] = useState("");
+  const [indexText, setIndexText] = useState("");
+  const [forceReindex, setForceReindex] = useState(false);
+  const [indexChunkingStrategy, setIndexChunkingStrategy] = useState("");
+  const [indexChunkMaxSize, setIndexChunkMaxSize] = useState("");
+  const [indexChunkOverlap, setIndexChunkOverlap] = useState("");
+  const [indexChunkUnit, setIndexChunkUnit] = useState("character");
+  const [debug, setDebug] = useState(true);
   const [expandedQuery, setExpandedQuery] = useState("");
   const [expandedKeywords, setExpandedKeywords] = useState<string[]>([]);
-  const [rows, setRows] = useState<VectorSearchResultDto[]>([]);
+  const [vectorRows, setVectorRows] = useState<VectorSearchResultDto[]>([]);
+  const [ragRows, setRagRows] = useState<SearchResultDto[]>([]);
+  const [vectorSearched, setVectorSearched] = useState(false);
+  const [ragSearched, setRagSearched] = useState(false);
+  const [lastRagSearchQuery, setLastRagSearchQuery] = useState("");
+  const [selectedVectorResult, setSelectedVectorResult] = useState<VectorSearchResultDto | null>(null);
+  const [selectedRagResult, setSelectedRagResult] = useState<SearchResultDto | null>(null);
   const [chatInput, setChatInput] = useState("");
   const [chatMessages, setChatMessages] = useState<ChatMessageDto[]>([]);
   const [ragDiagnostics, setRagDiagnostics] = useState<Record<string, unknown> | null>(null);
+  const [targetMetadata, setTargetMetadata] = useState<Record<string, unknown> | null>(null);
+  const [targetIndexed, setTargetIndexed] = useState<boolean | null>(null);
+  const [confirmedScope, setConfirmedScope] = useState<ConfirmedScope | null>(null);
+  const [jobs, setJobs] = useState<RagIndexJobDto[]>([]);
+  const [jobsTotal, setJobsTotal] = useState(0);
+  const [jobStatusFilter, setJobStatusFilter] = useState<RagJobStatusFilter>("");
+  const [selectedJob, setSelectedJob] = useState<RagIndexJobDto | null>(null);
+  const [jobLogs, setJobLogs] = useState<RagIndexJobLogDto[]>([]);
+  const [chunks, setChunks] = useState<RagIndexChunkDto[]>([]);
+  const [selectedChunk, setSelectedChunk] = useState<RagIndexChunkDto | null>(null);
+  const [chunkPage, setChunkPage] = useState({ offset: 0, limit: 50, hasMore: false });
+  const [lastMetadata, setLastMetadata] = useState<ChatResponseMetadataDto | null>(null);
+  const [lastValidatedAt, setLastValidatedAt] = useState<string | null>(null);
+  const [tab, setTab] = useState<ValidationTab>("vector");
+  const [chunkPreviewOpen, setChunkPreviewOpen] = useState(false);
+  const [chunkConfig, setChunkConfig] = useState<RagChunkConfigResponseDto | null>(null);
+  const [chunkPreviewText, setChunkPreviewText] = useState("");
+  const [chunkPreviewStrategy, setChunkPreviewStrategy] = useState("");
+  const [chunkPreviewMaxSize, setChunkPreviewMaxSize] = useState("");
+  const [chunkPreviewOverlap, setChunkPreviewOverlap] = useState("");
+  const [chunkPreviewRows, setChunkPreviewRows] = useState<RagChunkPreviewItemDto[]>([]);
+  const [selectedPreviewChunk, setSelectedPreviewChunk] = useState<RagChunkPreviewItemDto | null>(null);
+  const [chunkPreviewSummary, setChunkPreviewSummary] = useState<{
+    totalChunks: number;
+    totalChars: number;
+    strategy: string;
+    maxSize: number;
+    overlap: number;
+    unit: string;
+    warnings: string[];
+  } | null>(null);
+  const [chunkPreviewLoading, setChunkPreviewLoading] = useState(false);
+  const [chunkPreviewError, setChunkPreviewError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [jobsLoading, setJobsLoading] = useState(false);
+  const [chunksLoading, setChunksLoading] = useState(false);
+  const [logsLoading, setLogsLoading] = useState(false);
+  const [vectorLoading, setVectorLoading] = useState(false);
+  const [ragLoading, setRagLoading] = useState(false);
+  const [chatLoading, setChatLoading] = useState(false);
 
   const providers = useMemo<ProviderInfo[]>(() => aiInfo?.providers ?? [], [aiInfo]);
+  const currentProvider = useMemo(
+    () => providers.find((item) => item.name === provider),
+    [provider, providers]
+  );
+  const objectTypeOptions = useMemo<ObjectTypeOption[]>(
+    () =>
+      objectTypes.map((item) => ({
+        value: String(item.objectType),
+        label: `${item.code} #${item.objectType}`,
+        name: item.name,
+        code: item.code,
+        objectType: item.objectType,
+      })),
+    [objectTypes]
+  );
+  const selectedObjectTypeOption = useMemo(
+    () => objectTypeOptions.find((item) => item.value === objectType) ?? null,
+    [objectType, objectTypeOptions]
+  );
+  const formatObjectTypeLabel = useCallback(
+    (value?: string | null) => {
+      if (!value) {
+        return "-";
+      }
+      return objectTypeOptions.find((item) => item.value === value)?.label ?? value;
+    },
+    [objectTypeOptions]
+  );
+  const resolveObjectTypeValue = useCallback(
+    (value?: string | null) => {
+      const trimmed = value?.trim();
+      if (!trimmed) {
+        return "";
+      }
+      const idFromLabel = trimmed.match(/#\s*(\d+)\s*$/)?.[1];
+      if (idFromLabel) {
+        return idFromLabel;
+      }
+      const match = objectTypeOptions.find(
+        (item) => item.value === trimmed || item.label === trimmed || item.code === trimmed
+      );
+      return match?.value ?? trimmed;
+    },
+    [objectTypeOptions]
+  );
+  const canCheckTarget = Boolean(attachmentId.trim() || (objectType.trim() && objectId.trim()));
+  const hasConfirmedScope = Boolean(confirmedScope);
+  const canIndexAttachment = Boolean(confirmedScope?.attachmentId);
+  const currentAttachmentIdForIndexing = resolveAttachmentIdForIndexing();
+  const canForceReindexTarget = Boolean(confirmedScope && currentAttachmentIdForIndexing);
+  const canCreateTextJob = Boolean(confirmedScope && !confirmedScope.attachmentId && indexText.trim());
+  const selectedJobSucceeded = selectedJob?.status === "SUCCEEDED" || selectedJob?.status === "WARNING";
+  const selectedJobFailed = selectedJob?.status === "FAILED" || selectedJob?.status === "CANCELLED";
+  const hasSearchResult = vectorRows.length > 0 || ragRows.length > 0 || Boolean(lastMetadata);
+  const hasJobInspection = Boolean(selectedJob && (jobLogs.length > 0 || chunks.length > 0));
+  const workflowActiveStep = !confirmedScope
+    ? 0
+    : !selectedJob || !selectedJobSucceeded
+      ? 1
+      : !hasJobInspection
+        ? 2
+        : 3;
+  const visibleJobCount = jobs.length;
+  const vectorReady = Boolean(aiInfo?.vector.available);
+  const indexChunkingUsesSizing = chunkStrategyUsesSizing(indexChunkingStrategy);
+  const chunkPreviewTextLength = chunkPreviewText.trim().length;
+  const chunkPreviewUsesSizing = chunkStrategyUsesSizing(chunkPreviewStrategy);
+  const chunkPreviewEffectiveMaxSize =
+    (chunkPreviewUsesSizing ? optionalNumber(chunkPreviewMaxSize) : undefined) ?? chunkConfig?.chunking.maxSize ?? 0;
+  const chunkPreviewSingleChunkLikely =
+    chunkPreviewUsesSizing &&
+    chunkPreviewTextLength > 0 &&
+    chunkPreviewEffectiveMaxSize > 0 &&
+    chunkPreviewTextLength <= chunkPreviewEffectiveMaxSize;
 
-  useEffect(() => {
-    reactAiApi
-      .fetchProviders()
-      .then((data) => {
-        setAiInfo(data);
-        setProvider(data.defaultProvider);
-        const match = data.providers.find((item) => item.name === data.defaultProvider);
-        setModel(match?.chat.model ?? "");
-      })
-      .catch((loadError) => setError(resolveAxiosError(loadError)));
+  function objectCacheKey(scopeObjectType?: string, scopeObjectId?: string) {
+    return `${scopeObjectType ?? ""}:${scopeObjectId ?? ""}`;
+  }
+
+  function chunksCacheKey(scopeObjectType?: string, scopeObjectId?: string, offset = 0, limit = chunkPage.limit) {
+    return `${objectCacheKey(scopeObjectType, scopeObjectId)}:${offset}:${limit}`;
+  }
+
+  function clearObjectInspectionCache(scopeObjectType?: string, scopeObjectId?: string) {
+    const prefix = `${objectCacheKey(scopeObjectType, scopeObjectId)}:`;
+    objectMetadataCacheRef.current.delete(objectCacheKey(scopeObjectType, scopeObjectId));
+    for (const key of chunksPageCacheRef.current.keys()) {
+      if (key.startsWith(prefix)) {
+        chunksPageCacheRef.current.delete(key);
+      }
+    }
+  }
+
+  function resetConfirmedScope() {
+    setConfirmedScope(null);
+    setTargetIndexed(null);
+    setTargetMetadata(null);
+    setSelectedJob(null);
+    setJobLogs([]);
+    setChunks([]);
+    setSelectedChunk(null);
+    setVectorRows([]);
+    setRagRows([]);
+    setVectorSearched(false);
+    setRagSearched(false);
+    setSelectedVectorResult(null);
+    setSelectedRagResult(null);
+    setChatMessages([]);
+    setLastMetadata(null);
+    setRagDiagnostics(null);
+    setLastRagSearchQuery("");
+    setChunkPage((current) => ({ ...current, offset: 0, hasMore: false }));
+  }
+
+  function clearSelectedJob() {
+    setSelectedJob(null);
+    setJobLogs([]);
+    setChunks([]);
+    setSelectedChunk(null);
+    setTargetIndexed(null);
+    setTargetMetadata(null);
+  }
+
+  function toggleSelectedJob(job: RagIndexJobDto) {
+    if (job.jobId === selectedJobIdRef.current) {
+      clearSelectedJob();
+      return;
+    }
+    void handleSelectJob(job);
+  }
+
+  const loadProviders = useCallback(async () => {
+    setError(null);
+    try {
+      const data = await reactAiApi.fetchProviders();
+      setAiInfo(data);
+      setProvider(data.defaultProvider);
+      const match = data.providers.find((item) => item.name === data.defaultProvider);
+      setModel(match?.chat.model ?? "");
+    } catch (loadError) {
+      setError(resolveAxiosError(loadError));
+    }
   }, []);
 
-  const columnDefs = useMemo<ColDef<VectorSearchResultDto>[]>(
+  const loadObjectTypes = useCallback(async () => {
+    try {
+      setObjectTypes(await reactObjectTypeApi.list({ status: "ACTIVE" }));
+    } catch {
+      setObjectTypes([]);
+    }
+  }, []);
+
+  const loadJobs = useCallback(async () => {
+    setError(null);
+    setJobsLoading(true);
+    try {
+      const response = await reactAiApi.listRagJobs({
+        status: jobStatusFilter || undefined,
+        offset: 0,
+        limit: 50,
+        sort: "createdAt",
+        direction: "desc",
+      });
+      setJobs(response.items ?? []);
+      setJobsTotal(response.total ?? 0);
+      const selectedJobId = selectedJobIdRef.current;
+      if (selectedJobId && !response.items.some((job) => job.jobId === selectedJobId)) {
+        setSelectedJob(null);
+        setJobLogs([]);
+        setChunks([]);
+      }
+    } catch (loadError) {
+      setError(resolveAxiosError(loadError));
+    } finally {
+      setJobsLoading(false);
+    }
+  }, [jobStatusFilter]);
+
+  useEffect(() => {
+    void loadProviders();
+    void loadObjectTypes();
+  }, [loadObjectTypes, loadProviders]);
+
+  useEffect(() => {
+    void loadJobs();
+  }, [loadJobs]);
+
+  useEffect(() => {
+    selectedJobIdRef.current = selectedJob?.jobId ?? null;
+  }, [selectedJob?.jobId]);
+
+  const loadChunkConfig = useCallback(async () => {
+    setChunkPreviewError(null);
+    try {
+      const config = await reactAiApi.getRagChunkConfig();
+      setChunkConfig(config);
+      const defaultStrategy = config.chunking.previewStrategy || config.chunking.strategy || "";
+      setIndexChunkingStrategy((current) => current || defaultStrategy);
+      setIndexChunkMaxSize((current) => current || String(config.chunking.maxSize));
+      setIndexChunkOverlap((current) => current || String(config.chunking.overlap));
+      setChunkPreviewStrategy((current) => current || defaultStrategy);
+      setChunkPreviewMaxSize((current) => current || String(config.chunking.maxSize));
+      setChunkPreviewOverlap((current) => current || String(config.chunking.overlap));
+    } catch (configError) {
+      setChunkPreviewError(resolveAxiosError(configError));
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadChunkConfig();
+  }, [loadChunkConfig]);
+
+  useEffect(() => {
+    if (!chunkPreviewOpen || chunkConfig) {
+      return;
+    }
+
+    let alive = true;
+    setChunkPreviewError(null);
+    void reactAiApi
+      .getRagChunkConfig()
+      .then((config) => {
+        if (!alive) {
+          return;
+        }
+        setChunkConfig(config);
+        const defaultStrategy = config.chunking.previewStrategy || config.chunking.strategy || "";
+        setIndexChunkingStrategy((current) => current || defaultStrategy);
+        setIndexChunkMaxSize((current) => current || String(config.chunking.maxSize));
+        setIndexChunkOverlap((current) => current || String(config.chunking.overlap));
+        setChunkPreviewStrategy((current) => current || defaultStrategy);
+        setChunkPreviewMaxSize((current) => current || String(config.chunking.maxSize));
+        setChunkPreviewOverlap((current) => current || String(config.chunking.overlap));
+      })
+      .catch((configError) => {
+        if (!alive) {
+          return;
+        }
+        setChunkPreviewError(resolveAxiosError(configError));
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, [chunkConfig, chunkPreviewOpen]);
+
+  async function handleRefresh() {
+    await Promise.all([loadProviders(), loadJobs()]);
+    if (selectedJob) {
+      await handleSelectJob(selectedJob, true);
+    }
+  }
+
+  const vectorColumnDefs = useMemo<ColDef<VectorSearchResultDto>[]>(
     () => [
-      { field: "id", headerName: "ID", flex: 0.5 },
-      { field: "score", headerName: "유사도", flex: 0.3, sortable: true },
+      { field: "id", headerName: "ID", width: 70, flex: 0, filter: false, cellClass: "ag-center-cell" },
+      {
+        field: "score",
+        headerName: "유사도",
+        width: 90,
+        flex: 0,
+        sortable: true,
+        filter: false,
+        cellClass: "ag-center-cell",
+        valueFormatter: (params) =>
+          typeof params.value === "number" ? params.value.toFixed(4) : "-",
+      },
       {
         colId: "objectScope",
         headerName: "객체 범위",
-        flex: 0.6,
+        width: 190,
+        flex: 0,
+        filter: false,
         valueGetter: (params) => {
           const metadata = params.data?.metadata ?? {};
           const type = metadata.objectType;
@@ -69,24 +777,673 @@ export function RagPage() {
           return type || id ? `${type ?? "-"}#${id ?? "-"}` : "-";
         },
       },
-      { field: "content", headerName: "콘텐츠", flex: 1.3 },
+      {
+        colId: "chunkOrder",
+        headerName: "Chunk",
+        width: 80,
+        flex: 0,
+        filter: false,
+        cellClass: "ag-center-cell",
+        valueGetter: (params) => formatChunkValue(params.data?.metadata),
+        tooltipValueGetter: (params) => formatChunkTooltip(params.data?.metadata),
+      },
+      { field: "content", headerName: "콘텐츠", flex: 1, minWidth: 420, filter: false },
     ],
     []
   );
 
-  async function handleSearch(usingExpandedQuery = false) {
+  const ragColumnDefs = useMemo<ColDef<SearchResultDto>[]>(
+    () => [
+      { field: "documentId", headerName: "Document", width: 120, flex: 0, filter: false },
+      {
+        field: "score",
+        headerName: "유사도",
+        width: 90,
+        flex: 0,
+        sortable: true,
+        filter: false,
+        cellClass: "ag-center-cell",
+        valueFormatter: (params) =>
+          typeof params.value === "number" ? params.value.toFixed(4) : "-",
+      },
+      {
+        colId: "objectScope",
+        headerName: "객체 범위",
+        width: 190,
+        flex: 0,
+        filter: false,
+        valueGetter: (params) => {
+          const metadata = params.data?.metadata ?? {};
+          const type = metadata.objectType;
+          const id = metadata.objectId;
+          return type || id ? `${type ?? "-"}#${id ?? "-"}` : "-";
+        },
+      },
+      {
+        colId: "chunkOrder",
+        headerName: "Chunk",
+        width: 80,
+        flex: 0,
+        filter: false,
+        cellClass: "ag-center-cell",
+        valueGetter: (params) => formatChunkValue(params.data?.metadata),
+        tooltipValueGetter: (params) => formatChunkTooltip(params.data?.metadata),
+      },
+      { field: "content", headerName: "콘텐츠", flex: 1, minWidth: 420, filter: false },
+    ],
+    []
+  );
+
+  const jobColumnDefs = useMemo<ColDef<RagIndexJobDto>[]>(
+    () => [
+      {
+        colId: "selection",
+        headerName: "",
+        width: 44,
+        minWidth: 44,
+        maxWidth: 44,
+        pinned: "left",
+        sortable: false,
+        filter: false,
+        resizable: false,
+        suppressMovable: true,
+        lockPosition: true,
+        cellClass: "selection-column-centered",
+        headerClass: "selection-column-centered",
+        cellRenderer: (params: ICellRendererParams<RagIndexJobDto>) => {
+          const checked = params.data?.jobId === selectedJob?.jobId;
+
+          return (
+            <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
+              <JobSelectionToggle
+                checked={checked}
+                onToggle={() => {
+                  if (!params.data) {
+                    return;
+                  }
+                  toggleSelectedJob(params.data);
+                }}
+              />
+            </Box>
+          );
+        },
+      },
+      {
+        field: "status",
+        headerName: "상태",
+        width: 120,
+        filter: false,
+        cellRenderer: (params: { value?: RagIndexJobStatus }) => (
+          <Chip size="small" color={statusColor(params.value)} label={params.value ?? "-"} />
+        ),
+      },
+      { field: "currentStep", headerName: "단계", width: 120, filter: false },
+      { field: "objectType", headerName: "객체 유형", width: 130, filter: false },
+      { field: "objectId", headerName: "객체 ID", width: 130, filter: false },
+      { field: "sourceType", headerName: "소스", width: 120, filter: false },
+      {
+        field: "chunkCount",
+        headerName: "Chunk",
+        width: 100,
+        filter: false,
+        type: "numericColumn",
+      },
+      {
+        field: "warningCount",
+        headerName: "경고",
+        width: 90,
+        filter: false,
+        type: "numericColumn",
+      },
+      {
+        field: "durationMs",
+        headerName: "소요",
+        width: 110,
+        filter: false,
+        valueFormatter: (params) =>
+          typeof params.value === "number" ? `${params.value.toLocaleString()}ms` : "-",
+      },
+      {
+        field: "createdAt",
+        headerName: "생성일시",
+        width: 190,
+        filter: false,
+        valueFormatter: (params) => formatDateTime(params.value as string | undefined),
+      },
+      {
+        field: "errorMessage",
+        headerName: "오류",
+        flex: 1.4,
+        minWidth: 220,
+        filter: false,
+        tooltipField: "errorMessage",
+        cellRenderer: ErrorMessageCell,
+      },
+    ],
+    [selectedJob?.jobId]
+  );
+
+  const jobGridOptions = useMemo<GridOptions<RagIndexJobDto>>(
+    () => ({
+      getRowId: (params) => params.data.jobId,
+      suppressRowClickSelection: true,
+      rowClassRules: {
+        "rag-job-row-selected": (params) => params.data?.jobId === selectedJob?.jobId,
+      },
+    }),
+    [selectedJob?.jobId]
+  );
+
+  const chunkColumnDefs = useMemo<ColDef<RagIndexChunkDto>[]>(
+    () => [
+      { field: "chunkOrder", headerName: "순서", width: 90, filter: false },
+      { field: "chunkId", headerName: "Chunk ID", width: 180, filter: false },
+      { field: "documentId", headerName: "Document", width: 160, filter: false },
+      {
+        field: "score",
+        headerName: "점수",
+        width: 100,
+        filter: false,
+        valueFormatter: (params) =>
+          typeof params.value === "number" ? params.value.toFixed(4) : "-",
+      },
+      { field: "headingPath", headerName: "위치", width: 180, filter: false },
+      { field: "content", headerName: "콘텐츠", flex: 1.4, filter: false },
+    ],
+    []
+  );
+
+  const chunkGridOptions = useMemo<GridOptions<RagIndexChunkDto>>(
+    () => ({
+      getRowId: (params) => chunkRowKey(params.data),
+      rowSelection: {
+        mode: "singleRow",
+        enableClickSelection: false,
+        checkboxes: false,
+      },
+      suppressRowClickSelection: true,
+      rowClassRules: {
+        "rag-chunk-row-selected": (params) => chunkRowKey(params.data) === chunkRowKey(selectedChunk),
+      },
+    }),
+    [selectedChunk]
+  );
+
+  const chunkPreviewColumnDefs = useMemo<ColDef<RagChunkPreviewItemDto>[]>(
+    () => [
+      { field: "chunkOrder", headerName: "순서", width: 90, filter: false },
+      { field: "chunkId", headerName: "Chunk ID", width: 180, filter: false },
+      { field: "chunkType", headerName: "유형", width: 110, filter: false },
+      { field: "contentLength", headerName: "길이", width: 90, filter: false, type: "numericColumn" },
+      { field: "headingPath", headerName: "위치", width: 180, filter: false },
+      { field: "content", headerName: "미리보기", flex: 1.4, filter: false },
+    ],
+    []
+  );
+
+  const logColumnDefs = useMemo<ColDef<RagIndexJobLogDto>[]>(
+    () => [
+      {
+        field: "level",
+        headerName: "레벨",
+        width: 100,
+        filter: false,
+        cellRenderer: (params: { value?: string }) => (
+          <Chip
+            size="small"
+            color={params.value === "ERROR" ? "error" : params.value === "WARN" ? "warning" : "default"}
+            label={params.value ?? "-"}
+          />
+        ),
+      },
+      { field: "step", headerName: "단계", width: 120, filter: false },
+      { field: "code", headerName: "코드", width: 200, filter: false },
+      { field: "message", headerName: "메시지", flex: 1, filter: false },
+      { field: "detail", headerName: "상세", flex: 1, filter: false },
+      {
+        field: "createdAt",
+        headerName: "생성일시",
+        width: 190,
+        filter: false,
+        valueFormatter: (params) => formatDateTime(params.value as string | undefined),
+      },
+    ],
+    []
+  );
+
+  function resolveScope() {
+    if (confirmedScope) {
+      return {
+        objectType: resolveObjectTypeValue(confirmedScope.objectType),
+        objectId: confirmedScope.objectId,
+      };
+    }
+    const scopedAttachmentId = attachmentId.trim();
+    const scopedObjectType = resolveObjectTypeValue(objectType);
+    return {
+      objectType: scopedObjectType || (scopedAttachmentId ? "attachment" : undefined),
+      objectId: objectId.trim() || scopedAttachmentId || undefined,
+    };
+  }
+
+  function resolveAttachmentIdForIndexing() {
+    if (confirmedScope?.attachmentId) {
+      return confirmedScope.attachmentId;
+    }
+
+    const trimmedDocumentId = documentId.trim();
+    if (
+      selectedJob?.sourceType === "attachment" &&
+      isPositiveIntegerText(trimmedDocumentId)
+    ) {
+      return trimmedDocumentId;
+    }
+
+    if (
+      selectedJob?.sourceType === "attachment" &&
+      selectedJob.objectType === "attachment" &&
+      isPositiveIntegerText(selectedJob.objectId)
+    ) {
+      return selectedJob.objectId;
+    }
+
+    return "";
+  }
+
+  function markValidated() {
+    setLastValidatedAt(new Date().toLocaleString());
+  }
+
+  function activateValidationTab(nextTab: ValidationTab) {
+    setTab(nextTab);
+    if (nextTab === "chat" && ragRows.length > 0 && chatMessages.length === 0) {
+      void handleRagChat();
+    }
+    window.requestAnimationFrame(() => {
+      validationSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
+  }
+
+  async function loadObjectMetadata(scopeObjectType?: string, scopeObjectId?: string, force = false) {
+    if (!scopeObjectType || !scopeObjectId) {
+      return;
+    }
+    const cacheKey = objectCacheKey(scopeObjectType, scopeObjectId);
+    if (!force && objectMetadataCacheRef.current.has(cacheKey)) {
+      setTargetMetadata(objectMetadataCacheRef.current.get(cacheKey) ?? null);
+      return;
+    }
+    try {
+      const metadata = await reactAiApi.getRagObjectMetadata(scopeObjectType, scopeObjectId);
+      objectMetadataCacheRef.current.set(cacheKey, metadata);
+      setTargetMetadata(metadata);
+    } catch {
+      // Metadata endpoint can be unavailable for stores that do not support it.
+    }
+  }
+
+  async function loadChunks(scopeObjectType?: string, scopeObjectId?: string, offset = 0, force = false) {
+    if (!scopeObjectType || !scopeObjectId) {
+      setChunks([]);
+      setSelectedChunk(null);
+      return;
+    }
+    const cacheKey = chunksCacheKey(scopeObjectType, scopeObjectId, offset, chunkPage.limit);
+    if (!force && chunksPageCacheRef.current.has(cacheKey)) {
+      const cached = chunksPageCacheRef.current.get(cacheKey);
+      if (cached) {
+        setChunks(cached.items ?? []);
+        setSelectedChunk(cached.items?.[0] ?? null);
+        setChunkPage({
+          offset: cached.offset,
+          limit: cached.limit,
+          hasMore: cached.hasMore,
+        });
+        return;
+      }
+    }
+    setChunksLoading(true);
+    try {
+      const response = await reactAiApi.getRagObjectChunksPage(scopeObjectType, scopeObjectId, offset, chunkPage.limit);
+      chunksPageCacheRef.current.set(cacheKey, response);
+      setChunks(response.items ?? []);
+      setSelectedChunk(response.items?.[0] ?? null);
+      setChunkPage({
+        offset: response.offset,
+        limit: response.limit,
+        hasMore: response.hasMore,
+      });
+    } finally {
+      setChunksLoading(false);
+    }
+  }
+
+  async function handleSelectJob(job: RagIndexJobDto, force = false) {
+    const jobAttachmentId = inferAttachmentIdFromJob(job);
+    const alreadySelected = selectedJobIdRef.current === job.jobId;
+    setSelectedJob(job);
+    setObjectType(job.objectType);
+    setObjectId(job.objectId);
+    setAttachmentId(jobAttachmentId ?? "");
+    setDocumentId(job.documentId ?? "");
+    setConfirmedScope({
+      objectType: job.objectType,
+      objectId: job.objectId,
+      attachmentId: jobAttachmentId,
+    });
+    setTargetIndexed(job.status === "SUCCEEDED" || job.status === "WARNING");
+    setTargetMetadata(null);
+    setError(null);
+    if (!force && alreadySelected && jobLogsCacheRef.current.has(job.jobId)) {
+      setJobLogs(jobLogsCacheRef.current.get(job.jobId) ?? []);
+      await Promise.all([
+        loadChunks(job.objectType, job.objectId, 0),
+        loadObjectMetadata(job.objectType, job.objectId),
+      ]);
+      return;
+    }
+    setLogsLoading(true);
+    try {
+      const logsPromise = !force && jobLogsCacheRef.current.has(job.jobId)
+        ? Promise.resolve(jobLogsCacheRef.current.get(job.jobId) ?? [])
+        : reactAiApi.getRagJobLogs(job.jobId);
+      const [logs] = await Promise.all([
+        logsPromise,
+        loadChunks(job.objectType, job.objectId, 0, force),
+        loadObjectMetadata(job.objectType, job.objectId, force),
+      ]);
+      jobLogsCacheRef.current.set(job.jobId, logs ?? []);
+      setJobLogs(logs ?? []);
+    } catch (selectError) {
+      setError(resolveAxiosError(selectError));
+    } finally {
+      setLogsLoading(false);
+    }
+  }
+
+  async function handleCreateJob() {
+    const scope = confirmedScope;
+    setError(null);
+
+    if (!scope?.objectType || !scope.objectId) {
+      setError("먼저 색인 대상을 상태 확인으로 확정하세요.");
+      return;
+    }
+    if (!scope.attachmentId && !indexText.trim()) {
+      setError("직접 색인 텍스트를 입력하거나 attachmentId를 입력해야 job을 생성할 수 있습니다.");
+      return;
+    }
+
+    try {
+      const job = await reactAiApi.createRagJob({
+        objectType: scope.objectType,
+        objectId: scope.objectId,
+        documentId: documentId.trim() || undefined,
+        sourceType: scope.attachmentId && !indexText.trim() ? "attachment" : undefined,
+        forceReindex,
+        text: indexText.trim() || undefined,
+        useLlmKeywordExtraction: true,
+        ...indexChunkingOptions(),
+      });
+      setSelectedJob(job);
+      await loadJobs();
+      clearObjectInspectionCache(job.objectType, job.objectId);
+      jobLogsCacheRef.current.delete(job.jobId);
+      await handleSelectJob(job, true);
+    } catch (createError) {
+      setError(resolveAxiosError(createError));
+    }
+  }
+
+  async function handleRetryJob() {
+    if (!selectedJob) {
+      return;
+    }
     setError(null);
     try {
-      const data = await reactAiApi.searchVector({
-        query: usingExpandedQuery ? expandedQuery : query,
-        topK: Number(topK) || 3,
-        hybrid: true,
-        objectType: objectType.trim() || undefined,
-        objectId: objectId.trim() || undefined,
+      const job = await reactAiApi.retryRagJob(selectedJob.jobId);
+      await loadJobs();
+      clearObjectInspectionCache(job.objectType, job.objectId);
+      jobLogsCacheRef.current.delete(job.jobId);
+      await handleSelectJob(job, true);
+    } catch (retryError) {
+      setError(resolveAxiosError(retryError));
+    }
+  }
+
+  async function handleCancelJob() {
+    if (!selectedJob) {
+      return;
+    }
+    setError(null);
+    try {
+      const job = await reactAiApi.cancelRagJob(selectedJob.jobId);
+      await loadJobs();
+      jobLogsCacheRef.current.delete(job.jobId);
+      await handleSelectJob(job, true);
+    } catch (cancelError) {
+      setError(resolveAxiosError(cancelError));
+    }
+  }
+
+  async function handleCheckTarget() {
+    const numericAttachmentId = Number(attachmentId);
+    const scopedObjectType = resolveObjectTypeValue(objectType);
+    const scopedObjectId = objectId.trim();
+    setError(null);
+    setTargetIndexed(null);
+    setTargetMetadata(null);
+
+    if (
+      !attachmentId.trim()
+      && (!scopedObjectType || !scopedObjectId)
+    ) {
+      setError("attachmentId 또는 objectType/objectId를 입력한 뒤 상태를 확인하세요.");
+      return;
+    }
+
+    try {
+      if (attachmentId.trim()) {
+        if (!Number.isFinite(numericAttachmentId) || numericAttachmentId <= 0) {
+          setError("attachmentId는 1 이상의 숫자여야 합니다.");
+          return;
+        }
+        const attachment = await reactFilesApi.getById(numericAttachmentId);
+        const nextScope = {
+          objectType: scopedObjectType || String(attachment.objectType),
+          objectId: scopedObjectId || String(attachment.objectId),
+          attachmentId: String(numericAttachmentId),
+        };
+        const indexed = await reactFilesApi.hasEmbedding(numericAttachmentId);
+        setTargetIndexed(indexed);
+        setObjectType(nextScope.objectType);
+        setObjectId(nextScope.objectId);
+        setDocumentId((current) => current || String(numericAttachmentId));
+        setConfirmedScope(nextScope);
+        setTargetMetadata(indexed ? await reactFilesApi.ragMetadata(numericAttachmentId) : null);
+        await loadChunks(nextScope.objectType, nextScope.objectId, 0);
+      } else {
+        const nextScope = {
+          objectType: scopedObjectType,
+          objectId: scopedObjectId,
+        };
+        setConfirmedScope(nextScope);
+        await Promise.all([
+          loadObjectMetadata(nextScope.objectType, nextScope.objectId),
+          loadChunks(nextScope.objectType, nextScope.objectId, 0),
+        ]);
+      }
+      markValidated();
+    } catch (checkError) {
+      setError(resolveAxiosError(checkError));
+    }
+  }
+
+  async function handleIndexAttachment() {
+    setError(null);
+
+    if (!confirmedScope?.attachmentId) {
+      setError("먼저 attachmentId를 상태 확인으로 확정하세요.");
+      return;
+    }
+
+    try {
+      const job = await reactAiApi.createRagJob({
+        objectType: confirmedScope.objectType,
+        objectId: confirmedScope.objectId,
+        documentId: documentId.trim() || confirmedScope.attachmentId,
+        sourceType: "attachment",
+        forceReindex,
+        metadata: {
+          attachmentId: confirmedScope.attachmentId,
+        },
+        useLlmKeywordExtraction: true,
+        ...indexChunkingOptions(),
       });
-      setRows(data);
+      setSelectedJob(job);
+      await loadJobs();
+      clearObjectInspectionCache(job.objectType, job.objectId);
+      jobLogsCacheRef.current.delete(job.jobId);
+      await handleSelectJob(job, true);
+    } catch (indexError) {
+      setError(resolveAxiosError(indexError));
+    }
+  }
+
+  async function handleForceReindexTarget() {
+    setError(null);
+
+    const attachmentIdForIndexing = resolveAttachmentIdForIndexing();
+    if (!confirmedScope || !attachmentIdForIndexing) {
+      setError("강제 재색인은 attachmentId가 확정된 대상에서만 실행할 수 있습니다.");
+      return;
+    }
+
+    try {
+      const job = await reactAiApi.createRagJob({
+        objectType: resolveObjectTypeValue(confirmedScope.objectType),
+        objectId: confirmedScope.objectId,
+        documentId: documentId.trim() || attachmentIdForIndexing,
+        sourceType: "attachment",
+        forceReindex: true,
+        metadata: {
+          attachmentId: attachmentIdForIndexing,
+        },
+        useLlmKeywordExtraction: true,
+        ...indexChunkingOptions(),
+      });
+      setSelectedJob(job);
+      await loadJobs();
+      clearObjectInspectionCache(job.objectType, job.objectId);
+      jobLogsCacheRef.current.delete(job.jobId);
+      await handleSelectJob(job, true);
+    } catch (indexError) {
+      setError(resolveAxiosError(indexError));
+    }
+  }
+
+  async function handleVectorSearch(usingExpandedQuery = false) {
+    const searchQuery = (usingExpandedQuery ? expandedQuery : query).trim();
+    const scope = resolveScope();
+    setError(null);
+
+    if (!searchQuery) {
+      return [];
+    }
+
+    setVectorSearched(true);
+    setVectorRows([]);
+    setSelectedVectorResult(null);
+    setVectorLoading(true);
+    try {
+      const data = await reactAiApi.searchVector({
+        query: searchQuery,
+        topK: Number(topK) || 5,
+        hybrid: true,
+        minScore: minScore.trim() ? Number(minScore) : undefined,
+        objectType: scope.objectType,
+        objectId: scope.objectId,
+      });
+      setVectorRows(data);
+      setSelectedVectorResult(data[0] ?? null);
+      markValidated();
+      return data;
     } catch (searchError) {
       setError(resolveAxiosError(searchError));
+      return [];
+    } finally {
+      setVectorLoading(false);
+    }
+  }
+
+  async function handleRagSearch(usingExpandedQuery = false) {
+    const scope = resolveScope();
+    const searchQuery = (usingExpandedQuery ? expandedQuery : query).trim();
+    setError(null);
+
+    if (!searchQuery) {
+      return [];
+    }
+
+    setRagSearched(true);
+    setRagRows([]);
+    setSelectedRagResult(null);
+    setChatMessages([]);
+    setLastMetadata(null);
+    setRagDiagnostics(null);
+    setLastRagSearchQuery("");
+    setRagLoading(true);
+    try {
+      const data = await reactAiApi.searchRag({
+        query: searchQuery,
+        topK: Number(topK) || 5,
+        objectType: scope.objectType,
+        objectId: scope.objectId,
+      });
+      setRagRows(data);
+      setLastRagSearchQuery(searchQuery);
+      setSelectedRagResult(data[0] ?? null);
+      setChatMessages([]);
+      setLastMetadata(null);
+      setRagDiagnostics(null);
+      markValidated();
+      return data;
+    } catch (searchError) {
+      setError(resolveAxiosError(searchError));
+      return [];
+    } finally {
+      setRagLoading(false);
+    }
+  }
+
+  function handleDefaultSearch(usingExpandedQuery = false) {
+    setTab("vector");
+    void handleVectorSearch(usingExpandedQuery);
+  }
+
+  async function handleValidationTabChange(value: ValidationTab) {
+    setTab(value);
+    if (!query.trim()) {
+      return;
+    }
+    if (value === "rag" && ragRows.length === 0) {
+      await handleRagSearch(false);
+    }
+    if (value === "vector" && vectorRows.length === 0) {
+      await handleVectorSearch(false);
+    }
+    if (value === "chat" && ragRows.length > 0 && chatMessages.length === 0) {
+      await handleRagChat();
+      return;
+    }
+    if (value === "chat" && ragRows.length === 0) {
+      const rows = await handleRagSearch(false);
+      if (rows.length > 0) {
+        await handleRagChat(rows);
+      }
     }
   }
 
@@ -101,33 +1458,52 @@ export function RagPage() {
     }
   }
 
-  async function handleRagChat() {
-    const trimmed = chatInput.trim();
-    if (!trimmed) {
+  async function handleRagChat(contextRows = ragRows) {
+    if (chatLoading) {
       return;
     }
 
+    const trimmed = chatInput.trim() || lastRagSearchQuery.trim() || query.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (contextRows.length === 0) {
+      setError("먼저 RAG 결과를 조회한 뒤 답변을 생성하세요.");
+      return;
+    }
+
+    const scope = resolveScope();
+    const ragTopK = Number(topK) || 5;
+    const visibleRagContext = buildVisibleRagContext(contextRows, ragTopK);
     const nextMessages: ChatMessageDto[] = [
-      ...chatMessages,
       { role: "user", content: trimmed },
     ];
 
+    setLastMetadata(null);
     setChatMessages(nextMessages);
     setChatInput("");
     setRagDiagnostics(null);
     setError(null);
 
+    setChatLoading(true);
     try {
       const response = await reactAiApi.sendRagChat({
         chat: {
           provider: provider || undefined,
           model: model || undefined,
+          systemPrompt:
+            [
+              "제공된 RAG 문서 내용에 근거해서만 답변하세요. 문서에서 확인할 수 없는 내용은 확인할 수 없다고 답변하세요.",
+              visibleRagContext
+                ? `아래는 현재 화면의 RAG 결과 탭에 표시된 후보 문맥입니다. 이 문맥을 우선 근거로 사용하세요.\n${visibleRagContext}`
+                : "",
+            ].filter(Boolean).join("\n\n"),
           messages: nextMessages,
         },
-        ragQuery: expandedQuery.trim() || query.trim() || trimmed,
-        ragTopK: Number(topK) || 3,
-        objectType: objectType.trim() || undefined,
-        objectId: objectId.trim() || undefined,
+        ragQuery: lastRagSearchQuery.trim() || trimmed,
+        ragTopK,
+        objectType: scope.objectType,
+        objectId: scope.objectId,
         debug,
       });
 
@@ -138,26 +1514,876 @@ export function RagPage() {
       if (assistant) {
         setChatMessages((current) => [...current, assistant]);
       }
-      setRagDiagnostics(
-        (response.metadata?.ragDiagnostics as Record<string, unknown> | undefined) ?? null
-      );
+      setLastMetadata(response.metadata ?? null);
+      setRagDiagnostics(extractRagDiagnostics(response.metadata));
+      markValidated();
     } catch (chatError) {
       setError(resolveAxiosError(chatError));
+    } finally {
+      setChatLoading(false);
     }
   }
 
+  function handleOpenChunkPreview() {
+    setChunkPreviewOpen(true);
+    setChunkPreviewError(null);
+    setChunkPreviewRows([]);
+    setSelectedPreviewChunk(null);
+    setChunkPreviewSummary(null);
+    if (!chunkPreviewText.trim() && indexText.trim()) {
+      setChunkPreviewText(indexText);
+    }
+  }
+
+  function optionalNumber(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const numberValue = Number(trimmed);
+    return Number.isFinite(numberValue) ? numberValue : undefined;
+  }
+
+  function indexChunkingOptions() {
+    const strategy = indexChunkingStrategy.trim();
+    const usesSizing = chunkStrategyUsesSizing(strategy);
+    return {
+      chunkingStrategy: strategy || undefined,
+      chunkMaxSize: usesSizing ? optionalNumber(indexChunkMaxSize) : undefined,
+      chunkOverlap: usesSizing ? optionalNumber(indexChunkOverlap) : undefined,
+      chunkUnit: indexChunkUnit.trim() || undefined,
+    };
+  }
+
+  async function handlePreviewChunks() {
+    const text = chunkPreviewText.trim();
+    if (!text) {
+      setChunkPreviewError("미리보기할 텍스트를 입력하세요.");
+      return;
+    }
+
+    setChunkPreviewLoading(true);
+    setChunkPreviewError(null);
+    try {
+      const response = await reactAiApi.previewRagChunks({
+        text,
+        documentId: documentId.trim() || undefined,
+        objectType: confirmedScope?.objectType ?? (objectType.trim() || undefined),
+        objectId: confirmedScope?.objectId ?? (objectId.trim() || undefined),
+        strategy: chunkPreviewStrategy || undefined,
+        maxSize: chunkPreviewUsesSizing ? optionalNumber(chunkPreviewMaxSize) : undefined,
+        overlap: chunkPreviewUsesSizing ? optionalNumber(chunkPreviewOverlap) : undefined,
+      });
+      setChunkPreviewRows(response.chunks ?? []);
+      setSelectedPreviewChunk(response.chunks?.[0] ?? null);
+      setChunkPreviewSummary({
+        totalChunks: response.totalChunks,
+        totalChars: response.totalChars,
+        strategy: response.strategy,
+        maxSize: response.maxSize,
+        overlap: response.overlap,
+        unit: response.unit,
+        warnings: response.warnings ?? [],
+      });
+    } catch (previewError) {
+      setChunkPreviewError(resolveAxiosError(previewError));
+    } finally {
+      setChunkPreviewLoading(false);
+    }
+  }
+
+  function handleStartNewIndexJob() {
+    resetConfirmedScope();
+    window.requestAnimationFrame(() => {
+      targetSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
+  }
+
   return (
-    <Stack spacing={1}>
+    <Stack spacing={1.5}>
       <PageToolbar
-        divider={false}
         breadcrumbs={["서비스 관리", "AI", "RAG"]}
-        label="문서 벡터 검색과 RAG Chat 요청을 수행합니다."
+        label="색인 작업을 선택해 Chunk, 로그, 검색 결과와 답변을 검증합니다."
+        onRefresh={() => void handleRefresh()}
+        actions={
+          <Stack direction="row" spacing={0.75} alignItems="center">
+            <Tooltip title="attachment 또는 텍스트 기준으로 새 RAG 색인 작업을 생성합니다.">
+              <Button size="small" variant="contained" onClick={handleStartNewIndexJob}>
+                새 색인 작업
+              </Button>
+            </Tooltip>
+            <Tooltip title="현재 청킹 설정과 텍스트 Chunk 결과를 색인 없이 미리 확인합니다.">
+              <Button size="small" variant="outlined" onClick={handleOpenChunkPreview}>
+                청킹 시뮬레이션
+              </Button>
+            </Tooltip>
+          </Stack>
+        }
       />
+
       {error ? <Alert severity="error">{error}</Alert> : null}
-      <Card variant="outlined">
+
+      <Stack spacing={1.5} sx={{ width: "100%" }}>
+      <Box
+        ref={statusSectionRef}
+        sx={{
+          scrollMarginTop: 56,
+        }}
+      >
+        <Card sx={{ border: 0, boxShadow: "none", bgcolor: "transparent" }}>
+          <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
+            <Stack spacing={1.5}>
+              <Box
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(4, 1fr)" },
+                  gap: 1,
+                }}
+              >
+                <SummaryStatusCard
+                  title="임베딩 모델"
+                  value={currentProvider?.embedding.model ?? "Embedding 없음"}
+                />
+                <SummaryStatusCard
+                  title="벡터 저장소"
+                  value={vectorReady ? aiInfo?.vector.implementation ?? "사용 가능" : "확인 필요"}
+                />
+                <SummaryStatusCard
+                  title="채팅 모델"
+                  value={model || "모델 정보 없음"}
+                />
+                <SummaryStatusCard
+                  title="청킹 모델"
+                  value={
+                    chunkConfig
+                      ? `${chunkConfig.chunking.strategy} · size ${chunkConfig.chunking.maxSize} / overlap ${chunkConfig.chunking.overlap}`
+                      : "청킹 정보 없음"
+                  }
+                />
+              </Box>
+            </Stack>
+          </CardContent>
+        </Card>
+      </Box>
+
+      <Stack spacing={1.5}>
+        <Card variant="outlined" ref={targetSectionRef} sx={{ scrollMarginTop: 56, borderRadius: 2, order: 2 }}>
+          <CardContent>
+            <Stack spacing={1.5}>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <StorageOutlined fontSize="small" color="primary" />
+                <Typography variant="subtitle2">새 색인 작업</Typography>
+              </Stack>
+              <Stepper
+                activeStep={workflowActiveStep}
+                sx={{
+                  opacity: hasConfirmedScope ? 1 : 0.55,
+                  "& .MuiStepLabel-label": { typography: "caption" },
+                }}
+              >
+                <Step completed={hasConfirmedScope}>
+                  <StepLabel>대상 확정</StepLabel>
+                </Step>
+                <Step completed={Boolean(selectedJobSucceeded)}>
+                  <StepLabel>색인 실행</StepLabel>
+                </Step>
+                <Step completed={Boolean(selectedJobSucceeded && hasJobInspection)}>
+                  <StepLabel>작업 확인</StepLabel>
+                </Step>
+                <Step completed={Boolean(selectedJobSucceeded && hasSearchResult)}>
+                  <StepLabel>검색 검증</StepLabel>
+                </Step>
+              </Stepper>
+              <Alert
+                severity={selectedJobFailed ? "error" : hasConfirmedScope ? "success" : "info"}
+                action={
+                  hasConfirmedScope ? (
+                    <Button color="inherit" size="small" onClick={resetConfirmedScope}>
+                      대상 변경
+                    </Button>
+                  ) : undefined
+                }
+              >
+                {selectedJobFailed && confirmedScope
+                  ? `선택한 job이 실패했습니다. 대상: ${formatObjectTypeLabel(confirmedScope.objectType)} / ${confirmedScope.objectId}`
+                  : confirmedScope
+                    ? `확정된 대상: ${formatObjectTypeLabel(confirmedScope.objectType)} / ${confirmedScope.objectId}${
+                        lastValidatedAt ? ` · 확인 ${lastValidatedAt}` : ""
+                      }`
+                  : "먼저 attachmentId 또는 objectType/objectId를 입력하고 상태 확인으로 색인 대상을 확정하세요. 대상이 확정되기 전에는 색인 실행과 Chunk 조회가 비활성화됩니다."}
+              </Alert>
+              {!confirmedScope ? (
+                <>
+                  <Stack direction={{ xs: "column", md: "row" }} spacing={1.5}>
+                    <TextField
+                      label="attachmentId"
+                      value={attachmentId}
+                      onChange={(event) => {
+                        setAttachmentId(event.target.value);
+                        resetConfirmedScope();
+                      }}
+                      placeholder="예: 123"
+                      fullWidth
+                      size="small"
+                    />
+                    <Autocomplete<ObjectTypeOption, false, false, true>
+                      freeSolo
+                      size="small"
+                      fullWidth
+                      options={objectTypeOptions}
+                      value={selectedObjectTypeOption ?? objectType}
+                      inputValue={selectedObjectTypeOption?.label ?? objectType}
+                      onInputChange={(_, value, reason) => {
+                        if (reason === "input") {
+                          setObjectType(resolveObjectTypeValue(value));
+                          resetConfirmedScope();
+                        }
+                        if (reason === "clear") {
+                          setObjectType("");
+                          resetConfirmedScope();
+                        }
+                      }}
+                      onChange={(_, value) => {
+                        if (typeof value === "string") {
+                          setObjectType(resolveObjectTypeValue(value));
+                          resetConfirmedScope();
+                          return;
+                        }
+                        setObjectType(value?.value ?? "");
+                        resetConfirmedScope();
+                      }}
+                      getOptionLabel={(option) => (typeof option === "string" ? option : option.label)}
+                      isOptionEqualToValue={(option, value) =>
+                        typeof value !== "string" && option.value === value.value
+                      }
+                      renderOption={(props, option) => (
+                        <Box component="li" {...props} key={option.value}>
+                          <Stack spacing={0}>
+                            <Typography variant="body2">{option.label}</Typography>
+                            <Typography variant="caption" color="text.secondary">
+                              {option.name}
+                            </Typography>
+                          </Stack>
+                        </Box>
+                      )}
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label="objectType"
+                          placeholder="정책 오브젝트 타입 선택 또는 attachment 직접 입력"
+                          helperText="정책 > 오브젝트 타입의 ACTIVE 항목을 선택할 수 있습니다."
+                        />
+                      )}
+                    />
+                    <TextField
+                      label="objectId"
+                      value={objectId}
+                      onChange={(event) => {
+                        setObjectId(event.target.value);
+                        resetConfirmedScope();
+                      }}
+                      placeholder="예: 123"
+                      fullWidth
+                      size="small"
+                    />
+                    <TextField
+                      label="documentId"
+                      value={documentId}
+                      onChange={(event) => setDocumentId(event.target.value)}
+                      placeholder="예: doc-123"
+                      fullWidth
+                      size="small"
+                    />
+                  </Stack>
+                </>
+              ) : null}
+              {confirmedScope && !selectedJob ? (
+                <TextField
+                  label="직접 색인 텍스트"
+                  value={indexText}
+                  onChange={(event) => setIndexText(event.target.value)}
+                  placeholder="attachment source 대신 직접 텍스트를 색인할 때 입력합니다."
+                  multiline
+                  minRows={3}
+                  size="small"
+                />
+              ) : null}
+              {confirmedScope ? (
+                <Box
+                  sx={{
+                    display: "grid",
+                    gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(4, 1fr)" },
+                    gap: 1,
+                  }}
+                >
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      Object Type
+                    </Typography>
+                    <Typography variant="body2" fontWeight={600} noWrap>
+                      {formatObjectTypeLabel(confirmedScope.objectType)}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      Object ID
+                    </Typography>
+                    <Typography variant="body2" fontWeight={600} noWrap>
+                      {confirmedScope.objectId}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      Document
+                    </Typography>
+                    <Typography variant="body2" fontWeight={600} noWrap>
+                      {documentId || "-"}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      선택 작업
+                    </Typography>
+                    {selectedJob ? (
+                      <Stack direction="row" spacing={0.75} alignItems="center">
+                        <Chip size="small" color={statusColor(selectedJob.status)} label={selectedJob.status} />
+                        <Typography variant="body2" fontWeight={600} noWrap>
+                          {selectedJob.currentStep ?? "-"}
+                        </Typography>
+                      </Stack>
+                    ) : (
+                      <Typography variant="body2" fontWeight={600}>
+                        -
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+              ) : null}
+              <Box sx={{ border: 1, borderColor: "divider", borderRadius: 2, p: 1.25 }}>
+                {!confirmedScope ? (
+                  <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="subtitle2">현재 단계: 대상 확정</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        입력한 attachmentId 또는 objectType/objectId의 색인 상태를 확인해 작업 대상을 확정합니다.
+                      </Typography>
+                    </Box>
+                    <Tooltip
+                      title={
+                        canCheckTarget
+                          ? "입력한 attachmentId 또는 objectType/objectId의 색인 상태와 metadata를 조회하고 작업 대상을 확정합니다."
+                          : "attachmentId 또는 objectType/objectId를 입력하면 활성화됩니다."
+                      }
+                    >
+                      <span>
+                        <Button
+                          variant="contained"
+                          size="small"
+                          disabled={!canCheckTarget}
+                          onClick={() => void handleCheckTarget()}
+                        >
+                          상태 확인
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  </Stack>
+                ) : null}
+
+                {confirmedScope && !selectedJob ? (
+                  <Stack spacing={1}>
+                    <Box>
+                      <Typography variant="subtitle2">현재 단계: 색인 실행</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        확정된 대상에 대해 attachment source 또는 직접 입력 텍스트 기반 색인 Job을 생성합니다.
+                      </Typography>
+                    </Box>
+                    <Accordion variant="outlined" sx={{ borderRadius: 1.5, "&:before": { display: "none" } }}>
+                      <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
+                        <Stack spacing={0.25}>
+                          <Typography variant="body2">운영 색인 청킹 옵션</Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            Job 생성 시 실제 색인 파이프라인에 전달되는 Chunking 옵션입니다.
+                          </Typography>
+                        </Stack>
+                      </AccordionSummary>
+                      <AccordionDetails>
+                        <Stack spacing={1.25}>
+                          <Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+                            <TextField
+                              select
+                              label="청킹 전략"
+                              value={indexChunkingStrategy}
+                              onChange={(event) => setIndexChunkingStrategy(event.target.value)}
+                              size="small"
+                              fullWidth
+                              helperText={chunkStrategyHint(indexChunkingStrategy)}
+                            >
+                              {(chunkConfig?.chunking.availableStrategies ?? ["fixed-size", "recursive", "structure-based"]).map(
+                                (strategy) => (
+                                  <MenuItem key={strategy} value={strategy}>
+                                    {strategy}
+                                  </MenuItem>
+                                )
+                              )}
+                            </TextField>
+                            <TextField
+                              label="Chunk 크기"
+                              value={indexChunkMaxSize}
+                              onChange={(event) => setIndexChunkMaxSize(event.target.value)}
+                              size="small"
+                              fullWidth
+                              disabled={!indexChunkingUsesSizing}
+                              helperText={
+                                indexChunkingUsesSizing
+                                  ? "색인 Chunk 하나의 최대 길이입니다."
+                                  : "선택한 전략에는 적용되지 않습니다."
+                              }
+                            />
+                            <TextField
+                              label="겹침"
+                              value={indexChunkOverlap}
+                              onChange={(event) => setIndexChunkOverlap(event.target.value)}
+                              size="small"
+                              fullWidth
+                              disabled={!indexChunkingUsesSizing}
+                              helperText={
+                                indexChunkingUsesSizing
+                                  ? "앞뒤 Chunk 사이에 다시 포함할 중복 길이입니다."
+                                  : "선택한 전략에는 적용되지 않습니다."
+                              }
+                            />
+                            <TextField
+                              select
+                              label="단위"
+                              value={indexChunkUnit}
+                              onChange={(event) => setIndexChunkUnit(event.target.value)}
+                              size="small"
+                              fullWidth
+                              helperText="크기와 겹침 값을 해석하는 단위입니다."
+                            >
+                              <MenuItem value="character">문자</MenuItem>
+                              <MenuItem value="token">토큰</MenuItem>
+                            </TextField>
+                          </Stack>
+                          <Typography variant="caption" color="text.secondary">
+                            값을 비우면 서버 기본 설정을 사용합니다. 현재 서버 기본값:{" "}
+                            {chunkConfig
+                              ? `${chunkConfig.chunking.strategy}, size ${chunkConfig.chunking.maxSize}, overlap ${chunkConfig.chunking.overlap}`
+                              : "-"}
+                          </Typography>
+                        </Stack>
+                      </AccordionDetails>
+                    </Accordion>
+                    <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+                      {canIndexAttachment ? (
+                        <Tooltip title="확정된 attachmentId 기준으로 파일을 읽고 RAG 색인 작업을 생성합니다.">
+                          <span>
+                            <Button
+                              variant="contained"
+                              size="small"
+                              onClick={() => void handleIndexAttachment()}
+                            >
+                              Attachment 색인
+                            </Button>
+                          </span>
+                        </Tooltip>
+                      ) : (
+                        <Tooltip title={canCreateTextJob ? "입력한 텍스트를 기준으로 RAG 색인 Job을 생성합니다." : "직접 색인 텍스트를 입력해야 합니다."}>
+                          <span>
+                            <Button
+                              variant="contained"
+                              size="small"
+                              startIcon={<PlayArrowOutlined />}
+                              disabled={!canCreateTextJob}
+                              onClick={() => void handleCreateJob()}
+                            >
+                              텍스트 색인
+                            </Button>
+                          </span>
+                        </Tooltip>
+                      )}
+                      <Tooltip title={forceReindex ? "기존 색인이 있어도 다시 색인합니다." : "서버 정책에 따라 중복 색인을 피합니다."}>
+                        <FormControlLabel
+                          sx={{ ml: 0, mr: 0 }}
+                          control={
+                            <Switch
+                              size="small"
+                              checked={forceReindex}
+                              onChange={(event) => setForceReindex(event.target.checked)}
+                            />
+                          }
+                          label={
+                            <Typography variant="body2" color="text.secondary">
+                              강제 재색인
+                            </Typography>
+                          }
+                        />
+                      </Tooltip>
+                    </Stack>
+                  </Stack>
+                ) : null}
+
+                {selectedJob && selectedJobFailed ? (
+                  <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="subtitle2" color="error.main">
+                        현재 단계: 색인 실패
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        선택한 job은 완료되지 않았습니다. 로그의 오류를 확인한 뒤 기존 job을 재시도하거나 확정된 attachment 대상을 강제 재색인하세요.
+                      </Typography>
+                    </Box>
+                    <Tooltip title="선택한 실패/중단 job을 서버 retry 엔드포인트로 다시 실행합니다.">
+                      <span>
+                        <Button size="small" variant="outlined" onClick={() => void handleRetryJob()}>
+                          선택 job 재시도
+                        </Button>
+                      </span>
+                    </Tooltip>
+                    <Tooltip
+                      title={
+                        canForceReindexTarget
+                          ? "확정된 attachment 대상의 색인을 force=true로 새 job을 생성해 다시 만듭니다."
+                          : "attachmentId가 확정된 대상에서 사용할 수 있습니다."
+                      }
+                    >
+                      <span>
+                        <Button
+                          size="small"
+                          variant="contained"
+                          color="warning"
+                          disabled={!canForceReindexTarget}
+                          onClick={() => void handleForceReindexTarget()}
+                        >
+                          강제 재색인
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  </Stack>
+                ) : null}
+
+                {selectedJob && !selectedJobFailed && !hasJobInspection ? (
+                  <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="subtitle2">현재 단계: 작업 확인</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        생성 또는 선택한 작업의 로그와 Chunk 조각을 조회합니다.
+                      </Typography>
+                    </Box>
+                    <Tooltip title="선택한 작업 대상의 생성 Chunk 조각을 조회합니다.">
+                      <span>
+                        <Button
+                          size="small"
+                          variant="contained"
+                          onClick={() => void loadChunks(confirmedScope?.objectType, confirmedScope?.objectId, 0, true)}
+                        >
+                          Chunk 조회
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  </Stack>
+                ) : null}
+
+                {selectedJobSucceeded && hasJobInspection ? (
+                  <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="subtitle2">현재 단계: 검색 검증</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        아래 `Chunk / 검색 검증` 영역에서 Vector 결과와 RAG 결과를 확인합니다.
+                      </Typography>
+                    </Box>
+                    <Tooltip title="Vector 결과 탭으로 이동합니다.">
+                      <Button size="small" variant="outlined" onClick={() => activateValidationTab("vector")}>
+                        Vector 결과
+                      </Button>
+                    </Tooltip>
+                    <Tooltip title="RAG 결과 탭으로 이동합니다.">
+                      <Button size="small" variant="outlined" onClick={() => activateValidationTab("rag")}>
+                        RAG 결과
+                      </Button>
+                    </Tooltip>
+                    <Tooltip title={ragRows.length > 0 ? "답변 생성 탭으로 이동합니다." : "먼저 RAG 결과를 조회하세요."}>
+                      <span>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          disabled={ragRows.length === 0}
+                          onClick={() => activateValidationTab("chat")}
+                        >
+                          답변 생성
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  </Stack>
+                ) : null}
+              </Box>
+              {targetIndexed != null ? (
+                <Box>
+                  <Chip
+                    size="small"
+                    color={selectedJobFailed ? "error" : targetIndexed ? "success" : "warning"}
+                    label={selectedJobFailed ? "선택 job 실패" : targetIndexed ? "색인됨" : "색인 없음"}
+                  />
+                </Box>
+              ) : null}
+              <Box
+                component="pre"
+                sx={{
+                  m: 0,
+                  p: 1,
+                  bgcolor: "action.hover",
+                  borderRadius: 2,
+                  minHeight: 120,
+                  maxHeight: 180,
+                  overflow: "auto",
+                  fontSize: 12,
+                }}
+              >
+                {targetMetadata ? JSON.stringify(targetMetadata, null, 2) : "metadata 조회 결과가 여기에 표시됩니다."}
+              </Box>
+            </Stack>
+          </CardContent>
+        </Card>
+
+        <Box ref={jobsSectionRef} sx={{ flex: 1, scrollMarginTop: 56, order: 1 }}>
+          <Stack spacing={1.25}>
+              <Typography variant="caption" color="text.secondary">
+                먼저 색인 작업을 선택합니다. 현재 {visibleJobCount.toLocaleString()}건
+                {jobsTotal ? ` / 전체 ${jobsTotal.toLocaleString()}건` : ""}
+              </Typography>
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <Typography variant="caption" color="text.secondary">
+                  상태
+                </Typography>
+                <Select
+                  value={jobStatusFilter}
+                  onChange={(event) => setJobStatusFilter(event.target.value as RagJobStatusFilter)}
+                  size="small"
+                  displayEmpty
+                  renderValue={(selected) => (selected ? String(selected) : "전체")}
+                  sx={{
+                    minWidth: 120,
+                    height: 32,
+                    "& .MuiSelect-select": {
+                      py: 0.5,
+                      fontSize: 13,
+                    },
+                  }}
+                >
+                  <MenuItem value="">전체</MenuItem>
+                  {(["PENDING", "RUNNING", "SUCCEEDED", "WARNING", "FAILED", "CANCELLED"] as RagIndexJobStatus[]).map(
+                    (status) => (
+                      <MenuItem key={status} value={status}>
+                        {status}
+                      </MenuItem>
+                    )
+                  )}
+                </Select>
+                <Button variant="outlined" size="small" sx={{ height: 32 }} onClick={() => void loadJobs()}>
+                  조회
+                </Button>
+                <Tooltip title="선택한 실패/중단 job을 서버 retry 엔드포인트로 다시 실행합니다. 기존 색인을 강제로 새로 만드는 기능은 아닙니다.">
+                  <span>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      startIcon={<ReplayOutlined />}
+                      disabled={!selectedJob || selectedJob.status === "PENDING" || selectedJob.status === "RUNNING"}
+                      onClick={() => void handleRetryJob()}
+                    >
+                      선택 job 재시도
+                    </Button>
+                  </span>
+                </Tooltip>
+                <Tooltip
+                  title={
+                    canForceReindexTarget
+                      ? "확정된 attachment 대상의 색인을 force=true로 새 job을 생성해 다시 만듭니다."
+                      : "attachmentId로 상태 확인을 완료한 대상에서 사용할 수 있습니다."
+                  }
+                >
+                  <span>
+                    <Button
+                      variant="contained"
+                      size="small"
+                      color="warning"
+                      startIcon={<ReplayOutlined />}
+                      disabled={!canForceReindexTarget}
+                      onClick={() => void handleForceReindexTarget()}
+                    >
+                      강제 재색인
+                    </Button>
+                  </span>
+                </Tooltip>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  color="warning"
+                  disabled={!selectedJob || (selectedJob.status !== "PENDING" && selectedJob.status !== "RUNNING")}
+                  onClick={() => void handleCancelJob()}
+                >
+                  취소
+                </Button>
+              </Stack>
+              <Box
+                sx={{
+                  "& .ag-row.rag-job-row-selected": {
+                    bgcolor: (theme) =>
+                      theme.palette.mode === "dark"
+                        ? "rgba(66, 165, 245, 0.22)"
+                        : "rgba(25, 118, 210, 0.12)",
+                  },
+                  "& .ag-row.rag-job-row-selected:hover": {
+                    bgcolor: (theme) =>
+                      theme.palette.mode === "dark"
+                        ? "rgba(66, 165, 245, 0.28)"
+                        : "rgba(25, 118, 210, 0.18)",
+                  },
+                  "& .ag-row.rag-job-row-selected::before": {
+                    content: '""',
+                    position: "absolute",
+                    left: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: 3,
+                    bgcolor: "primary.main",
+                    zIndex: 1,
+                  },
+                  "& .ag-row.rag-job-row-selected .ag-cell": {
+                    fontWeight: 600,
+                  },
+                }}
+              >
+                <GridContent<RagIndexJobDto>
+                  columns={jobColumnDefs}
+                  options={jobGridOptions}
+                  rowData={jobs}
+                  loading={jobsLoading}
+                  height={300}
+                  events={[
+                    {
+                      type: "rowClicked",
+                      listener: (event) => {
+                        const row = (event as { data?: RagIndexJobDto }).data;
+                        if (!row) {
+                          return;
+                        }
+                        toggleSelectedJob(row);
+                      },
+                    },
+                  ]}
+                />
+              </Box>
+              {selectedJob ? (
+                <Alert severity="info" icon={false}>
+                  <Stack direction={{ xs: "column", sm: "row" }} spacing={0.75} alignItems={{ sm: "center" }}>
+                    <Chip size="small" color="primary" label="선택됨" />
+                    <Typography variant="caption" color="text.secondary">
+                      {selectedJob.jobId} / {selectedJob.status} / {selectedJob.currentStep ?? "-"} /{" "}
+                      {formatObjectTypeLabel(selectedJob.objectType)} / {selectedJob.objectId}
+                    </Typography>
+                  </Stack>
+                </Alert>
+              ) : (
+                <Typography variant="caption" color="text.secondary">
+                  작업 row를 선택하면 실행 로그와 생성된 Chunk 조각을 확인할 수 있습니다.
+                </Typography>
+              )}
+              {selectedJob ? (
+                <Box
+                  sx={{
+                    display: "grid",
+                    gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(6, 1fr)" },
+                    gap: 1,
+                    p: 1.25,
+                    borderRadius: 2,
+                    bgcolor: "action.hover",
+                  }}
+                >
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      상태
+                    </Typography>
+                    <Stack direction="row" spacing={0.5} alignItems="center">
+                      <Chip size="small" color={statusColor(selectedJob.status)} label={selectedJob.status} />
+                    </Stack>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      단계
+                    </Typography>
+                    <Typography variant="body2" fontWeight={700} noWrap>
+                      {selectedJob.currentStep ?? "-"}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      객체
+                    </Typography>
+                    <Typography variant="body2" fontWeight={700} noWrap>
+                      {formatObjectTypeLabel(selectedJob.objectType)} / {selectedJob.objectId}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      소스
+                    </Typography>
+                    <Typography variant="body2" fontWeight={700} noWrap>
+                      {selectedJob.sourceType ?? "-"}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      Chunk
+                    </Typography>
+                    <Typography variant="body2" fontWeight={700} noWrap>
+                      {selectedJob.chunkCount?.toLocaleString?.() ?? selectedJob.chunkCount ?? "-"}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      소요
+                    </Typography>
+                    <Typography variant="body2" fontWeight={700} noWrap>
+                      {typeof selectedJob.durationMs === "number" ? `${selectedJob.durationMs.toLocaleString()}ms` : "-"}
+                    </Typography>
+                  </Box>
+                </Box>
+              ) : null}
+              {selectedJob?.errorMessage ? (
+                <Alert severity="error">
+                  <Typography variant="caption" color="inherit" display="block" sx={{ mb: 0.5 }}>
+                    선택한 작업 오류
+                  </Typography>
+                  <Typography variant="body2" color="inherit" sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>
+                    {selectedJob.errorMessage}
+                  </Typography>
+                </Alert>
+              ) : null}
+          </Stack>
+        </Box>
+      </Stack>
+
+      <Card variant="outlined" ref={validationSectionRef} sx={{ scrollMarginTop: 56, borderRadius: 2 }}>
         <CardContent>
-          <Stack spacing={2}>
-            <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+          <Stack spacing={1.5}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <HubOutlined fontSize="small" color="primary" />
+              <Typography variant="subtitle2">Chunk / 검색 검증</Typography>
+            </Stack>
+            <Alert severity="info">
+              <Typography variant="caption" color="text.secondary">
+                현재 범위: {confirmedScope ? `${formatObjectTypeLabel(confirmedScope.objectType)} / ${confirmedScope.objectId}` : "전체 색인 대상"}
+                {" · "}Vector 결과는 유사 Chunk를 확인하고, RAG 결과는 답변 후보 문맥을 확인합니다.
+                {!confirmedScope
+                  ? " 전체 색인 대상에서는 검색어와 직접 관련이 낮은 문서도 함께 보일 수 있으므로, 파일 단위 검증은 먼저 색인 대상을 확정하세요."
+                  : null}
+              </Typography>
+            </Alert>
+            <Stack direction={{ xs: "column", lg: "row" }} spacing={1.5} alignItems={{ lg: "flex-start" }}>
               <TextField
                 select
                 label="Provider"
@@ -177,129 +2403,690 @@ export function RagPage() {
                   </MenuItem>
                 ))}
               </TextField>
-              <TextField label="Model" value={model} onChange={(event) => setModel(event.target.value)} fullWidth size="small" />
-              <TextField label="topK" value={topK} onChange={(event) => setTopK(event.target.value)} sx={{ maxWidth: 140 }} size="small" />
-            </Stack>
-            <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
               <TextField
-                label="objectType"
-                value={objectType}
-                onChange={(event) => setObjectType(event.target.value)}
-                placeholder="예: attachment"
-                helperText="첨부 파일 RAG는 attachment를 사용합니다."
+                label="Model"
+                value={model}
+                onChange={(event) => setModel(event.target.value)}
                 fullWidth
                 size="small"
               />
-              <TextField
-                label="objectId"
-                value={objectId}
-                onChange={(event) => setObjectId(event.target.value)}
-                placeholder="예: 123"
-                helperText="파일 기반 RAG는 attachmentId를 입력합니다."
-                fullWidth
-                size="small"
-              />
-              <TextField
-                select
-                label="debug"
-                value={debug ? "true" : "false"}
-                onChange={(event) => setDebug(event.target.value === "true")}
-                sx={{ maxWidth: 140 }}
-                size="small"
-                helperText="운영 정보 표시"
+              <Tooltip title="검색 결과로 가져올 최대 Chunk 개수입니다. 값이 클수록 후보 문맥은 많아지지만 노이즈와 비용도 늘 수 있습니다.">
+                <TextField
+                  label="topK"
+                  value={topK}
+                  onChange={(event) => setTopK(event.target.value)}
+                  sx={{ minWidth: 140 }}
+                  size="small"
+                  helperText="가져올 후보 수"
+                />
+              </Tooltip>
+              <Tooltip
+                title={
+                  tab === "vector"
+                    ? "이 유사도 점수보다 낮은 Vector 검색 결과를 제외합니다. 비워두면 서버 기본값을 사용합니다. 너무 높이면 결과가 없을 수 있습니다."
+                    : "현재 서버 RAG 검색 API는 minScore를 받지 않습니다. RAG 결과는 topK와 선택된 색인 대상 기준으로 조회됩니다."
+                }
               >
-                <MenuItem value="false">false</MenuItem>
-                <MenuItem value="true">true</MenuItem>
-              </TextField>
-            </Stack>
-            <TextField label="쿼리" value={query} onChange={(event) => setQuery(event.target.value)} size="small" />
-            <Stack direction="row" spacing={1}>
-              <Button variant="contained" onClick={() => void handleSearch(false)} disabled={!query.trim()}>
-                검색
-              </Button>
-              <Button variant="outlined" onClick={() => void handleRewrite()} disabled={!query.trim()}>
-                쿼리 확장
-              </Button>
-              <Button variant="text" onClick={() => void handleSearch(true)} disabled={!expandedQuery.trim()}>
-                확장 쿼리로 검색
-              </Button>
-            </Stack>
-          </Stack>
-        </CardContent>
-      </Card>
-      <Card variant="outlined">
-        <CardContent>
-          <Stack spacing={2}>
-            <Typography variant="subtitle2">RAG Chat</Typography>
-            <Stack spacing={1}>
-              {chatMessages.length === 0 ? (
-                <Typography color="text.secondary">RAG 대화를 시작하세요.</Typography>
-              ) : (
-                chatMessages.map((message, index) => (
-                  <TextField
-                    key={`${message.role}-${index}`}
-                    label={message.role}
-                    value={message.content}
-                    InputProps={{ readOnly: true }}
-                    multiline
-                    minRows={2}
+                <TextField
+                  label="Vector minScore"
+                  value={minScore}
+                  onChange={(event) => setMinScore(event.target.value)}
+                  sx={{ minWidth: 160 }}
+                  size="small"
+                  placeholder="예: 0.65"
+                  helperText={tab === "vector" ? "최소 유사도" : "RAG 검색에는 미적용"}
+                  disabled={tab !== "vector"}
+                />
+              </Tooltip>
+              <Tooltip title="RAG 검색과 답변 생성 응답에 진단 metadata를 포함합니다.">
+                <Box
+                  sx={{
+                    minWidth: 130,
+                    height: 40,
+                    display: "flex",
+                    alignItems: "center",
+                  }}
+                >
+                  <FormControlLabel
+                    sx={{ ml: 0, mr: 0 }}
+                    control={
+                      <Switch
+                        size="small"
+                        checked={debug}
+                        onChange={(event) => setDebug(event.target.checked)}
+                      />
+                    }
+                    label={
+                      <Typography variant="body2" color="text.secondary">
+                        debug
+                      </Typography>
+                    }
                   />
-                ))
-              )}
+                </Box>
+              </Tooltip>
             </Stack>
-            <TextField
-              label="RAG 질문"
-              value={chatInput}
-              onChange={(event) => setChatInput(event.target.value)}
-              multiline
-              minRows={3}
-            />
-            <Stack direction="row" justifyContent="flex-end">
-              <Button variant="contained" onClick={() => void handleRagChat()} disabled={!chatInput.trim()}>
-                RAG 요청
-              </Button>
+            <Stack spacing={1}>
+              <TextField
+                value={query}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && query.trim()) {
+                    handleDefaultSearch(false);
+                  }
+                }}
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                  setVectorSearched(false);
+                  setRagSearched(false);
+                  setVectorRows([]);
+                  setRagRows([]);
+                  setSelectedVectorResult(null);
+                  setSelectedRagResult(null);
+                  setChatMessages([]);
+                  setLastMetadata(null);
+                  setRagDiagnostics(null);
+                  setLastRagSearchQuery("");
+                }}
+                placeholder="검증 쿼리 입력"
+                size="small"
+                fullWidth
+                inputProps={{ "aria-label": "검증 쿼리" }}
+                slotProps={{
+                  input: {
+                    endAdornment: (
+                      <Tooltip
+                        title="입력한 쿼리 그대로 Vector 결과를 먼저 조회합니다. RAG 결과는 탭을 열 때 조회합니다."
+                      >
+                        <span>
+                          <Button
+                            size="small"
+                            variant="text"
+                            startIcon={<SearchOutlined />}
+                            onClick={() => handleDefaultSearch(false)}
+                            disabled={!query.trim()}
+                          >
+                            검색
+                          </Button>
+                        </span>
+                      </Tooltip>
+                    ),
+                  },
+                }}
+              />
+              <Accordion variant="outlined" disableGutters>
+                <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
+                  <Stack spacing={0.25}>
+                    <Typography variant="body2" fontWeight={700}>
+                      AI 검색어 개선
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      검색 결과가 부족하면 AI가 질문을 검색 친화적인 표현으로 바꾸고, 그 검색어로 다시 찾습니다.
+                    </Typography>
+                  </Stack>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Stack spacing={1}>
+                    <Stack direction="row" spacing={1} flexWrap="wrap">
+                      <Tooltip title="AI가 입력한 질문을 검색에 더 잘 맞는 검색어와 키워드로 바꿉니다.">
+                        <span>
+                          <Button
+                            variant="outlined"
+                            startIcon={<SearchOutlined />}
+                            onClick={() => void handleRewrite()}
+                            disabled={!query.trim()}
+                          >
+                            AI가 검색어 다듬기
+                          </Button>
+                        </span>
+                      </Tooltip>
+                      <Tooltip
+                        title="AI가 다듬은 검색어로 Vector 결과를 먼저 조회합니다. RAG 결과는 탭을 열 때 조회합니다."
+                      >
+                        <span>
+                          <Button
+                            variant="outlined"
+                            startIcon={<SearchOutlined />}
+                            onClick={() => handleDefaultSearch(true)}
+                            disabled={!expandedQuery.trim()}
+                          >
+                            개선된 검색어로 검색
+                          </Button>
+                        </span>
+                      </Tooltip>
+                    </Stack>
+                    {expandedQuery || expandedKeywords.length > 0 ? (
+                      <Stack direction="row" spacing={0.75} flexWrap="wrap">
+                        {expandedQuery ? (
+                          <Chip label={`다듬은 검색어: ${expandedQuery}`} size="small" variant="outlined" />
+                        ) : null}
+                        {expandedKeywords.map((keyword) => (
+                          <Chip key={keyword} label={keyword} size="small" />
+                        ))}
+                      </Stack>
+                    ) : null}
+                  </Stack>
+                </AccordionDetails>
+              </Accordion>
             </Stack>
+            <Tabs value={tab} onChange={(_, value: ValidationTab) => void handleValidationTabChange(value)}>
+              <Tab
+                value="vector"
+                label={
+                  <Badge color="primary" badgeContent={vectorRows.length} invisible={!vectorSearched}>
+                    <Box component="span" sx={{ pr: 1.25 }}>
+                      Vector 결과
+                      <ChevronRightOutlined sx={{ ml: 0.5, fontSize: 16, verticalAlign: "middle" }} />
+                    </Box>
+                  </Badge>
+                }
+              />
+              <Tab
+                value="rag"
+                label={
+                  <Badge color="primary" badgeContent={ragRows.length} invisible={!ragSearched}>
+                    <Box component="span" sx={{ pr: 1.25 }}>
+                      RAG 결과
+                      <ChevronRightOutlined sx={{ ml: 0.5, fontSize: 16, verticalAlign: "middle" }} />
+                    </Box>
+                  </Badge>
+                }
+              />
+              <Tab value="chat" label="답변 생성" />
+            </Tabs>
+
+            {tab === "vector" ? (
+              <Stack spacing={1}>
+                <Alert severity="success" variant="outlined">
+                  <Typography variant="body2">
+                    Vector 검색은 입력 쿼리와 가장 가까운 Chunk를 점수순으로 보여줍니다.
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Vector store의 원시 유사도 결과입니다. 색인이 제대로 되었는지, 원하는 문서 조각이 검색되는지 확인할 때 사용합니다. 검색이 잘 안 되면 `AI 검색어 개선`으로 질문을 검색 친화적인 표현으로 바꾼 뒤 다시 찾을 수 있습니다.
+                    {!confirmedScope
+                      ? " 현재는 전체 색인에서 검색하므로 topK를 낮추거나 minScore를 높이면 노이즈를 줄일 수 있습니다."
+                      : null}
+                  </Typography>
+                </Alert>
+                <GridContent<VectorSearchResultDto>
+                  columns={vectorColumnDefs}
+                  rowData={vectorRows}
+                  loading={vectorLoading}
+                  height={360}
+                  events={[
+                    {
+                      type: "rowClicked",
+                      listener: (event) => {
+                        const row = (event as { data?: VectorSearchResultDto }).data;
+                        setSelectedVectorResult(row ?? null);
+                      },
+                    },
+                  ]}
+                />
+                <SearchResultDetail
+                  title={
+                    selectedVectorResult
+                      ? `선택한 Chunk 전체 내용 · ${selectedVectorResult.id}`
+                      : "선택한 Chunk 전체 내용"
+                  }
+                  content={selectedVectorResult?.content}
+                  metadata={selectedVectorResult?.metadata}
+                />
+              </Stack>
+            ) : null}
+
+            {tab === "rag" ? (
+              <Stack spacing={1}>
+                <Alert severity="success" variant="outlined">
+                  <Typography variant="body2">
+                    RAG 검색은 실제 답변 생성 전에 사용될 후보 문맥을 확인합니다.
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Vector 검색 결과를 RAG 검색 파이프라인 규칙으로 한 번 더 정리한 후보 문맥입니다. 필터, fallback, context expansion 설정에 따라 Vector 검색과 건수나 순서가 달라질 수 있습니다.
+                    현재 서버 RAG 검색 API는 minScore를 받지 않으므로 topK와 선택된 색인 대상 기준으로 조회합니다.
+                  </Typography>
+                </Alert>
+                <GridContent<SearchResultDto>
+                  columns={ragColumnDefs}
+                  rowData={ragRows}
+                  loading={ragLoading}
+                  height={360}
+                  events={[
+                    {
+                      type: "rowClicked",
+                      listener: (event) => {
+                        const row = (event as { data?: SearchResultDto }).data;
+                        setSelectedRagResult(row ?? null);
+                      },
+                    },
+                  ]}
+                />
+                <SearchResultDetail
+                  title={
+                    selectedRagResult
+                      ? `선택한 후보 문맥 전체 내용 · ${selectedRagResult.documentId}`
+                      : "선택한 후보 문맥 전체 내용"
+                  }
+                  content={selectedRagResult?.content}
+                  metadata={selectedRagResult?.metadata}
+                />
+              </Stack>
+            ) : null}
+
+            {tab === "chat" ? (
+              <Stack spacing={1.5}>
+                <Alert severity={ragRows.length > 0 ? "success" : "warning"} variant="outlined">
+                  <Typography variant="body2">
+                    RAG 결과에서 확인한 후보 문맥을 기준으로 최종 답변을 생성합니다.
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    이미 RAG 결과가 있으면 이 탭에서 바로 답변을 확인합니다. 질문을 비워두면 현재 검증 쿼리를 사용합니다.
+                  </Typography>
+                </Alert>
+                {lastRagSearchQuery ? (
+                  <Typography variant="caption" color="text.secondary">
+                    답변 생성 기준 RAG 쿼리: {lastRagSearchQuery} / 후보 문맥 {ragRows.length.toLocaleString()}건
+                  </Typography>
+                ) : null}
+                <Stack spacing={1}>
+                  {chatMessages.filter((message) => message.role === "assistant").length === 0 ? (
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      {chatLoading ? <CircularProgress size={18} /> : null}
+                      <Typography variant="body2" color="text.secondary">
+                        {chatLoading ? "문맥 기반 답변을 생성하고 있습니다." : "아직 생성된 답변이 없습니다."}
+                      </Typography>
+                    </Stack>
+                  ) : (
+                    chatMessages.filter((message) => message.role === "assistant").map((message, index) => (
+                      <Box
+                        key={`${message.role}-${index}`}
+                        sx={{
+                          alignSelf: message.role === "user" ? "flex-end" : "flex-start",
+                          maxWidth: "82%",
+                          borderRadius: 2,
+                          px: 1.25,
+                          py: 1,
+                          bgcolor: message.role === "user" ? "primary.main" : "action.hover",
+                          color: message.role === "user" ? "primary.contrastText" : "text.primary",
+                          whiteSpace: "pre-wrap",
+                          fontSize: 13,
+                        }}
+                      >
+                        {message.content}
+                      </Box>
+                    ))
+                  )}
+                  {chatLoading ? (
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <CircularProgress size={18} />
+                      <Typography variant="body2" color="text.secondary">
+                        답변을 갱신하고 있습니다.
+                      </Typography>
+                    </Stack>
+                  ) : null}
+                </Stack>
+                <TextField
+                  label="답변 생성 질문"
+                  value={chatInput}
+                  onChange={(event) => setChatInput(event.target.value)}
+                  placeholder={query.trim() || "예: 이 파일의 핵심 내용을 요약해줘"}
+                  helperText="RAG 결과 문맥을 바탕으로 답변할 질문입니다. 비워두면 RAG 결과를 만든 쿼리를 사용합니다."
+                  multiline
+                  minRows={3}
+                  size="small"
+                />
+                <Stack direction={{ xs: "column", sm: "row" }} justifyContent="space-between" alignItems={{ sm: "center" }} spacing={1}>
+                  <Typography variant="caption" color="text.secondary">
+                    {lastMetadata
+                      ? `${lastMetadata.provider ?? provider} / ${lastMetadata.resolvedModel ?? model} / ${formatTokenUsage(lastMetadata.tokenUsage)} / ${lastMetadata.latencyMs ?? "-"}ms`
+                      : `RAG 후보 문맥 ${ragRows.length.toLocaleString()}건`}
+                  </Typography>
+                  <Button
+                    variant="contained"
+                    startIcon={chatLoading ? <CircularProgress color="inherit" size={16} /> : undefined}
+                    onClick={() => void handleRagChat()}
+                    disabled={chatLoading || ragRows.length === 0 || !(chatInput.trim() || query.trim())}
+                  >
+                    {chatLoading ? "생성 중" : "문맥 기반 답변 생성"}
+                  </Button>
+                </Stack>
+              </Stack>
+            ) : null}
           </Stack>
         </CardContent>
       </Card>
-      {expandedKeywords.length > 0 ? (
-        <Card variant="outlined">
-          <CardContent>
-            <Stack spacing={1}>
-              <Typography variant="subtitle2">확장 키워드</Typography>
-              <Stack direction="row" spacing={1} flexWrap="wrap">
-                {expandedKeywords.map((keyword) => (
-                  <Chip key={keyword} label={keyword} />
+
+      <Card variant="outlined" ref={chunksSectionRef} sx={{ scrollMarginTop: 56, borderRadius: 2 }}>
+        <CardContent>
+          <Stack spacing={1.25}>
+            <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+              <Stack direction="row" spacing={1} alignItems="center">
+                <StorageOutlined fontSize="small" color="primary" />
+                <Typography variant="subtitle2">Chunk</Typography>
+              </Stack>
+              <Stack direction="row" spacing={1}>
+                <Tooltip title={confirmedScope ? "확정된 대상의 생성 Chunk 조각을 조회합니다." : "먼저 상태 확인으로 색인 대상을 확정하세요."}>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      disabled={!confirmedScope}
+                      onClick={() => void loadChunks(confirmedScope?.objectType, confirmedScope?.objectId, 0, true)}
+                    >
+                      Chunk 조회
+                    </Button>
+                  </span>
+                </Tooltip>
+                <Tooltip title="이전 Chunk 페이지를 조회합니다.">
+                  <span>
+                    <Button
+                      size="small"
+                      variant="text"
+                      disabled={chunkPage.offset <= 0}
+                      onClick={() =>
+                        void loadChunks(
+                          confirmedScope?.objectType,
+                          confirmedScope?.objectId,
+                          Math.max(0, chunkPage.offset - chunkPage.limit)
+                        )
+                      }
+                    >
+                      이전
+                    </Button>
+                  </span>
+                </Tooltip>
+                <Tooltip title="다음 Chunk 페이지를 조회합니다.">
+                  <span>
+                    <Button
+                      size="small"
+                      variant="text"
+                      disabled={!chunkPage.hasMore}
+                      onClick={() =>
+                        void loadChunks(confirmedScope?.objectType, confirmedScope?.objectId, chunkPage.offset + chunkPage.limit)
+                      }
+                    >
+                      다음
+                    </Button>
+                  </span>
+                </Tooltip>
+              </Stack>
+            </Stack>
+            <Box
+              sx={{
+                "& .ag-row.rag-chunk-row-selected": {
+                  bgcolor: (theme) =>
+                    theme.palette.mode === "dark"
+                      ? "rgba(66, 165, 245, 0.22)"
+                      : "rgba(25, 118, 210, 0.12)",
+                },
+                "& .ag-row.rag-chunk-row-selected:hover": {
+                  bgcolor: (theme) =>
+                    theme.palette.mode === "dark"
+                      ? "rgba(66, 165, 245, 0.28)"
+                      : "rgba(25, 118, 210, 0.18)",
+                },
+                "& .ag-row.rag-chunk-row-selected .ag-cell": {
+                  fontWeight: 600,
+                },
+              }}
+            >
+              <GridContent<RagIndexChunkDto>
+                columns={chunkColumnDefs}
+                options={chunkGridOptions}
+                rowData={chunks}
+                loading={chunksLoading}
+                height={280}
+                events={[
+                  {
+                    type: "rowClicked",
+                    listener: (event) => {
+                      const row = (event as { data?: RagIndexChunkDto }).data;
+                      const node = (event as {
+                        node?: { setSelected: (selected: boolean, clearSelection?: boolean) => void };
+                      }).node;
+                      if (row) {
+                        node?.setSelected(true, true);
+                        setSelectedChunk(row);
+                      }
+                    },
+                  },
+                ]}
+              />
+            </Box>
+            <Typography variant="caption" color="text.secondary">
+              offset {chunkPage.offset.toLocaleString()} / returned {chunks.length.toLocaleString()} / hasMore{" "}
+              {chunkPage.hasMore ? "true" : "false"}
+            </Typography>
+            <SearchResultDetail
+              title={
+                selectedChunk
+                  ? `선택한 Chunk 전체 내용 · #${selectedChunk.chunkOrder ?? "-"}`
+                  : "선택한 Chunk 전체 내용"
+              }
+              content={selectedChunk?.content}
+              metadata={selectedChunk?.metadata}
+            />
+            <Accordion variant="outlined" disableGutters sx={{ "&:before": { display: "none" } }}>
+              <AccordionSummary expandIcon={<ExpandMoreOutlined />}>
+                <Stack spacing={0.25}>
+                  <Typography variant="body2" fontWeight={700}>
+                    실패·경고 로그
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    선택한 색인 job의 처리 로그입니다. 오류 원인 확인이 필요할 때 펼쳐서 확인합니다.
+                  </Typography>
+                </Stack>
+              </AccordionSummary>
+              <AccordionDetails>
+                <GridContent<RagIndexJobLogDto>
+                  columns={logColumnDefs}
+                  rowData={jobLogs}
+                  loading={logsLoading}
+                  height={220}
+                />
+              </AccordionDetails>
+            </Accordion>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Card variant="outlined" ref={diagnosticsSectionRef} sx={{ scrollMarginTop: 56, borderRadius: 2 }}>
+        <CardContent>
+          <Stack spacing={1.25}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <ArticleOutlined fontSize="small" color="primary" />
+              <Typography variant="subtitle2">결과 / 진단</Typography>
+            </Stack>
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" },
+                gap: 1,
+              }}
+            >
+              <StatusMetric label="RAG Diagnostics" value={ragDiagnostics ? "수신됨" : "없음"} />
+              <StatusMetric label="Token Usage" value={formatTokenUsage(lastMetadata?.tokenUsage)} />
+              <StatusMetric label="Latency" value={lastMetadata?.latencyMs ? `${lastMetadata.latencyMs}ms` : "-"} />
+            </Box>
+            <Divider />
+            <Box
+              component="pre"
+              sx={{
+                m: 0,
+                p: 1,
+                bgcolor: "action.hover",
+                borderRadius: 2,
+                overflow: "auto",
+                fontSize: 12,
+                minHeight: 120,
+                maxHeight: 260,
+              }}
+            >
+              {ragDiagnostics
+                ? JSON.stringify(ragDiagnostics, null, 2)
+                : "RAG Chat debug=true 응답의 diagnostics가 여기에 표시됩니다."}
+            </Box>
+            {targetMetadata ? (
+              <Stack spacing={0.5}>
+                <Typography variant="caption" color="text.secondary">
+                  Metadata preview
+                </Typography>
+                {Object.entries(targetMetadata).slice(0, 8).map(([key, value]) => (
+                  <Stack key={key} direction="row" spacing={1}>
+                    <Typography variant="caption" sx={{ width: 160, flexShrink: 0 }}>
+                      {key}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" sx={{ overflowWrap: "anywhere" }}>
+                      {formatValue(value)}
+                    </Typography>
+                  </Stack>
                 ))}
               </Stack>
-              <TextField label="확장 쿼리" value={expandedQuery} InputProps={{ readOnly: true }} />
-            </Stack>
-          </CardContent>
-        </Card>
-      ) : null}
-      {ragDiagnostics ? (
-        <Card variant="outlined">
-          <CardContent>
-            <Stack spacing={1}>
-              <Typography variant="subtitle2">RAG Diagnostics</Typography>
-              <Box
-                component="pre"
-                sx={{
-                  m: 0,
-                  p: 1,
-                  bgcolor: "grey.100",
-                  borderRadius: 1,
-                  overflow: "auto",
-                  fontSize: 12,
-                }}
+            ) : null}
+          </Stack>
+        </CardContent>
+      </Card>
+
+      </Stack>
+
+      <Dialog open={chunkPreviewOpen} onClose={() => setChunkPreviewOpen(false)} maxWidth="lg" fullWidth>
+        <DialogTitle>청킹 시뮬레이션</DialogTitle>
+        <DialogContent>
+          <Stack spacing={1.5} sx={{ pt: 0.5 }}>
+            <Alert severity="info" icon={<InfoOutlined />}>
+              입력 텍스트를 현재 ChunkingOrchestrator 설정으로 나누어 봅니다. 이 작업은 embedding, vector 저장,
+              색인 Job 생성을 수행하지 않습니다.
+            </Alert>
+            {chunkPreviewError ? <Alert severity="error">{chunkPreviewError}</Alert> : null}
+            <Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+              <TextField
+                select
+                label="청킹 전략"
+                value={chunkPreviewStrategy}
+                onChange={(event) => setChunkPreviewStrategy(event.target.value)}
+                size="small"
+                fullWidth
+                helperText={chunkStrategyHint(chunkPreviewStrategy)}
               >
-                {JSON.stringify(ragDiagnostics, null, 2)}
-              </Box>
+                {(chunkConfig?.chunking.availableStrategies ?? ["fixed-size", "recursive", "structure-based"]).map(
+                  (strategy) => (
+                    <MenuItem key={strategy} value={strategy}>
+                      {strategy}
+                    </MenuItem>
+                  )
+                )}
+              </TextField>
+              <TextField
+                label="Chunk 크기"
+                value={chunkPreviewMaxSize}
+                onChange={(event) => setChunkPreviewMaxSize(event.target.value)}
+                size="small"
+                fullWidth
+                disabled={!chunkPreviewUsesSizing}
+                helperText={
+                  chunkPreviewUsesSizing
+                    ? "Chunk 하나의 최대 길이입니다."
+                    : "선택한 전략에는 적용되지 않습니다."
+                }
+              />
+              <TextField
+                label="겹침"
+                value={chunkPreviewOverlap}
+                onChange={(event) => setChunkPreviewOverlap(event.target.value)}
+                size="small"
+                fullWidth
+                disabled={!chunkPreviewUsesSizing}
+                helperText={
+                  chunkPreviewUsesSizing
+                    ? "앞뒤 Chunk 사이에 다시 포함할 중복 길이입니다."
+                    : "선택한 전략에는 적용되지 않습니다."
+                }
+              />
             </Stack>
-          </CardContent>
-        </Card>
-      ) : null}
-      <GridContent<VectorSearchResultDto> columns={columnDefs} rowData={rows} height={360} />
+            <Typography variant="caption" color="text.secondary">
+              미리보기 제한:{" "}
+              {chunkConfig
+                ? `${chunkConfig.limits.maxInputChars.toLocaleString()}자 / ${chunkConfig.limits.maxPreviewChunks}개`
+                : "-"}
+            </Typography>
+            <TextField
+              label="텍스트"
+              value={chunkPreviewText}
+              onChange={(event) => setChunkPreviewText(event.target.value)}
+              placeholder="청킹 결과를 확인할 텍스트를 입력하세요."
+              multiline
+              minRows={8}
+              maxRows={8}
+              size="small"
+              fullWidth
+              slotProps={{
+                input: {
+                  sx: {
+                    alignItems: "flex-start",
+                    "& textarea": {
+                      overflow: "auto !important",
+                    },
+                  },
+                },
+              }}
+            />
+            <Typography variant="caption" color="text.secondary">
+              입력 길이: {chunkPreviewTextLength.toLocaleString()}자 · 현재 Chunk 크기 기준:{" "}
+              {chunkPreviewEffectiveMaxSize ? `${chunkPreviewEffectiveMaxSize.toLocaleString()}자` : "-"}
+            </Typography>
+            {chunkPreviewSingleChunkLikely ? (
+              <Alert severity="info">
+                현재 입력 길이가 Chunk 크기보다 작습니다. recursive 전략도 가능한 한 자연스러운
+                구간을 찾되, 기준 크기를 넘지 않으면 단일 Chunk로 생성될 수 있습니다.
+              </Alert>
+            ) : null}
+            {chunkPreviewSummary ? (
+              <Stack direction="row" spacing={0.75} flexWrap="wrap">
+                <Chip size="small" label={`총 ${chunkPreviewSummary.totalChunks} chunks`} />
+                <Chip size="small" label={`${chunkPreviewSummary.totalChars.toLocaleString()} chars`} />
+                <Chip size="small" label={chunkPreviewSummary.strategy} />
+                <Chip size="small" label={`size ${chunkPreviewSummary.maxSize}`} />
+                <Chip size="small" label={`overlap ${chunkPreviewSummary.overlap}`} />
+                <Chip size="small" label={chunkPreviewSummary.unit} />
+              </Stack>
+            ) : null}
+            {chunkPreviewSummary?.warnings?.length ? (
+              <Alert severity="warning">{chunkPreviewSummary.warnings.join(" ")}</Alert>
+            ) : null}
+            <GridContent<RagChunkPreviewItemDto>
+              columns={chunkPreviewColumnDefs}
+              rowData={chunkPreviewRows}
+              loading={chunkPreviewLoading}
+              height={260}
+              events={[
+                {
+                  type: "rowClicked",
+                  listener: (event) => {
+                    setSelectedPreviewChunk((event as { data?: RagChunkPreviewItemDto }).data ?? null);
+                  },
+                },
+              ]}
+            />
+            <SearchResultDetail
+              title={
+                selectedPreviewChunk
+                  ? `선택한 Chunk 전체 내용 · #${selectedPreviewChunk.chunkOrder ?? "-"}`
+                  : "선택한 Chunk 전체 내용"
+              }
+              content={selectedPreviewChunk?.content}
+              metadata={selectedPreviewChunk?.metadata}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setChunkPreviewOpen(false)}>닫기</Button>
+          <Button
+            variant="contained"
+            disabled={chunkPreviewLoading || !chunkPreviewText.trim()}
+            onClick={() => void handlePreviewChunks()}
+          >
+            {chunkPreviewLoading ? "실행 중" : "미리보기 실행"}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Stack>
   );
 }

--- a/src/react/pages/ai/RagSearchValidationPanel.tsx
+++ b/src/react/pages/ai/RagSearchValidationPanel.tsx
@@ -1,0 +1,1528 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Badge,
+  Box,
+  Button,
+  ButtonGroup,
+  Chip,
+  CircularProgress,
+  Stack,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import BugReportOutlined from "@mui/icons-material/BugReportOutlined";
+import DescriptionOutlined from "@mui/icons-material/DescriptionOutlined";
+import ExpandMore from "@mui/icons-material/ExpandMore";
+import SpeedOutlined from "@mui/icons-material/SpeedOutlined";
+import TagOutlined from "@mui/icons-material/TagOutlined";
+import type { ColDef } from "ag-grid-community";
+import { GridContent } from "@/react/components/ag-grid";
+import { reactAiApi } from "@/react/pages/ai/api";
+import type {
+  AiInfoResponse,
+  ChatMessageDto,
+  ChatResponseMetadataDto,
+  RagIndexJobDto,
+  SearchResultDto,
+  TokenUsageDto,
+  VectorSearchResultDto,
+} from "@/types/studio/ai";
+import { resolveAxiosError } from "@/utils/helpers";
+
+type ResultTab = "vector" | "rag" | "answer";
+type RunningAction = ResultTab | null;
+
+const CITATION_PRIMARY = "#7C3AED";
+const CITATION_BACKGROUND = "#EDE9FE";
+const ANSWER_BACKGROUND = "#F9FAFB";
+const REFERENCE_COLORS = [
+  { main: "#7C3AED", soft: "#EDE9FE", border: "#C4B5FD", text: "#4C1D95" },
+  { main: "#2563EB", soft: "#DBEAFE", border: "#93C5FD", text: "#1E3A8A" },
+  { main: "#059669", soft: "#D1FAE5", border: "#6EE7B7", text: "#064E3B" },
+  { main: "#D97706", soft: "#FEF3C7", border: "#FCD34D", text: "#78350F" },
+  { main: "#E11D48", soft: "#FFE4E6", border: "#FDA4AF", text: "#881337" },
+];
+
+function buildRequestKey(value: unknown) {
+  return JSON.stringify(value);
+}
+
+function formatValue(value: unknown) {
+  if (value == null || value === "") {
+    return "-";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function formatTokenUsage(usage?: TokenUsageDto) {
+  if (!usage) {
+    return "토큰 정보 없음";
+  }
+  return `입력 ${usage.inputTokens.toLocaleString()} / 출력 ${usage.outputTokens.toLocaleString()} / 합계 ${usage.totalTokens.toLocaleString()}`;
+}
+
+function sourceDisplayName(job?: RagIndexJobDto | null) {
+  if (!job) {
+    return "-";
+  }
+  return job.sourceName || job.documentId || `${job.objectType} #${job.objectId}` || job.jobId;
+}
+
+function metadataValue(metadata: Record<string, unknown> | undefined, keys: string[]) {
+  if (!metadata) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = metadata[key];
+    if (value != null && value !== "") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function chunkValue(metadata?: Record<string, unknown>) {
+  const order = metadataValue(metadata, ["chunkOrder", "chunkIndex", "chunk_order", "chunk_index", "order", "index"]);
+  if (order != null) {
+    return `#${formatValue(order)}`;
+  }
+  return formatValue(metadataValue(metadata, ["chunkId", "chunk_id", "id"]));
+}
+
+function resultSourceName(row: SearchResultDto) {
+  const metadataName = metadataValue(row.metadata, [
+    "sourceName",
+    "fileName",
+    "filename",
+    "originalFilename",
+    "documentName",
+    "title",
+    "name",
+  ]);
+  if (metadataName != null) {
+    return formatValue(metadataName);
+  }
+
+  const objectType = metadataValue(row.metadata, ["objectType", "object_type"]);
+  const objectId = metadataValue(row.metadata, ["objectId", "object_id"]);
+  if (objectType != null && objectId != null) {
+    return `${formatValue(objectType)} #${formatValue(objectId)}`;
+  }
+
+  return row.documentId || "문서";
+}
+
+function referenceLabel(row: SearchResultDto, index: number) {
+  const chunk = chunkValue(row.metadata);
+  const score = typeof row.score === "number" ? `유사도 ${row.score.toFixed(4)}` : "";
+  return [`근거 ${index + 1}`, resultSourceName(row), chunk !== "-" ? chunk : "", score]
+    .filter(Boolean)
+    .join(" / ");
+}
+
+function referenceColor(index: number) {
+  return REFERENCE_COLORS[index % REFERENCE_COLORS.length];
+}
+
+function parseCitationIndex(value: string) {
+  const match = value.match(/근거\s*(\d+)/);
+  if (!match) {
+    return null;
+  }
+  const index = Number(match[1]) - 1;
+  return Number.isFinite(index) && index >= 0 ? index : null;
+}
+
+function extractCitationIndices(value: string) {
+  const seen = new Set<number>();
+  const regex = /[\[(]근거\s*(\d+)[^\])\]]*[\])]/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(value)) !== null) {
+    const index = Number(match[1]) - 1;
+    if (Number.isFinite(index) && index >= 0) {
+      seen.add(index);
+    }
+  }
+  return [...seen];
+}
+
+function isTableSeparatorLine(line: string) {
+  const cells = parseTableLine(line);
+  return cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+function parseTableLine(line: string) {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+type AnswerBlock =
+  | { type: "text"; text: string }
+  | { type: "table"; rows: string[][] };
+
+function parseAnswerBlocks(content: string): AnswerBlock[] {
+  const lines = content.split(/\r?\n/);
+  const blocks: AnswerBlock[] = [];
+  let textLines: string[] = [];
+
+  const flushText = () => {
+    const text = textLines.join("\n").trim();
+    if (text) {
+      blocks.push({ type: "text", text });
+    }
+    textLines = [];
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const nextLine = lines[index + 1] ?? "";
+    if (line.includes("|") && isTableSeparatorLine(nextLine)) {
+      flushText();
+      const tableLines = [line, nextLine];
+      index += 2;
+      while (index < lines.length && lines[index].includes("|")) {
+        tableLines.push(lines[index]);
+        index += 1;
+      }
+      index -= 1;
+      const rows = tableLines
+        .filter((tableLine, tableLineIndex) => tableLineIndex !== 1)
+        .map(parseTableLine)
+        .filter((row) => row.length > 0);
+      if (rows.length > 0) {
+        blocks.push({ type: "table", rows });
+      }
+      continue;
+    }
+
+    if (!line.trim()) {
+      flushText();
+      continue;
+    }
+
+    textLines.push(line);
+  }
+
+  flushText();
+  return blocks;
+}
+
+function CitationBadge({
+  index,
+  onReferenceHover,
+}: {
+  index: number;
+  onReferenceHover: (index: number | null) => void;
+}) {
+  const color = referenceColor(index);
+  const scrollToReference = () => {
+    document.getElementById(`rag-reference-${index}`)?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
+  };
+  return (
+    <Box
+      component="span"
+      onMouseEnter={() => onReferenceHover(index)}
+      onMouseLeave={() => onReferenceHover(null)}
+      onClick={scrollToReference}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.2,
+        mx: 0.18,
+        px: 0.52,
+        py: 0.02,
+        borderRadius: 999,
+        border: 1,
+        borderColor: "transparent",
+        bgcolor: "rgba(237, 233, 254, 0.72)",
+        color: "#4C1D95",
+        fontSize: 10.5,
+        fontWeight: 700,
+        lineHeight: 1.35,
+        verticalAlign: "super",
+        cursor: "pointer",
+        transition: "background-color 140ms ease, border-color 140ms ease, color 140ms ease",
+        "&:hover": {
+          borderColor: CITATION_PRIMARY,
+          bgcolor: CITATION_BACKGROUND,
+          color: "#3B0764",
+        },
+      }}
+    >
+      <DescriptionOutlined sx={{ fontSize: 11, color: color.main }} />
+      ({index + 1})
+    </Box>
+  );
+}
+
+function renderTextWithCitations(text: string, onReferenceHover: (index: number | null) => void) {
+  const parts = text.split(/(\[근거\s*\d+[^\]]*\]|\(근거\s*\d+[^\)]*\))/g);
+  return parts.map((part, index) => {
+    const referenceIndex = parseCitationIndex(part);
+    if (referenceIndex == null) {
+      return part;
+    }
+    return (
+      <CitationBadge
+        key={`${part}-${index}`}
+        index={referenceIndex}
+        onReferenceHover={onReferenceHover}
+      />
+    );
+  });
+}
+
+function stripCitationLabels(text: string) {
+  return text
+    .replace(/\s*[\[(]근거\s*\d+[^\])\]]*[\])]/g, "")
+    .replace(/\s+([.,!?])/g, "$1")
+    .trim();
+}
+
+function CitationGroup({
+  indices,
+  onReferenceHover,
+}: {
+  indices: number[];
+  onReferenceHover: (index: number | null) => void;
+}) {
+  if (indices.length === 0) {
+    return null;
+  }
+  return (
+    <Box component="span" sx={{ whiteSpace: "nowrap" }}>
+      {indices.map((index) => (
+        <CitationBadge key={index} index={index} onReferenceHover={onReferenceHover} />
+      ))}
+    </Box>
+  );
+}
+
+function renderInlineMarkdown(text: string) {
+  return text.split(/(\*\*[^*]+\*\*)/g).map((part, index) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      return (
+        <Box key={`${part}-${index}`} component="strong" sx={{ fontWeight: 700 }}>
+          {part.slice(2, -2)}
+        </Box>
+      );
+    }
+    return part;
+  });
+}
+
+function MarkdownText({
+  text,
+  citationIndices,
+  onReferenceHover,
+}: {
+  text: string;
+  citationIndices: number[];
+  onReferenceHover: (index: number | null) => void;
+}) {
+  const lines = text.split(/\r?\n/).filter((line) => line.trim());
+  const listItems = lines.filter((line) => /^\s*[-*]\s+/.test(line));
+
+  if (lines.length > 0 && listItems.length === lines.length) {
+    return (
+      <Box component="ul" sx={{ m: 0, pl: 2.25 }}>
+        {lines.map((line, index) => (
+          <Box key={`${line}-${index}`} component="li" sx={{ mb: index === lines.length - 1 ? 0 : 0.85 }}>
+            {renderInlineMarkdown(line.replace(/^\s*[-*]\s+/, ""))}
+            {index === lines.length - 1 ? (
+              <>
+                {" "}
+                <CitationGroup indices={citationIndices} onReferenceHover={onReferenceHover} />
+              </>
+            ) : null}
+          </Box>
+        ))}
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      {lines.map((line, index) => (
+        <Box key={`${line}-${index}`} component="p" sx={{ m: 0, mb: index === lines.length - 1 ? 0 : 1 }}>
+          {renderInlineMarkdown(line)}
+          {index === lines.length - 1 ? (
+            <>
+              {" "}
+              <CitationGroup indices={citationIndices} onReferenceHover={onReferenceHover} />
+            </>
+          ) : null}
+        </Box>
+      ))}
+    </>
+  );
+}
+
+function buildVisibleRagContext(rows: SearchResultDto[], topK: number) {
+  return rows
+    .slice(0, Math.max(1, topK))
+    .map((row, index) => {
+      const content = row.content?.trim();
+      if (!content) {
+        return "";
+      }
+      const score = typeof row.score === "number" ? ` score=${row.score.toFixed(4)}` : "";
+      const chunk = chunkValue(row.metadata);
+      const chunkLabel = chunk === "-" ? "" : ` chunk=${chunk}`;
+      return `[${referenceLabel(row, index)}] documentId=${row.documentId}${score}${chunkLabel}\n${content.slice(0, 1600)}`;
+    })
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function highlightText(content: string, query: string) {
+  const terms = query
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter((term) => term.length >= 2);
+
+  if (terms.length === 0) {
+    return content;
+  }
+
+  const escaped = terms.map((term) => term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const regex = new RegExp(`(${escaped.join("|")})`, "gi");
+  return content.split(regex).map((part, index) => {
+    const matched = terms.some((term) => part.toLocaleLowerCase().includes(term.toLocaleLowerCase()));
+    if (!matched) {
+      return part;
+    }
+    return (
+      <Box
+        key={`${part}-${index}`}
+        component="mark"
+        sx={{
+          px: 0.25,
+          py: 0.05,
+          borderRadius: 0.5,
+          bgcolor: "warning.light",
+          color: "warning.contrastText",
+        }}
+      >
+        {part}
+      </Box>
+    );
+  });
+}
+
+function ReferenceDocuments({
+  rows,
+  topK,
+  query,
+  activeReferenceIndex,
+}: {
+  rows: SearchResultDto[];
+  topK: number;
+  query: string;
+  activeReferenceIndex: number | null;
+}) {
+  const references = rows.slice(0, Math.max(1, topK));
+  const [expandedReferenceIndex, setExpandedReferenceIndex] = useState<number | false>(0);
+
+  useEffect(() => {
+    if (activeReferenceIndex != null) {
+      setExpandedReferenceIndex(activeReferenceIndex);
+    }
+  }, [activeReferenceIndex]);
+
+  if (references.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box
+      sx={{
+        border: 0,
+        borderRadius: 2,
+        bgcolor: "background.paper",
+        overflow: "hidden",
+        height: "100%",
+        minWidth: 0,
+      }}
+    >
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        sx={{ px: 1.5, py: 1, bgcolor: ANSWER_BACKGROUND }}
+      >
+        <Typography variant="subtitle2">참고 문서</Typography>
+        <Chip label={`${references.length}개 근거`} size="small" sx={{ bgcolor: CITATION_BACKGROUND, color: "#4C1D95" }} />
+      </Stack>
+      <Stack
+        spacing={1}
+        sx={{
+          p: 1,
+          maxHeight: { xs: "none", lg: 520 },
+          overflow: { xs: "visible", lg: "auto" },
+          "&::-webkit-scrollbar": {
+            width: 6,
+          },
+          "&::-webkit-scrollbar-thumb": {
+            borderRadius: 8,
+            bgcolor: "divider",
+          },
+        }}
+      >
+        {references.map((row, index) => {
+          const color = referenceColor(index);
+          const active = activeReferenceIndex === index;
+          const scorePercent =
+            typeof row.score === "number" ? Math.max(0, Math.min(100, row.score * 100)) : 0;
+          return (
+            <Accordion
+              key={`${row.documentId}-${index}`}
+              id={`rag-reference-${index}`}
+              expanded={expandedReferenceIndex === index}
+              disableGutters
+              onChange={(_, expanded) => setExpandedReferenceIndex(expanded ? index : false)}
+              sx={{
+                border: 1,
+                borderColor: active ? color.border : "divider",
+                borderRadius: 1.5,
+                bgcolor: active ? color.soft : "background.default",
+                borderLeft: 4,
+                borderLeftColor: color.main,
+                boxShadow: active ? `0 0 0 3px ${color.soft}, 0 8px 20px rgba(124, 58, 237, 0.08)` : "none",
+                transition: "background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease",
+                transform: active ? "translateY(-1px)" : "none",
+                overflow: "hidden",
+                "&::before": {
+                  display: "none",
+                },
+                "&.Mui-expanded": {
+                  m: 0,
+                },
+              }}
+            >
+              <AccordionSummary
+                expandIcon={<ExpandMore />}
+                sx={{
+                  minHeight: 64,
+                  px: 1.25,
+                  py: 0.75,
+                  "&.Mui-expanded": {
+                    minHeight: 64,
+                  },
+                  "& .MuiAccordionSummary-content": {
+                    m: 0,
+                    minWidth: 0,
+                  },
+                  "& .MuiAccordionSummary-content.Mui-expanded": {
+                    m: 0,
+                  },
+                }}
+              >
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  alignItems="center"
+                  justifyContent="space-between"
+                  sx={{ width: "100%", minWidth: 0 }}
+                >
+                  <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0 }}>
+                    <Box
+                      sx={{
+                        width: 30,
+                        height: 30,
+                        borderRadius: 1,
+                        display: "inline-flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        bgcolor: color.main,
+                        color: "#fff",
+                        flexShrink: 0,
+                      }}
+                    >
+                      <DescriptionOutlined fontSize="small" />
+                    </Box>
+                    <Box sx={{ minWidth: 0 }}>
+                      <Stack direction="row" spacing={0.75} alignItems="center">
+                        <Typography variant="body2" fontWeight={700} sx={{ flexShrink: 0 }}>
+                          근거 {index + 1}
+                        </Typography>
+                        <Typography
+                          variant="body2"
+                          fontWeight={600}
+                          sx={{
+                            minWidth: 0,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {resultSourceName(row)}
+                        </Typography>
+                      </Stack>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{
+                          display: "block",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {(row.content?.trim() || "-").slice(0, 90)}
+                      </Typography>
+                    </Box>
+                  </Stack>
+                  <Stack
+                    direction="row"
+                    spacing={0.5}
+                    alignItems="center"
+                    sx={{
+                      flexShrink: 0,
+                      display: { xs: "none", sm: "flex" },
+                    }}
+                  >
+                    <Chip
+                      icon={<TagOutlined />}
+                      label={chunkValue(row.metadata)}
+                      size="small"
+                      variant="outlined"
+                    />
+                    {typeof row.score === "number" ? (
+                      <Stack direction="row" spacing={0.75} alignItems="center">
+                        <Box
+                          sx={{
+                            position: "relative",
+                            width: 34,
+                            height: 34,
+                            borderRadius: "50%",
+                            background: `conic-gradient(${color.main} ${scorePercent}%, #E5E7EB 0)`,
+                            "&::after": {
+                              content: '""',
+                              position: "absolute",
+                              inset: 4,
+                              borderRadius: "50%",
+                              bgcolor: "background.paper",
+                            },
+                          }}
+                        />
+                        <Chip
+                          icon={<SpeedOutlined />}
+                          label={row.score.toFixed(4)}
+                          size="small"
+                          color={row.score >= 0.7 ? "success" : "warning"}
+                          variant="outlined"
+                        />
+                      </Stack>
+                    ) : null}
+                  </Stack>
+                </Stack>
+              </AccordionSummary>
+              <AccordionDetails sx={{ px: 1.25, pt: 0, pb: 1.25 }}>
+                <Stack
+                  direction="row"
+                  spacing={0.5}
+                  useFlexGap
+                  flexWrap="wrap"
+                  sx={{
+                    display: { xs: "flex", sm: "none" },
+                    mb: 0.75,
+                  }}
+                >
+                  <Chip icon={<TagOutlined />} label={chunkValue(row.metadata)} size="small" variant="outlined" />
+                  {typeof row.score === "number" ? (
+                    <Chip
+                      icon={<SpeedOutlined />}
+                      label={row.score.toFixed(4)}
+                      size="small"
+                      color={row.score >= 0.7 ? "success" : "warning"}
+                      variant="outlined"
+                    />
+                  ) : null}
+                </Stack>
+                <Typography
+                  component="div"
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{
+                    maxHeight: 180,
+                    overflow: "auto",
+                    pr: 0.75,
+                    lineHeight: 1.6,
+                    overflowWrap: "anywhere",
+                    whiteSpace: "pre-wrap",
+                    bgcolor: active ? "#FFFBEB" : "transparent",
+                    borderRadius: 1,
+                    px: active ? 0.75 : 0,
+                    py: active ? 0.5 : 0,
+                    "&::-webkit-scrollbar": {
+                      width: 6,
+                    },
+                    "&::-webkit-scrollbar-thumb": {
+                      borderRadius: 8,
+                      bgcolor: "divider",
+                    },
+                  }}
+                >
+                  {highlightText(row.content?.trim() || "-", query)}
+                </Typography>
+              </AccordionDetails>
+            </Accordion>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}
+
+function AnswerTextBlock({
+  text,
+  onReferenceHover,
+}: {
+  text: string;
+  onReferenceHover: (index: number | null) => void;
+}) {
+  const indices = extractCitationIndices(text);
+  const cleanText = stripCitationLabels(text);
+  return (
+    <Box
+      sx={{ minWidth: 0 }}
+    >
+      <Typography
+        component="div"
+        sx={{
+          overflowWrap: "anywhere",
+          fontSize: 13,
+          lineHeight: 1.75,
+        }}
+      >
+        <MarkdownText
+          text={cleanText}
+          citationIndices={indices}
+          onReferenceHover={onReferenceHover}
+        />
+      </Typography>
+    </Box>
+  );
+}
+
+function AnswerTable({
+  rows,
+  onReferenceHover,
+}: {
+  rows: string[][];
+  onReferenceHover: (index: number | null) => void;
+}) {
+  const [header, ...bodyRows] = rows;
+  if (!header) {
+    return null;
+  }
+  return (
+    <Box sx={{ overflowX: "auto", borderRadius: 1.5 }}>
+      <Box component="table" sx={{ width: "100%", borderCollapse: "collapse", fontSize: 13, lineHeight: 1.9 }}>
+        <Box component="thead" sx={{ bgcolor: ANSWER_BACKGROUND }}>
+          <Box component="tr">
+            {header.map((cell, index) => (
+              <Box
+                key={`${cell}-${index}`}
+                component="th"
+                sx={{
+                  textAlign: "left",
+                  px: 1.25,
+                  py: 1.1,
+                  fontWeight: 700,
+                  color: "text.primary",
+                  borderBottom: 1,
+                  borderColor: "divider",
+                }}
+              >
+                {renderTextWithCitations(cell, onReferenceHover)}
+              </Box>
+            ))}
+          </Box>
+        </Box>
+        <Box component="tbody">
+          {bodyRows.map((row, rowIndex) => (
+            <Box key={rowIndex} component="tr">
+              {header.map((_, cellIndex) => (
+                <Box
+                  key={`${rowIndex}-${cellIndex}`}
+                  component="td"
+                  sx={{
+                    px: 1.25,
+                    py: 1.1,
+                    verticalAlign: "top",
+                    borderBottom: rowIndex === bodyRows.length - 1 ? 0 : 1,
+                    borderColor: "divider",
+                    bgcolor: rowIndex % 2 === 1 ? "rgba(249, 250, 251, 0.72)" : "transparent",
+                    color: "text.secondary",
+                  }}
+                >
+                  {renderTextWithCitations(row[cellIndex] ?? "", onReferenceHover)}
+                </Box>
+              ))}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+function AnswerRenderer({
+  content,
+  onReferenceHover,
+}: {
+  content: string;
+  onReferenceHover: (index: number | null) => void;
+}) {
+  const blocks = parseAnswerBlocks(content);
+  return (
+    <Stack spacing={1.25}>
+      {blocks.map((block, index) =>
+        block.type === "table" ? (
+          <AnswerTable key={`table-${index}`} rows={block.rows} onReferenceHover={onReferenceHover} />
+        ) : (
+          <AnswerTextBlock key={`text-${index}`} text={block.text} onReferenceHover={onReferenceHover} />
+        )
+      )}
+    </Stack>
+  );
+}
+
+function AnswerPanel({
+  messages,
+  referencesCount,
+  onReferenceHover,
+}: {
+  messages: ChatMessageDto[];
+  referencesCount: number;
+  onReferenceHover: (index: number | null) => void;
+}) {
+  return (
+    <Box
+      sx={{
+        borderRadius: 2,
+        bgcolor: ANSWER_BACKGROUND,
+        overflow: "hidden",
+        height: "100%",
+        minWidth: 0,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        sx={{ px: 1.5, py: 1.25 }}
+      >
+        <Typography variant="subtitle2">생성 답변</Typography>
+        {referencesCount > 0 ? (
+          <Chip label={`근거 ${referencesCount}개 사용`} size="small" color="success" variant="outlined" />
+        ) : null}
+      </Stack>
+      <Stack
+        spacing={1.5}
+        sx={{
+          px: 1.5,
+          pb: 1.5,
+          flex: 1,
+          maxHeight: { xs: "none", lg: 520 },
+          overflow: { xs: "visible", lg: "auto" },
+          "&::-webkit-scrollbar": {
+            width: 6,
+          },
+          "&::-webkit-scrollbar-thumb": {
+            borderRadius: 8,
+            bgcolor: "divider",
+          },
+        }}
+      >
+        {messages.map((message, index) => (
+          <Box
+            key={`${message.role}-${index}`}
+            sx={{
+              borderRadius: 1.5,
+              bgcolor: "background.paper",
+              p: 1.5,
+            }}
+          >
+            <AnswerRenderer content={message.content} onReferenceHover={onReferenceHover} />
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+function MetadataPanel({
+  metadata,
+  provider,
+  model,
+}: {
+  metadata: ChatResponseMetadataDto | null;
+  provider: string;
+  model: string;
+}) {
+  return (
+    <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+      <Chip
+        label={metadata ? metadata.provider ?? provider : provider || "-"}
+        size="small"
+        variant="outlined"
+      />
+      <Chip
+        label={metadata ? metadata.resolvedModel ?? model : model || "-"}
+        size="small"
+        variant="outlined"
+      />
+      {metadata ? (
+        <>
+          <Chip label={formatTokenUsage(metadata.tokenUsage)} size="small" variant="outlined" />
+          <Chip label={`${metadata.latencyMs ?? "-"}ms`} size="small" variant="outlined" />
+        </>
+      ) : null}
+    </Stack>
+  );
+}
+
+function LoadingPanel() {
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderColor: "divider",
+        borderRadius: 2,
+        p: 2,
+        bgcolor: "background.paper",
+      }}
+    >
+      <Stack direction="row" spacing={1.25} alignItems="center">
+        <CircularProgress size={18} />
+        <Box>
+          <Typography variant="body2" fontWeight={600}>
+            문맥 기반 답변을 생성하는 중입니다.
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            조회된 RAG 문맥을 기준으로 답변과 근거 정보를 정리합니다.
+          </Typography>
+        </Box>
+      </Stack>
+    </Box>
+  );
+}
+
+function EmptyAnswerPanel() {
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderStyle: "dashed",
+        borderColor: "divider",
+        borderRadius: 2,
+        p: 2,
+        bgcolor: "background.paper",
+      }}
+    >
+      <Typography variant="body2" color="text.secondary">
+        문맥 기반 답변 생성 결과가 여기에 표시됩니다.
+      </Typography>
+    </Box>
+  );
+}
+
+function ContentPreview({
+  title,
+  content,
+  metadata,
+}: {
+  title: string;
+  content?: string | null;
+  metadata?: Record<string, unknown>;
+}) {
+  return (
+    <Box sx={{ border: 1, borderColor: "divider", borderRadius: 2, p: 1.25 }}>
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">{title}</Typography>
+        <Box
+          component="pre"
+          sx={{
+            m: 0,
+            p: 1,
+            minHeight: 120,
+            maxHeight: 300,
+            overflow: "auto",
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+            bgcolor: "action.hover",
+            borderRadius: 2,
+            fontFamily: (theme) => theme.typography.fontFamily,
+            fontSize: 12,
+            lineHeight: 1.7,
+          }}
+        >
+          {content?.trim() || "row를 선택하면 전체 내용이 표시됩니다."}
+        </Box>
+        {metadata ? (
+          <Box
+            component="pre"
+            sx={{
+              m: 0,
+              maxHeight: 160,
+              overflow: "auto",
+              whiteSpace: "pre-wrap",
+              overflowWrap: "anywhere",
+              color: "text.secondary",
+              fontSize: 12,
+            }}
+          >
+            {JSON.stringify(metadata, null, 2)}
+          </Box>
+        ) : null}
+      </Stack>
+    </Box>
+  );
+}
+
+export function RagSearchValidationPanel({ job }: { job: RagIndexJobDto | null }) {
+  const [aiInfo, setAiInfo] = useState<AiInfoResponse | null>(null);
+  const [query, setQuery] = useState("");
+  const [topK, setTopK] = useState("2");
+  const [minScore, setMinScore] = useState("0.7");
+  const [debug, setDebug] = useState(true);
+  const [tab, setTab] = useState<ResultTab>("vector");
+  const [vectorRows, setVectorRows] = useState<VectorSearchResultDto[]>([]);
+  const [ragRows, setRagRows] = useState<SearchResultDto[]>([]);
+  const [selectedVector, setSelectedVector] = useState<VectorSearchResultDto | null>(null);
+  const [selectedRag, setSelectedRag] = useState<SearchResultDto | null>(null);
+  const [messages, setMessages] = useState<ChatMessageDto[]>([]);
+  const [lastMetadata, setLastMetadata] = useState<ChatResponseMetadataDto | null>(null);
+  const [diagnostics, setDiagnostics] = useState<Record<string, unknown> | null>(null);
+  const [runningAction, setRunningAction] = useState<RunningAction>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [answerError, setAnswerError] = useState(false);
+  const [lastVectorKey, setLastVectorKey] = useState<string | null>(null);
+  const [lastRagKey, setLastRagKey] = useState<string | null>(null);
+  const [lastAnswerKey, setLastAnswerKey] = useState<string | null>(null);
+  const [activeReferenceIndex, setActiveReferenceIndex] = useState<number | null>(null);
+
+  const provider = aiInfo?.defaultProvider ?? "";
+  const model = aiInfo?.providers.find((item) => item.name === provider)?.chat.model ?? "";
+  const topKNumber = Math.max(1, Number(topK) || 5);
+  const minScoreNumber = minScore.trim() === "" ? undefined : Number(minScore);
+  const searchScope = job ? { objectType: job.objectType, objectId: job.objectId } : {};
+  const isRunning = runningAction != null;
+  const currentSearchKey = buildRequestKey({
+    query: query.trim(),
+    topK: topKNumber,
+    minScore: Number.isFinite(minScoreNumber) ? minScoreNumber : undefined,
+    ...searchScope,
+  });
+  const currentRagKey = buildRequestKey({
+    query: query.trim(),
+    topK: topKNumber,
+    hybrid: true,
+    ...searchScope,
+  });
+  const currentAnswerKey = buildRequestKey({
+    search: currentSearchKey,
+    rag: lastRagKey === currentRagKey ? currentRagKey : null,
+    provider,
+    model,
+    debug,
+  });
+  const vectorLoaded = lastVectorKey === currentSearchKey;
+  const ragLoaded = lastRagKey === currentRagKey;
+  const answerLoaded = lastAnswerKey === currentAnswerKey && (messages.length > 0 || answerError);
+
+  useEffect(() => {
+    let alive = true;
+    reactAiApi
+      .fetchProviders()
+      .then((response) => {
+        if (alive) {
+          setAiInfo(response);
+        }
+      })
+      .catch((providerError) => {
+        if (alive) {
+          setError(resolveAxiosError(providerError));
+        }
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    setVectorRows([]);
+    setRagRows([]);
+    setSelectedVector(null);
+    setSelectedRag(null);
+    setMessages([]);
+    setLastMetadata(null);
+    setDiagnostics(null);
+    setError(null);
+    setAnswerError(false);
+    setLastVectorKey(null);
+    setLastRagKey(null);
+    setLastAnswerKey(null);
+    setActiveReferenceIndex(null);
+  }, [job?.jobId]);
+
+  const vectorColumns = useMemo<ColDef<VectorSearchResultDto>[]>(
+    () => [
+      { field: "id", headerName: "ID", width: 70, filter: false, cellClass: "ag-center-cell" },
+      {
+        field: "score",
+        headerName: "유사도",
+        width: 90,
+        filter: false,
+        cellClass: "ag-center-cell",
+        valueFormatter: (params) =>
+          typeof params.value === "number" ? params.value.toFixed(4) : "-",
+      },
+      {
+        colId: "chunk",
+        headerName: "Chunk",
+        width: 80,
+        filter: false,
+        cellClass: "ag-center-cell",
+        valueGetter: (params) => chunkValue(params.data?.metadata),
+      },
+      { field: "content", headerName: "콘텐츠", flex: 1, minWidth: 420, filter: false },
+    ],
+    []
+  );
+
+  const ragColumns = useMemo<ColDef<SearchResultDto>[]>(
+    () => [
+      { field: "documentId", headerName: "Document", width: 120, filter: false },
+      {
+        field: "score",
+        headerName: "유사도",
+        width: 90,
+        filter: false,
+        cellClass: "ag-center-cell",
+        valueFormatter: (params) =>
+          typeof params.value === "number" ? params.value.toFixed(4) : "-",
+      },
+      {
+        colId: "chunk",
+        headerName: "Chunk",
+        width: 80,
+        filter: false,
+        cellClass: "ag-center-cell",
+        valueGetter: (params) => chunkValue(params.data?.metadata),
+      },
+      { field: "content", headerName: "콘텐츠", flex: 1, minWidth: 420, filter: false },
+    ],
+    []
+  );
+
+  async function handleVectorSearch(force = false) {
+    if (!query.trim()) {
+      return;
+    }
+    if (!force && vectorLoaded) {
+      setTab("vector");
+      return;
+    }
+    setRunningAction("vector");
+    setTab("vector");
+    setError(null);
+    setVectorRows([]);
+    setSelectedVector(null);
+    try {
+      const response = await reactAiApi.searchVector({
+        query: query.trim(),
+        topK: topKNumber,
+        ...searchScope,
+        minScore: Number.isFinite(minScoreNumber) ? minScoreNumber : undefined,
+      });
+      setVectorRows(response);
+      setLastVectorKey(currentSearchKey);
+    } catch (searchError) {
+      setError(resolveAxiosError(searchError));
+      setLastVectorKey(null);
+    } finally {
+      setRunningAction(null);
+    }
+  }
+
+  async function handleRagSearch(force = false) {
+    if (!query.trim()) {
+      return;
+    }
+    if (!force && ragLoaded) {
+      setTab("rag");
+      return;
+    }
+    setRunningAction("rag");
+    setTab("rag");
+    setError(null);
+    setRagRows([]);
+    setSelectedRag(null);
+    setMessages([]);
+    setLastMetadata(null);
+    setDiagnostics(null);
+    setAnswerError(false);
+    setLastAnswerKey(null);
+    setActiveReferenceIndex(null);
+    try {
+      const response = await reactAiApi.searchRag({
+        query: query.trim(),
+        topK: topKNumber,
+        hybrid: true,
+        ...searchScope,
+      });
+      setRagRows(response);
+      setLastRagKey(currentRagKey);
+    } catch (searchError) {
+      setError(resolveAxiosError(searchError));
+      setLastRagKey(null);
+    } finally {
+      setRunningAction(null);
+    }
+  }
+
+  async function handleAnswer(force = false) {
+    if (!query.trim()) {
+      return;
+    }
+    if (!force && answerLoaded) {
+      setTab("answer");
+      return;
+    }
+    setRunningAction("answer");
+    setTab("answer");
+    setError(null);
+    setMessages([]);
+    setLastMetadata(null);
+    setDiagnostics(null);
+    setAnswerError(false);
+    setActiveReferenceIndex(null);
+    const visibleRagContext = buildVisibleRagContext(ragRows, topKNumber);
+    try {
+      const response = await reactAiApi.sendRagChat({
+        chat: {
+          provider: provider || undefined,
+          model: model || undefined,
+          systemPrompt: [
+            "제공된 RAG 문서 내용에 근거해서만 답변하세요. 문서에서 확인할 수 없는 내용은 확인할 수 없다고 답변하세요.",
+            "답변에서 참고 문서를 언급할 때는 긴 문서명이나 Chunk를 쓰지 말고 반드시 (근거 1), (근거 2) 형식만 사용하세요.",
+            "같은 문장 안에서는 근거를 반복하지 말고 문장 끝에 필요한 근거만 한 번 모아서 표시하세요.",
+            "표가 적절한 경우 Markdown table로 작성하고, 표의 셀이나 행에도 필요한 경우 (근거 N)을 붙이세요.",
+            visibleRagContext
+              ? `아래는 현재 화면의 RAG 결과입니다. 이 내용을 우선 근거로 사용하세요.\n${visibleRagContext}`
+              : "",
+          ].filter(Boolean).join("\n\n"),
+          messages: [{ role: "user", content: query.trim() }],
+        },
+        ragQuery: query.trim(),
+        ragTopK: topKNumber,
+        topK: topKNumber,
+        ...searchScope,
+        minScore: Number.isFinite(minScoreNumber) ? minScoreNumber : undefined,
+        debug,
+      });
+      setMessages(response.messages ?? []);
+      setLastMetadata(response.metadata ?? null);
+      const ragDiagnostics = response.metadata?.ragDiagnostics;
+      const contextDiagnostics = response.metadata?.ragContextDiagnostics;
+      setDiagnostics(
+        ragDiagnostics || contextDiagnostics
+          ? { retrieval: ragDiagnostics, context: contextDiagnostics }
+          : null
+      );
+      setAnswerError(false);
+      setLastAnswerKey(currentAnswerKey);
+    } catch (answerError) {
+      setError(resolveAxiosError(answerError));
+      setAnswerError(true);
+      setLastAnswerKey(currentAnswerKey);
+    } finally {
+      setRunningAction(null);
+    }
+  }
+
+  return (
+    <Stack spacing={1.5} sx={{ mt: 1.5 }}>
+      <Stack direction={{ xs: "column", md: "row" }} spacing={1} alignItems={{ md: "center" }}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="subtitle1">검색 검증</Typography>
+          <Typography variant="caption" color="text.secondary" noWrap>
+            {job
+              ? `${sourceDisplayName(job)} / ${job.objectType} #${job.objectId}`
+              : "색인 작업을 선택하지 않으면 전체 RAG 범위에서 검색합니다."}
+          </Typography>
+        </Box>
+      </Stack>
+
+      {error ? <Alert severity="error">{error}</Alert> : null}
+
+      <Stack direction={{ xs: "column", md: "row" }} spacing={1} alignItems={{ md: "center" }}>
+        <TextField
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setVectorRows([]);
+            setRagRows([]);
+            setMessages([]);
+            setAnswerError(false);
+            setSelectedVector(null);
+            setSelectedRag(null);
+            setLastVectorKey(null);
+            setLastRagKey(null);
+            setLastAnswerKey(null);
+            setActiveReferenceIndex(null);
+          }}
+          placeholder="검증 쿼리 입력"
+          size="small"
+          fullWidth
+          inputProps={{ "aria-label": "검증 쿼리" }}
+        />
+        <TextField
+          label="Top K"
+          value={topK}
+          onChange={(event) => setTopK(event.target.value)}
+          size="small"
+          sx={{ width: { xs: "100%", md: 110 } }}
+        />
+        <TextField
+          label="Min Score"
+          value={minScore}
+          onChange={(event) => setMinScore(event.target.value)}
+          size="small"
+          sx={{ width: { xs: "100%", md: 130 } }}
+        />
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Typography variant="caption" color="text.secondary">
+            Debug
+          </Typography>
+          <Switch checked={debug} onChange={(event) => setDebug(event.target.checked)} />
+        </Stack>
+      </Stack>
+
+      <Stack spacing={0.5} alignItems="flex-start">
+        <ButtonGroup
+          variant="outlined"
+          size="small"
+          sx={{
+            flexWrap: "wrap",
+            "& .MuiButton-root": {
+              minWidth: { xs: 150, md: 180 },
+              px: 2,
+            },
+          }}
+        >
+          <Button
+            variant={tab === "vector" ? "contained" : "outlined"}
+            onClick={() => void handleVectorSearch()}
+            disabled={isRunning || !query.trim()}
+            startIcon={
+              runningAction === "vector" ? <CircularProgress size={16} color="inherit" /> : undefined
+            }
+          >
+            <Tooltip describeChild title={vectorLoaded ? "배지를 클릭하면 같은 조건으로 다시 조회합니다." : ""}>
+              <Badge
+                badgeContent={vectorLoaded ? vectorRows.length : null}
+                color={vectorRows.length === 0 ? "default" : "primary"}
+                invisible={!vectorLoaded}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  if (!isRunning && query.trim()) {
+                    void handleVectorSearch(true);
+                  }
+                }}
+                sx={{
+                  cursor: vectorLoaded ? "pointer" : "inherit",
+                  "& .MuiBadge-badge": { right: -14 },
+                }}
+              >
+                <Box component="span">벡터 검색</Box>
+              </Badge>
+            </Tooltip>
+          </Button>
+          <Button
+            variant={tab === "rag" ? "contained" : "outlined"}
+            onClick={() => void handleRagSearch()}
+            disabled={isRunning || !query.trim()}
+            startIcon={runningAction === "rag" ? <CircularProgress size={16} color="inherit" /> : undefined}
+          >
+            <Tooltip describeChild title={ragLoaded ? "배지를 클릭하면 같은 조건으로 다시 조회합니다." : ""}>
+              <Badge
+                badgeContent={ragLoaded ? ragRows.length : null}
+                color={ragRows.length === 0 ? "default" : "primary"}
+                invisible={!ragLoaded}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  if (!isRunning && query.trim()) {
+                    void handleRagSearch(true);
+                  }
+                }}
+                sx={{
+                  cursor: ragLoaded ? "pointer" : "inherit",
+                  "& .MuiBadge-badge": { right: -14 },
+                }}
+              >
+                <Box component="span">RAG 결과 조회</Box>
+              </Badge>
+            </Tooltip>
+          </Button>
+          <Button
+            variant={tab === "answer" ? "contained" : "outlined"}
+            onClick={() => void handleAnswer()}
+            disabled={isRunning || !query.trim()}
+            startIcon={
+              runningAction === "answer" ? <CircularProgress size={16} color="inherit" /> : undefined
+            }
+          >
+            <Tooltip describeChild title={answerLoaded ? "배지를 클릭하면 같은 조건으로 다시 생성합니다." : ""}>
+              <Badge
+                badgeContent={
+                  answerLoaded
+                    ? answerError
+                      ? <BugReportOutlined sx={{ fontSize: 12 }} />
+                      : "완료"
+                    : null
+                }
+                color={answerError ? "error" : "success"}
+                invisible={!answerLoaded}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  if (!isRunning && query.trim()) {
+                    void handleAnswer(true);
+                  }
+                }}
+                sx={{
+                  cursor: answerLoaded ? "pointer" : "inherit",
+                  "& .MuiBadge-badge": {
+                    minWidth: answerError ? 18 : undefined,
+                    right: answerError ? -12 : -18,
+                  },
+                }}
+              >
+                <Box component="span">문맥 기반 답변 생성</Box>
+              </Badge>
+            </Tooltip>
+          </Button>
+        </ButtonGroup>
+      </Stack>
+
+      {tab === "vector" ? (
+        <Stack spacing={1}>
+          <GridContent<VectorSearchResultDto>
+            columns={vectorColumns}
+            rowData={vectorRows}
+            loading={runningAction === "vector"}
+            height={280}
+            events={[
+              {
+                type: "rowClicked",
+                listener: (event) =>
+                  setSelectedVector((event as { data?: VectorSearchResultDto }).data ?? null),
+              },
+            ]}
+          />
+          <ContentPreview
+            title="선택한 벡터 결과"
+            content={selectedVector?.content}
+            metadata={selectedVector?.metadata}
+          />
+        </Stack>
+      ) : null}
+
+      {tab === "rag" ? (
+        <Stack spacing={1}>
+          <GridContent<SearchResultDto>
+            columns={ragColumns}
+            rowData={ragRows}
+            loading={runningAction === "rag"}
+            height={280}
+            events={[
+              {
+                type: "rowClicked",
+                listener: (event) => setSelectedRag((event as { data?: SearchResultDto }).data ?? null),
+              },
+            ]}
+          />
+          <ContentPreview
+            title="선택한 RAG 결과"
+            content={selectedRag?.content}
+            metadata={selectedRag?.metadata}
+          />
+        </Stack>
+      ) : null}
+
+      {tab === "answer" ? (
+        <Stack spacing={1}>
+          {runningAction === "answer" ? (
+            <LoadingPanel />
+          ) : messages.length ? (
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: {
+                  xs: "minmax(0, 1fr)",
+                  lg: "minmax(0, 1fr) minmax(0, 1fr)",
+                },
+                gap: 1.25,
+                alignItems: "stretch",
+              }}
+            >
+              <AnswerPanel
+                messages={messages}
+                referencesCount={Math.min(ragRows.length, topKNumber)}
+                onReferenceHover={setActiveReferenceIndex}
+              />
+              <ReferenceDocuments
+                rows={ragRows}
+                topK={topKNumber}
+                query={query}
+                activeReferenceIndex={activeReferenceIndex}
+              />
+            </Box>
+          ) : (
+            <EmptyAnswerPanel />
+          )}
+          <MetadataPanel metadata={lastMetadata} provider={provider} model={model} />
+          {diagnostics ? (
+            <Box
+              component="pre"
+              sx={{
+                m: 0,
+                p: 1,
+                maxHeight: 220,
+                overflow: "auto",
+                bgcolor: "action.hover",
+                borderRadius: 2,
+                fontSize: 12,
+              }}
+            >
+              {JSON.stringify(diagnostics, null, 2)}
+            </Box>
+          ) : null}
+        </Stack>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/api.ts
+++ b/src/react/pages/ai/api.ts
@@ -15,6 +15,18 @@ import type {
   ConversationSummaryDto,
   QueryRewriteRequestDto,
   QueryRewriteResponseDto,
+  RagChunkConfigResponseDto,
+  RagChunkPreviewRequestDto,
+  RagChunkPreviewResponseDto,
+  RagIndexChunkDto,
+  RagIndexChunkPageResponseDto,
+  RagIndexJobCreateRequestDto,
+  RagIndexJobDto,
+  RagIndexJobListResponseDto,
+  RagIndexJobLogDto,
+  RagIndexJobStatus,
+  SearchRequestDto,
+  SearchResponseDto,
   RegenerateRequestDto,
   VectorSearchRequestDto,
   VectorSearchResultDto,
@@ -157,6 +169,73 @@ export const reactAiApi = {
 
   searchVector(req: VectorSearchRequestDto) {
     return apiRequest<VectorSearchResultDto[]>("post", `${MGMT_BASE}/vectors/search`, { data: req });
+  },
+
+  async searchRag(req: SearchRequestDto) {
+    const response = await apiRequest<SearchResponseDto>("post", `${MGMT_BASE}/rag/search`, { data: req });
+    return response.results ?? [];
+  },
+
+  listRagJobs(params?: {
+    status?: RagIndexJobStatus | "";
+    objectType?: string;
+    objectId?: string;
+    documentId?: string;
+    offset?: number;
+    limit?: number;
+    sort?: string;
+    direction?: "asc" | "desc";
+  }) {
+    return apiRequest<RagIndexJobListResponseDto>("get", `${MGMT_BASE}/rag/jobs`, { params });
+  },
+
+  getRagJob(jobId: string) {
+    return apiRequest<RagIndexJobDto>("get", `${MGMT_BASE}/rag/jobs/${encodeURIComponent(jobId)}`);
+  },
+
+  createRagJob(req: RagIndexJobCreateRequestDto) {
+    return apiRequest<RagIndexJobDto>("post", `${MGMT_BASE}/rag/jobs`, { data: req });
+  },
+
+  retryRagJob(jobId: string) {
+    return apiRequest<RagIndexJobDto>("post", `${MGMT_BASE}/rag/jobs/${encodeURIComponent(jobId)}/retry`);
+  },
+
+  cancelRagJob(jobId: string) {
+    return apiRequest<RagIndexJobDto>("post", `${MGMT_BASE}/rag/jobs/${encodeURIComponent(jobId)}/cancel`);
+  },
+
+  getRagJobLogs(jobId: string) {
+    return apiRequest<RagIndexJobLogDto[]>("get", `${MGMT_BASE}/rag/jobs/${encodeURIComponent(jobId)}/logs`);
+  },
+
+  getRagJobChunks(jobId: string, limit = 200) {
+    return apiRequest<RagIndexChunkDto[]>("get", `${MGMT_BASE}/rag/jobs/${encodeURIComponent(jobId)}/chunks`, {
+      params: { limit },
+    });
+  },
+
+  getRagObjectChunksPage(objectType: string, objectId: string, offset = 0, limit = 50) {
+    return apiRequest<RagIndexChunkPageResponseDto>(
+      "get",
+      `${MGMT_BASE}/rag/objects/${encodeURIComponent(objectType)}/${encodeURIComponent(objectId)}/chunks/page`,
+      { params: { offset, limit } }
+    );
+  },
+
+  getRagObjectMetadata(objectType: string, objectId: string) {
+    return apiRequest<Record<string, unknown>>(
+      "get",
+      `${MGMT_BASE}/rag/objects/${encodeURIComponent(objectType)}/${encodeURIComponent(objectId)}/metadata`
+    );
+  },
+
+  getRagChunkConfig() {
+    return apiRequest<RagChunkConfigResponseDto>("get", `${MGMT_BASE}/rag/chunks/config`);
+  },
+
+  previewRagChunks(req: RagChunkPreviewRequestDto) {
+    return apiRequest<RagChunkPreviewResponseDto>("post", `${MGMT_BASE}/rag/chunks/preview`, { data: req });
   },
 
   rewriteQuery(req: QueryRewriteRequestDto) {

--- a/src/react/pages/ai/api.ts
+++ b/src/react/pages/ai/api.ts
@@ -1,11 +1,20 @@
 import { apiRequest } from "@/react/query/fetcher";
+import { API_BASE_URL } from "@/config/backend";
+import { authStore } from "@/react/auth/store";
 import type {
   AiInfoResponse,
   ChatRagRequestDto,
   ChatRequestDto,
   ChatResponseDto,
+  ChatStreamCompleteEventDto,
+  ChatStreamDeltaEventDto,
+  ChatStreamUsageEventDto,
+  ConversationDeleteResponseDto,
+  ConversationDetailDto,
+  ConversationSummaryDto,
   QueryRewriteRequestDto,
   QueryRewriteResponseDto,
+  RegenerateRequestDto,
   VectorSearchRequestDto,
   VectorSearchResultDto,
 } from "@/types/studio/ai";
@@ -24,6 +33,106 @@ export const reactAiApi = {
 
   fetchProviders() {
     return apiRequest<AiInfoResponse>("get", `${BASE}/info/providers`);
+  },
+
+  listConversations() {
+    return apiRequest<ConversationSummaryDto[]>("get", `${BASE}/chat/conversations`);
+  },
+
+  getConversation(conversationId: string) {
+    return apiRequest<ConversationDetailDto>("get", `${BASE}/chat/conversations/${encodeURIComponent(conversationId)}`);
+  },
+
+  deleteConversation(conversationId: string) {
+    return apiRequest<ConversationDeleteResponseDto>("delete", `${BASE}/chat/conversations/${encodeURIComponent(conversationId)}`);
+  },
+
+  regenerate(req: RegenerateRequestDto) {
+    return apiRequest<ChatResponseDto>("post", `${BASE}/chat/regenerate`, { data: req });
+  },
+
+  async sendChatStream(
+    req: ChatRequestDto,
+    handlers: {
+      onDelta?: (payload: ChatStreamDeltaEventDto) => void;
+      onUsage?: (payload: ChatStreamUsageEventDto) => void;
+      onComplete?: (payload: ChatStreamCompleteEventDto) => void;
+    }
+  ) {
+    const token = authStore.getState().token;
+    const response = await fetch(`${API_BASE_URL}${BASE}/chat/stream`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      credentials: "include",
+      body: JSON.stringify(req),
+    });
+
+    if (!response.ok || !response.body) {
+      throw new Error(`채팅 스트림 요청에 실패했습니다. (${response.status})`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    const flush = (rawBlock: string) => {
+      const lines = rawBlock.split(/\r?\n/);
+      let currentEvent = "message";
+      const dataLines: string[] = [];
+      for (const line of lines) {
+        if (line.startsWith("event:")) {
+          currentEvent = line.slice(6).trim();
+        } else if (line.startsWith("data:")) {
+          dataLines.push(line.slice(5).trimStart());
+        }
+      }
+      const data = dataLines.join("\n").trim();
+      if (!data) {
+        return;
+      }
+      let parsed:
+        | ChatStreamDeltaEventDto
+        | ChatStreamUsageEventDto
+        | ChatStreamCompleteEventDto;
+      try {
+        parsed = JSON.parse(data) as
+          | ChatStreamDeltaEventDto
+          | ChatStreamUsageEventDto
+          | ChatStreamCompleteEventDto;
+      } catch {
+        throw new Error(`채팅 스트림 응답을 해석할 수 없습니다. (${currentEvent})`);
+      }
+
+      if (currentEvent === "delta") {
+        handlers.onDelta?.(parsed as ChatStreamDeltaEventDto);
+      } else if (currentEvent === "usage") {
+        handlers.onUsage?.(parsed as ChatStreamUsageEventDto);
+      } else if (currentEvent === "complete") {
+        handlers.onComplete?.(parsed as ChatStreamCompleteEventDto);
+      }
+    };
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const chunks = buffer.split(/\r?\n\r?\n/);
+      buffer = chunks.pop() ?? "";
+
+      for (const chunk of chunks) {
+        flush(chunk);
+      }
+    }
+
+    if (buffer.trim()) {
+      flush(buffer);
+    }
   },
 
   searchVector(req: VectorSearchRequestDto) {

--- a/src/react/pages/ai/api.ts
+++ b/src/react/pages/ai/api.ts
@@ -1,6 +1,7 @@
 import { apiRequest } from "@/react/query/fetcher";
 import { API_BASE_URL } from "@/config/backend";
 import { authStore } from "@/react/auth/store";
+import { parseJwtExp } from "@/utils/jwt";
 import type {
   AiInfoResponse,
   ChatRagRequestDto,
@@ -21,6 +22,25 @@ import type {
 
 const BASE = "/api/ai";
 const MGMT_BASE = "/api/mgmt/ai";
+
+function isTokenExpired(token: string, skewSeconds = 30) {
+  const exp = parseJwtExp(token);
+  if (!exp) return true;
+  return exp < Math.floor(Date.now() / 1000) + skewSeconds;
+}
+
+async function getAccessTokenForFetch() {
+  const state = authStore.getState();
+  let token = state.token;
+
+  if (!token) {
+    token = await state.refreshTokens();
+  } else if (isTokenExpired(token)) {
+    token = await state.refreshTokens();
+  }
+
+  return token;
+}
 
 export const reactAiApi = {
   sendChat(req: ChatRequestDto) {
@@ -59,7 +79,7 @@ export const reactAiApi = {
       onComplete?: (payload: ChatStreamCompleteEventDto) => void;
     }
   ) {
-    const token = authStore.getState().token;
+    const token = await getAccessTokenForFetch();
     const response = await fetch(`${API_BASE_URL}${BASE}/chat/stream`, {
       method: "POST",
       headers: {

--- a/src/react/pages/ai/components/AssistantMessageBubble.tsx
+++ b/src/react/pages/ai/components/AssistantMessageBubble.tsx
@@ -1,0 +1,97 @@
+import { Box, IconButton, Stack, Tooltip, Typography } from "@mui/material";
+import { ContentCopyOutlined, RefreshOutlined, SyncOutlined } from "@mui/icons-material";
+import type { ChatMessage, ChatResponseMetadataDto } from "@/react/pages/ai/components/chatTypes";
+
+function renderTokenUsage(metadata?: ChatResponseMetadataDto) {
+  const usage = metadata?.tokenUsage;
+  if (!usage) return null;
+
+  return (
+    <Typography variant="caption" color="text.secondary" sx={{ mt: 0.75, display: "block", fontSize: 11 }}>
+      tokens · input {usage.inputTokens ?? "-"} · output {usage.outputTokens ?? "-"} · total{" "}
+      {usage.totalTokens ?? "-"}
+      {metadata?.latencyMs ? ` · ${metadata.latencyMs}ms` : ""}
+    </Typography>
+  );
+}
+
+function formatMessageTime(value?: string) {
+  if (!value) return "";
+  return new Date(value).toLocaleTimeString("ko-KR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+interface Props {
+  message: ChatMessage;
+  sending: boolean;
+  isLastAssistant: boolean;
+  onCopy: (content: string) => void;
+  onRegenerate: () => void;
+  onRetryLastUser: () => void;
+}
+
+export function AssistantMessageBubble({
+  message,
+  sending,
+  isLastAssistant,
+  onCopy,
+  onRegenerate,
+  onRetryLastUser,
+}: Props) {
+  const isErrorMessage =
+    message.metadata?.finishReason === "error" || message.content.startsWith("오류:");
+
+  return (
+    <Stack spacing={0.5} alignItems="flex-start" sx={{ width: "100%" }}>
+      <Box
+        sx={{
+          maxWidth: { xs: "92%", md: "72%" },
+          px: 2,
+          py: 1.5,
+          borderRadius: "18px 18px 18px 4px",
+          bgcolor: "background.paper",
+          color: "text.primary",
+          border: "none",
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          Assistant{message.model ? ` · ${message.model}` : ""}
+        </Typography>
+        <Typography sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: 13 }}>
+          {message.content || (sending ? "응답 생성 중..." : "")}
+        </Typography>
+        {renderTokenUsage(message.metadata)}
+      </Box>
+      <Stack direction="row" spacing={0.5} alignItems="center" sx={{ pl: 0.25 }}>
+        {message.createdAt ? (
+          <Typography variant="caption" color="text.secondary">
+            {formatMessageTime(message.createdAt)}
+          </Typography>
+        ) : null}
+        <Tooltip title="복사">
+          <IconButton size="small" onClick={() => onCopy(message.content)}>
+            <ContentCopyOutlined fontSize="inherit" />
+          </IconButton>
+        </Tooltip>
+        {isLastAssistant ? (
+          <Tooltip title="답변 다시 생성">
+            <span>
+              <IconButton size="small" disabled={sending} onClick={onRegenerate}>
+                <SyncOutlined fontSize="inherit" />
+              </IconButton>
+            </span>
+          </Tooltip>
+        ) : null}
+        {isErrorMessage ? (
+          <Tooltip title="마지막 질문 다시 보내기">
+            <IconButton size="small" onClick={onRetryLastUser}>
+              <RefreshOutlined fontSize="inherit" />
+            </IconButton>
+          </Tooltip>
+        ) : null}
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/components/AssistantMessageBubble.tsx
+++ b/src/react/pages/ai/components/AssistantMessageBubble.tsx
@@ -35,6 +35,18 @@ function metadataValue(reference: RagReferenceDto, keys: string[]) {
   return "";
 }
 
+function formatLocationFromSourceRef(sourceRef: string) {
+  const pageMatch = sourceRef.match(/page\[(\d+)]/i) ?? sourceRef.match(/\bpage\s*[:#-]?\s*(\d+)/i);
+  if (pageMatch?.[1]) {
+    return `페이지 ${pageMatch[1]}`;
+  }
+  const slideMatch = sourceRef.match(/slide\[(\d+)]/i) ?? sourceRef.match(/\bslide\s*[:#-]?\s*(\d+)/i);
+  if (slideMatch?.[1]) {
+    return `슬라이드 ${slideMatch[1]}`;
+  }
+  return "";
+}
+
 function normalizeReference(reference: RagReferenceDto, fallbackIndex: number): NormalizedRagReference {
   const title =
     reference.sourceName ||
@@ -43,14 +55,11 @@ function normalizeReference(reference: RagReferenceDto, fallbackIndex: number): 
     `근거 ${reference.index ?? fallbackIndex}`;
   const page = reference.page ?? reference.pageNumber ?? metadataValue(reference, ["page", "pageNumber", "page_number"]);
   const slide = reference.slide ?? reference.slideNumber ?? metadataValue(reference, ["slide", "slideNumber", "slide_number"]);
-  const chunkOrder = reference.chunkOrder ?? metadataValue(reference, ["chunkOrder", "chunkIndex", "chunk_order", "chunk_index"]);
+  const sourceRef = reference.sourceRef || reference.sourceRefs || metadataValue(reference, ["sourceRef", "sourceRefs"]);
   const chunk =
-    (page != null && page !== "" ? `p.${stringifyValue(page)}` : "") ||
-    (slide != null && slide !== "" ? `slide ${stringifyValue(slide)}` : "") ||
-    (chunkOrder != null && chunkOrder !== "" ? `chunk #${stringifyValue(chunkOrder)}` : "") ||
-    reference.sourceRef ||
-    reference.chunkId ||
-    metadataValue(reference, ["sourceRef", "chunkId", "chunk_id", "id"]);
+    (page != null && page !== "" ? `페이지 ${stringifyValue(page)}` : "") ||
+    (slide != null && slide !== "" ? `슬라이드 ${stringifyValue(slide)}` : "") ||
+    (sourceRef ? formatLocationFromSourceRef(sourceRef) : "");
 
   return {
     index: reference.index ?? fallbackIndex,

--- a/src/react/pages/ai/components/AssistantMessageBubble.tsx
+++ b/src/react/pages/ai/components/AssistantMessageBubble.tsx
@@ -1,6 +1,67 @@
-import { Box, IconButton, Stack, Tooltip, Typography } from "@mui/material";
-import { ContentCopyOutlined, RefreshOutlined, SyncOutlined } from "@mui/icons-material";
+import { useState } from "react";
+import { Box, Divider, IconButton, Popover, Stack, Tooltip, Typography } from "@mui/material";
+import { ContentCopyOutlined, DescriptionOutlined, RefreshOutlined, SyncOutlined } from "@mui/icons-material";
 import type { ChatMessage, ChatResponseMetadataDto } from "@/react/pages/ai/components/chatTypes";
+
+const numberFormatter = new Intl.NumberFormat("ko-KR");
+
+function formatNumber(value?: number) {
+  return typeof value === "number" ? numberFormatter.format(value) : "-";
+}
+
+interface RagReference {
+  index?: number;
+  title?: string;
+  chunk?: string;
+  score?: number;
+  content?: string;
+}
+
+function getRagReferences(metadata?: ChatResponseMetadataDto): RagReference[] {
+  const references = metadata?.ragReferences;
+  return Array.isArray(references) ? references.slice(0, 5) as RagReference[] : [];
+}
+
+function formatReferenceTitle(reference: RagReference) {
+  return [reference.title || `근거 ${reference.index ?? ""}`, reference.chunk].filter(Boolean).join(" · ");
+}
+
+function formatReferenceSummary(reference: RagReference) {
+  return (reference.content ?? "").replace(/\s+/g, " ").trim();
+}
+
+function scorePercent(score?: number) {
+  if (typeof score !== "number") {
+    return undefined;
+  }
+  return Math.max(0, Math.min(100, Math.round(score * 100)));
+}
+
+function scoreLabel(percent?: number) {
+  if (percent == null) {
+    return "";
+  }
+  if (percent >= 80) {
+    return "높음";
+  }
+  if (percent >= 60) {
+    return "보통";
+  }
+  return "낮음";
+}
+
+function scoreColor(percent?: number) {
+  if (percent == null) {
+    return "text.secondary";
+  }
+  if (percent >= 80) {
+    return "success.main";
+  }
+  if (percent >= 60) {
+    return "primary.main";
+  }
+  return "warning.main";
+}
 
 function renderTokenUsage(metadata?: ChatResponseMetadataDto) {
   const usage = metadata?.tokenUsage;
@@ -8,11 +69,25 @@ function renderTokenUsage(metadata?: ChatResponseMetadataDto) {
 
   return (
     <Typography variant="caption" color="text.secondary" sx={{ mt: 0.75, display: "block", fontSize: 11 }}>
-      tokens · input {usage.inputTokens ?? "-"} · output {usage.outputTokens ?? "-"} · total{" "}
-      {usage.totalTokens ?? "-"}
-      {metadata?.latencyMs ? ` · ${metadata.latencyMs}ms` : ""}
+      tokens · input {formatNumber(usage.inputTokens)} · output {formatNumber(usage.outputTokens)} · total{" "}
+      {formatNumber(usage.totalTokens)}
+      {metadata?.latencyMs ? ` · ${formatNumber(metadata.latencyMs)}ms` : ""}
     </Typography>
   );
+}
+
+function renderInlineMarkdown(text: string) {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g);
+  return parts.map((part, index) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      return (
+        <Box component="strong" key={`${part}-${index}`} sx={{ fontWeight: 700 }}>
+          {part.slice(2, -2)}
+        </Box>
+      );
+    }
+    return part;
+  });
 }
 
 function formatMessageTime(value?: string) {
@@ -40,8 +115,11 @@ export function AssistantMessageBubble({
   onRegenerate,
   onRetryLastUser,
 }: Props) {
+  const [sourceAnchorEl, setSourceAnchorEl] = useState<HTMLElement | null>(null);
   const isErrorMessage =
     message.metadata?.finishReason === "error" || message.content.startsWith("오류:");
+  const ragReferences = getRagReferences(message.metadata);
+  const sourcePopoverOpen = Boolean(sourceAnchorEl);
 
   return (
     <Stack spacing={0.5} alignItems="flex-start" sx={{ width: "100%" }}>
@@ -59,8 +137,8 @@ export function AssistantMessageBubble({
         <Typography variant="caption" color="text.secondary">
           Assistant{message.model ? ` · ${message.model}` : ""}
         </Typography>
-        <Typography sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: 13 }}>
-          {message.content || (sending ? "응답 생성 중..." : "")}
+        <Typography component="div" sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: 13 }}>
+          {message.content ? renderInlineMarkdown(message.content) : (sending ? "응답 생성 중..." : "")}
         </Typography>
         {renderTokenUsage(message.metadata)}
       </Box>
@@ -90,6 +168,150 @@ export function AssistantMessageBubble({
               <RefreshOutlined fontSize="inherit" />
             </IconButton>
           </Tooltip>
+        ) : null}
+        {ragReferences.length > 0 ? (
+          <>
+            <Box
+              component="button"
+              type="button"
+              onClick={(event) => setSourceAnchorEl(event.currentTarget)}
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.75,
+                border: 0,
+                px: 1,
+                py: 0.45,
+                ml: 0.5,
+                borderRadius: "999px",
+                bgcolor: "transparent",
+                color: "text.secondary",
+                cursor: "pointer",
+                font: "inherit",
+                transition: "background-color 120ms ease, color 120ms ease",
+                "&:hover": {
+                  bgcolor: "action.selected",
+                  color: "text.primary",
+                },
+              }}
+            >
+              <Stack direction="row" spacing={-0.55} alignItems="center">
+                {ragReferences.slice(0, 4).map((reference) => (
+                  <Box
+                    key={`${reference.index}-${reference.title}-${reference.chunk}`}
+                    sx={{
+                      width: 19,
+                      height: 19,
+                      borderRadius: "50%",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      bgcolor: "background.paper",
+                      border: "1px solid",
+                      borderColor: "divider",
+                      boxShadow: 0.5,
+                    }}
+                  >
+                    <DescriptionOutlined sx={{ fontSize: 13 }} />
+                  </Box>
+                ))}
+              </Stack>
+              <Typography variant="caption" color="inherit" sx={{ fontWeight: 600 }}>
+                출처
+              </Typography>
+            </Box>
+            <Popover
+              open={sourcePopoverOpen}
+              anchorEl={sourceAnchorEl}
+              onClose={() => setSourceAnchorEl(null)}
+              anchorOrigin={{ vertical: "top", horizontal: "center" }}
+              transformOrigin={{ vertical: "bottom", horizontal: "center" }}
+              slotProps={{
+                paper: {
+                  sx: {
+                    width: 520,
+                    maxWidth: "calc(100vw - 32px)",
+                    maxHeight: 520,
+                    borderRadius: "8px",
+                    boxShadow: 8,
+                    overflow: "hidden",
+                  },
+                },
+              }}
+            >
+              <Box sx={{ px: 2, py: 1.25, borderBottom: "1px solid", borderColor: "divider" }}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  출처
+                </Typography>
+              </Box>
+              <Stack divider={<Divider />} sx={{ maxHeight: 460, overflowY: "auto" }}>
+                {ragReferences.map((reference) => {
+                  const percent = scorePercent(reference.score);
+                  return (
+                    <Stack key={`${reference.index}-${reference.title}-${reference.chunk}`} direction="row" spacing={1.5} sx={{ px: 2, py: 1.75 }}>
+                      <Box
+                        sx={{
+                          width: 28,
+                          height: 28,
+                          borderRadius: "50%",
+                          display: "inline-flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          bgcolor: "action.hover",
+                          flex: "0 0 auto",
+                        }}
+                      >
+                        <DescriptionOutlined sx={{ fontSize: 17 }} />
+                      </Box>
+                      <Stack spacing={0.5} sx={{ minWidth: 0, flex: 1 }}>
+                        <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap>
+                          <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                            {reference.index ? `근거 ${reference.index}` : "근거"}
+                          </Typography>
+                          {percent != null ? (
+                            <Stack direction="row" spacing={0.75} alignItems="center">
+                              <Typography variant="caption" sx={{ color: scoreColor(percent), fontWeight: 700 }}>
+                                관련도 {percent}%
+                              </Typography>
+                              <Box
+                                sx={{
+                                  width: 54,
+                                  height: 5,
+                                  borderRadius: 999,
+                                  bgcolor: "action.hover",
+                                  overflow: "hidden",
+                                }}
+                              >
+                                <Box
+                                  sx={{
+                                    width: `${percent}%`,
+                                    height: "100%",
+                                    borderRadius: 999,
+                                    bgcolor: scoreColor(percent),
+                                  }}
+                                />
+                              </Box>
+                              <Typography variant="caption" color="text.secondary">
+                                {scoreLabel(percent)}
+                              </Typography>
+                            </Stack>
+                          ) : null}
+                        </Stack>
+                        <Typography variant="body2" sx={{ fontWeight: 700, overflowWrap: "anywhere" }}>
+                          {formatReferenceTitle(reference)}
+                        </Typography>
+                        {formatReferenceSummary(reference) ? (
+                          <Typography variant="body2" color="text.secondary" sx={{ overflowWrap: "anywhere" }}>
+                            {formatReferenceSummary(reference)}
+                          </Typography>
+                        ) : null}
+                      </Stack>
+                    </Stack>
+                  );
+                })}
+              </Stack>
+            </Popover>
+          </>
         ) : null}
       </Stack>
     </Stack>

--- a/src/react/pages/ai/components/AssistantMessageBubble.tsx
+++ b/src/react/pages/ai/components/AssistantMessageBubble.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Box, Divider, IconButton, Popover, Stack, Tooltip, Typography } from "@mui/material";
 import { ContentCopyOutlined, DescriptionOutlined, RefreshOutlined, SyncOutlined } from "@mui/icons-material";
 import type { ChatMessage, ChatResponseMetadataDto } from "@/react/pages/ai/components/chatTypes";
+import type { RagReferenceDto } from "@/types/studio/ai";
 
 const numberFormatter = new Intl.NumberFormat("ko-KR");
 
@@ -9,7 +10,7 @@ function formatNumber(value?: number) {
   return typeof value === "number" ? numberFormatter.format(value) : "-";
 }
 
-interface RagReference {
+interface NormalizedRagReference {
   index?: number;
   title?: string;
   chunk?: string;
@@ -17,16 +18,64 @@ interface RagReference {
   content?: string;
 }
 
-function getRagReferences(metadata?: ChatResponseMetadataDto): RagReference[] {
-  const references = metadata?.ragReferences;
-  return Array.isArray(references) ? references.slice(0, 5) as RagReference[] : [];
+function stringifyValue(value: unknown) {
+  if (value == null || value === "") {
+    return "";
+  }
+  return typeof value === "object" ? JSON.stringify(value) : String(value);
 }
 
-function formatReferenceTitle(reference: RagReference) {
+function metadataValue(reference: RagReferenceDto, keys: string[]) {
+  for (const key of keys) {
+    const value = reference.metadata?.[key];
+    if (value != null && value !== "") {
+      return stringifyValue(value);
+    }
+  }
+  return "";
+}
+
+function normalizeReference(reference: RagReferenceDto, fallbackIndex: number): NormalizedRagReference {
+  const title =
+    reference.sourceName ||
+    metadataValue(reference, ["sourceName", "fileName", "filename", "originalFilename", "documentName", "title"]) ||
+    reference.documentId ||
+    `근거 ${reference.index ?? fallbackIndex}`;
+  const page = reference.page ?? reference.pageNumber ?? metadataValue(reference, ["page", "pageNumber", "page_number"]);
+  const slide = reference.slide ?? reference.slideNumber ?? metadataValue(reference, ["slide", "slideNumber", "slide_number"]);
+  const chunkOrder = reference.chunkOrder ?? metadataValue(reference, ["chunkOrder", "chunkIndex", "chunk_order", "chunk_index"]);
+  const chunk =
+    (page != null && page !== "" ? `p.${stringifyValue(page)}` : "") ||
+    (slide != null && slide !== "" ? `slide ${stringifyValue(slide)}` : "") ||
+    (chunkOrder != null && chunkOrder !== "" ? `chunk #${stringifyValue(chunkOrder)}` : "") ||
+    reference.sourceRef ||
+    reference.chunkId ||
+    metadataValue(reference, ["sourceRef", "chunkId", "chunk_id", "id"]);
+
+  return {
+    index: reference.index ?? fallbackIndex,
+    title,
+    chunk,
+    score: reference.score,
+    content: reference.content,
+  };
+}
+
+function getRagReferences(metadata?: ChatResponseMetadataDto): NormalizedRagReference[] {
+  const references = metadata?.ragReferences;
+  return Array.isArray(references)
+    ? references
+        .slice(0, 5)
+        .filter((reference): reference is RagReferenceDto => typeof reference === "object" && reference !== null)
+        .map((reference, index) => normalizeReference(reference, index + 1))
+    : [];
+}
+
+function formatReferenceTitle(reference: NormalizedRagReference) {
   return [reference.title || `근거 ${reference.index ?? ""}`, reference.chunk].filter(Boolean).join(" · ");
 }
 
-function formatReferenceSummary(reference: RagReference) {
+function formatReferenceSummary(reference: NormalizedRagReference) {
   return (reference.content ?? "").replace(/\s+/g, " ").trim();
 }
 

--- a/src/react/pages/ai/components/ChatComposer.tsx
+++ b/src/react/pages/ai/components/ChatComposer.tsx
@@ -1,0 +1,171 @@
+import { ArrowUpwardOutlined, CheckOutlined, ExpandMoreOutlined } from "@mui/icons-material";
+import { Box, Button, Card, CardContent, Chip, IconButton, Popover, Stack, Tooltip, Typography } from "@mui/material";
+import type { ProviderInfo } from "@/types/studio/ai";
+
+interface Props {
+  input: string;
+  sending: boolean;
+  configurationMissing: boolean;
+  model: string;
+  provider: string;
+  conversationId: string;
+  chatModeLabel: string;
+  chatModeDescription: string;
+  latencyMs?: number;
+  inputHistory: string[];
+  onInputChange: (value: string) => void;
+  onSubmit: () => void;
+  onKeyDown: (event: React.KeyboardEvent) => void;
+  onOpenModelMenu: (event: React.MouseEvent<HTMLElement>) => void;
+  modelMenuOpen: boolean;
+  modelAnchorEl: HTMLElement | null;
+  providers: ProviderInfo[];
+  onCloseModelMenu: () => void;
+  onSelectProvider: (provider: string) => void;
+  onOpenSettings: () => void;
+  onSelectHistory: (value: string) => void;
+}
+
+export function ChatComposer({
+  input,
+  sending,
+  configurationMissing,
+  model,
+  provider,
+  conversationId,
+  chatModeLabel,
+  chatModeDescription,
+  latencyMs,
+  inputHistory,
+  onInputChange,
+  onSubmit,
+  onKeyDown,
+  onOpenModelMenu,
+  modelMenuOpen,
+  modelAnchorEl,
+  providers,
+  onCloseModelMenu,
+  onSelectProvider,
+  onOpenSettings,
+  onSelectHistory,
+}: Props) {
+  return (
+    <Box sx={{ px: { xs: 1, md: 4 }, pb: 2 }}>
+      <Card variant="outlined" sx={{ borderRadius: 3, bgcolor: "background.paper" }}>
+        <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
+          <Stack spacing={1}>
+            <textarea
+              value={input}
+              onChange={(event) => onInputChange(event.target.value)}
+              onKeyDown={onKeyDown}
+              placeholder="답글..."
+              rows={3}
+              style={{
+                width: "100%",
+                minHeight: 64,
+                maxHeight: 160,
+                resize: "vertical",
+                border: 0,
+                outline: "none",
+                background: "transparent",
+                color: "inherit",
+                font: "inherit",
+              }}
+            />
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+                  <Tooltip title={chatModeDescription}>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: 1, bgcolor: "action.hover", fontSize: 11 }}>
+                      {chatModeLabel}
+                    </Typography>
+                  </Tooltip>
+                  <Tooltip title="현재 provider">
+                    <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: 1, bgcolor: "action.hover", fontSize: 11 }}>
+                      {provider || "default"}
+                    </Typography>
+                  </Tooltip>
+                  <Tooltip title="현재 model">
+                    <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: 1, bgcolor: "action.hover", fontSize: 11, maxWidth: 180, overflow: "hidden", textOverflow: "ellipsis" }}>
+                      {model || "미설정"}
+                    </Typography>
+                  </Tooltip>
+                  {latencyMs ? (
+                    <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: 1, bgcolor: "action.hover", fontSize: 11 }}>
+                      {latencyMs}ms
+                    </Typography>
+                  ) : null}
+                  {conversationId ? (
+                    <Tooltip title={conversationId}>
+                      <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: 1, bgcolor: "action.hover", fontSize: 11 }}>
+                        {conversationId.slice(0, 12)}
+                      </Typography>
+                    </Tooltip>
+                  ) : null}
+                </Stack>
+              </Box>
+              <Tooltip title="모델 선택">
+                <Button size="small" variant="text" endIcon={<ExpandMoreOutlined fontSize="small" />} onClick={onOpenModelMenu} sx={{ color: "text.primary", px: 1, minWidth: 0 }}>
+                  {model || "모델 설정"}
+                </Button>
+              </Tooltip>
+              <Tooltip title="보내기">
+                <span>
+                  <IconButton color="primary" onClick={onSubmit} disabled={sending || !input.trim() || configurationMissing} sx={{ width: 40, height: 40, bgcolor: "primary.main", color: "primary.contrastText" }}>
+                    <ArrowUpwardOutlined fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Stack>
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={1}
+              alignItems={{ sm: "center" }}
+              justifyContent="space-between"
+            >
+              <Typography variant="caption" color="text.secondary">
+                `Ctrl/Cmd + Enter` 전송 · 빈 입력에서 `ArrowUp/Down` 최근 질문
+              </Typography>
+              {inputHistory.length > 0 ? (
+                <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+                  {inputHistory.slice(0, 3).map((historyItem) => (
+                    <Chip
+                      key={historyItem}
+                      size="small"
+                      variant="outlined"
+                      label={historyItem.length > 18 ? `${historyItem.slice(0, 18)}…` : historyItem}
+                      onClick={() => onSelectHistory(historyItem)}
+                    />
+                  ))}
+                </Stack>
+              ) : null}
+            </Stack>
+          </Stack>
+        </CardContent>
+      </Card>
+      <Popover open={modelMenuOpen} anchorEl={modelAnchorEl} onClose={onCloseModelMenu} anchorOrigin={{ vertical: "top", horizontal: "right" }} transformOrigin={{ vertical: "bottom", horizontal: "right" }} PaperProps={{ sx: { width: 360, borderRadius: 2, p: 1, mb: 1 } }}>
+        <Stack spacing={0.5}>
+          {providers.filter((item) => item.chat.enabled).map((item) => {
+            const selected = item.name === provider;
+            return (
+              <Button key={item.name} variant="text" onClick={() => onSelectProvider(item.name)} sx={{ justifyContent: "space-between", textAlign: "left", color: "text.primary", px: 1.5, py: 1 }}>
+                <Box>
+                  <Typography variant="body2">{item.chat.model || item.name}</Typography>
+                  <Typography variant="caption" color="text.secondary">{item.name}</Typography>
+                </Box>
+                {selected ? <CheckOutlined color="primary" fontSize="small" /> : null}
+              </Button>
+            );
+          })}
+          <Button variant="text" onClick={onOpenSettings} sx={{ justifyContent: "space-between", color: "text.primary", px: 1.5, py: 1 }}>
+            <Box>
+              <Typography variant="body2">더 많은 모델</Typography>
+              <Typography variant="caption" color="text.secondary">provider와 model을 직접 설정합니다.</Typography>
+            </Box>
+            <ExpandMoreOutlined fontSize="small" sx={{ transform: "rotate(-90deg)" }} />
+          </Button>
+        </Stack>
+      </Popover>
+    </Box>
+  );
+}

--- a/src/react/pages/ai/components/ChatComposer.tsx
+++ b/src/react/pages/ai/components/ChatComposer.tsx
@@ -3,6 +3,16 @@ import { ArrowUpwardOutlined, CheckOutlined, ExpandMoreOutlined, HistoryOutlined
 import { alpha, Box, Button, IconButton, Menu, MenuItem, Popover, Stack, Tooltip, Typography } from "@mui/material";
 import type { ProviderInfo } from "@/types/studio/ai";
 
+const numberFormatter = new Intl.NumberFormat("ko-KR");
+
+function formatNumber(value?: number) {
+  return typeof value === "number" ? numberFormatter.format(value) : "-";
+}
+
+function formatMilliseconds(value?: number) {
+  return typeof value === "number" ? `${numberFormatter.format(value)}ms` : "";
+}
+
 interface Props {
   input: string;
   sending: boolean;
@@ -30,6 +40,9 @@ interface Props {
   onSelectProvider: (provider: string) => void;
   onOpenSettings: () => void;
   onSelectHistory: (value: string) => void;
+  controls?: React.ReactNode;
+  settingsMenuLabel?: string;
+  settingsMenuDescription?: string;
 }
 
 export function ChatComposer({
@@ -55,6 +68,9 @@ export function ChatComposer({
   onSelectProvider,
   onOpenSettings,
   onSelectHistory,
+  controls,
+  settingsMenuLabel = "더 많은 모델",
+  settingsMenuDescription = "provider와 model을 직접 설정합니다.",
 }: Props) {
   const [historyAnchorEl, setHistoryAnchorEl] = useState<HTMLElement | null>(null);
   const historyMenuOpen = Boolean(historyAnchorEl);
@@ -102,6 +118,7 @@ export function ChatComposer({
               lineHeight: 1.55,
             }}
           />
+          {controls ? <Box>{controls}</Box> : null}
           <Stack direction="row" spacing={0.75} alignItems="center">
             <Tooltip title="최근 질문">
               <span>
@@ -124,15 +141,15 @@ export function ChatComposer({
                 </Tooltip>
                 {latencyMs ? (
                   <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: "6px", bgcolor: "action.hover", fontSize: 11 }}>
-                    {latencyMs}ms
+                    {formatMilliseconds(latencyMs)}
                   </Typography>
                 ) : null}
                 {tokenUsage ? (
                   <Tooltip
-                    title={`input ${tokenUsage.inputTokens ?? "-"} · output ${tokenUsage.outputTokens ?? "-"} · total ${tokenUsage.totalTokens ?? "-"}`}
+                    title={`input ${formatNumber(tokenUsage.inputTokens)} · output ${formatNumber(tokenUsage.outputTokens)} · total ${formatNumber(tokenUsage.totalTokens)}`}
                   >
                     <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: "6px", bgcolor: "action.hover", fontSize: 11 }}>
-                      tokens {tokenUsage.totalTokens ?? "-"}
+                      tokens {formatNumber(tokenUsage.totalTokens)}
                     </Typography>
                   </Tooltip>
                 ) : null}
@@ -217,8 +234,8 @@ export function ChatComposer({
           })}
           <Button variant="text" onClick={onOpenSettings} sx={{ justifyContent: "space-between", color: "text.primary", px: 1.5, py: 1 }}>
             <Box>
-              <Typography variant="body2">더 많은 모델</Typography>
-              <Typography variant="caption" color="text.secondary">provider와 model을 직접 설정합니다.</Typography>
+              <Typography variant="body2">{settingsMenuLabel}</Typography>
+              <Typography variant="caption" color="text.secondary">{settingsMenuDescription}</Typography>
             </Box>
             <ExpandMoreOutlined fontSize="small" sx={{ transform: "rotate(-90deg)" }} />
           </Button>

--- a/src/react/pages/ai/components/ChatComposer.tsx
+++ b/src/react/pages/ai/components/ChatComposer.tsx
@@ -1,5 +1,6 @@
-import { ArrowUpwardOutlined, CheckOutlined, ExpandMoreOutlined } from "@mui/icons-material";
-import { Box, Button, Card, CardContent, Chip, IconButton, Popover, Stack, Tooltip, Typography } from "@mui/material";
+import { useState } from "react";
+import { ArrowUpwardOutlined, CheckOutlined, ExpandMoreOutlined, HistoryOutlined } from "@mui/icons-material";
+import { alpha, Box, Button, IconButton, Menu, MenuItem, Popover, Stack, Tooltip, Typography } from "@mui/material";
 import type { ProviderInfo } from "@/types/studio/ai";
 
 interface Props {
@@ -12,6 +13,11 @@ interface Props {
   chatModeLabel: string;
   chatModeDescription: string;
   latencyMs?: number;
+  tokenUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
   inputHistory: string[];
   onInputChange: (value: string) => void;
   onSubmit: () => void;
@@ -36,6 +42,7 @@ export function ChatComposer({
   chatModeLabel,
   chatModeDescription,
   latencyMs,
+  tokenUsage,
   inputHistory,
   onInputChange,
   onSubmit,
@@ -49,61 +56,95 @@ export function ChatComposer({
   onOpenSettings,
   onSelectHistory,
 }: Props) {
+  const [historyAnchorEl, setHistoryAnchorEl] = useState<HTMLElement | null>(null);
+  const historyMenuOpen = Boolean(historyAnchorEl);
+
+  function handleSelectHistory(value: string) {
+    onSelectHistory(value);
+    setHistoryAnchorEl(null);
+  }
+
   return (
     <Box sx={{ px: { xs: 1, md: 4 }, pb: 2 }}>
-      <Card variant="outlined" sx={{ borderRadius: 3, bgcolor: "background.paper" }}>
-        <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
-          <Stack spacing={1}>
-            <textarea
-              value={input}
-              onChange={(event) => onInputChange(event.target.value)}
-              onKeyDown={onKeyDown}
-              placeholder="답글..."
-              rows={3}
-              style={{
-                width: "100%",
-                minHeight: 64,
-                maxHeight: 160,
-                resize: "vertical",
-                border: 0,
-                outline: "none",
-                background: "transparent",
-                color: "inherit",
-                font: "inherit",
-              }}
-            />
-            <Stack direction="row" spacing={1} alignItems="center">
-              <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
-                  <Tooltip title={chatModeDescription}>
-                    <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: 1, bgcolor: "action.hover", fontSize: 11 }}>
-                      {chatModeLabel}
+      <Box
+        sx={{
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: "8px",
+          bgcolor: (theme) =>
+            theme.palette.mode === "dark"
+              ? alpha(theme.palette.common.white, 0.06)
+              : theme.palette.background.paper,
+          boxShadow: (theme) =>
+            `0 8px 20px ${alpha(theme.palette.common.black, theme.palette.mode === "dark" ? 0.24 : 0.08)}`,
+          px: 1.25,
+          py: 1,
+        }}
+      >
+        <Stack spacing={0.75}>
+          <textarea
+            value={input}
+            onChange={(event) => onInputChange(event.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="답글..."
+            rows={1}
+            style={{
+              width: "100%",
+              minHeight: 30,
+              maxHeight: 120,
+              resize: "none",
+              border: 0,
+              outline: "none",
+              background: "transparent",
+              color: "inherit",
+              font: "inherit",
+              fontSize: 14,
+              lineHeight: 1.55,
+            }}
+          />
+          <Stack direction="row" spacing={0.75} alignItems="center">
+            <Tooltip title="최근 질문">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={(event) => setHistoryAnchorEl(event.currentTarget)}
+                  disabled={inputHistory.length === 0}
+                  sx={{ width: 32, height: 32 }}
+                >
+                  <HistoryOutlined fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                <Tooltip title={chatModeDescription}>
+                  <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: "6px", bgcolor: "action.hover", fontSize: 11 }}>
+                    {chatModeLabel}
+                  </Typography>
+                </Tooltip>
+                {latencyMs ? (
+                  <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: "6px", bgcolor: "action.hover", fontSize: 11 }}>
+                    {latencyMs}ms
+                  </Typography>
+                ) : null}
+                {tokenUsage ? (
+                  <Tooltip
+                    title={`input ${tokenUsage.inputTokens ?? "-"} · output ${tokenUsage.outputTokens ?? "-"} · total ${tokenUsage.totalTokens ?? "-"}`}
+                  >
+                    <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: "6px", bgcolor: "action.hover", fontSize: 11 }}>
+                      tokens {tokenUsage.totalTokens ?? "-"}
                     </Typography>
                   </Tooltip>
-                  <Tooltip title="현재 provider">
-                    <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: 1, bgcolor: "action.hover", fontSize: 11 }}>
-                      {provider || "default"}
+                ) : null}
+                {conversationId ? (
+                  <Tooltip title={conversationId}>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: "6px", bgcolor: "action.hover", fontSize: 11 }}>
+                      {conversationId.slice(0, 12)}
                     </Typography>
                   </Tooltip>
-                  <Tooltip title="현재 model">
-                    <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: 1, bgcolor: "action.hover", fontSize: 11, maxWidth: 180, overflow: "hidden", textOverflow: "ellipsis" }}>
-                      {model || "미설정"}
-                    </Typography>
-                  </Tooltip>
-                  {latencyMs ? (
-                    <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: 1, bgcolor: "action.hover", fontSize: 11 }}>
-                      {latencyMs}ms
-                    </Typography>
-                  ) : null}
-                  {conversationId ? (
-                    <Tooltip title={conversationId}>
-                      <Typography variant="caption" color="text.secondary" sx={{ display: "inline-flex", alignItems: "center", px: 0.75, py: 0.25, borderRadius: 1, bgcolor: "action.hover", fontSize: 11 }}>
-                        {conversationId.slice(0, 12)}
-                      </Typography>
-                    </Tooltip>
-                  ) : null}
-                </Stack>
-              </Box>
+                ) : null}
+              </Stack>
+            </Box>
               <Tooltip title="모델 선택">
                 <Button size="small" variant="text" endIcon={<ExpandMoreOutlined fontSize="small" />} onClick={onOpenModelMenu} sx={{ color: "text.primary", px: 1, minWidth: 0 }}>
                   {model || "모델 설정"}
@@ -111,38 +152,55 @@ export function ChatComposer({
               </Tooltip>
               <Tooltip title="보내기">
                 <span>
-                  <IconButton color="primary" onClick={onSubmit} disabled={sending || !input.trim() || configurationMissing} sx={{ width: 40, height: 40, bgcolor: "primary.main", color: "primary.contrastText" }}>
-                    <ArrowUpwardOutlined fontSize="small" />
-                  </IconButton>
-                </span>
-              </Tooltip>
-            </Stack>
-            <Stack
-              direction={{ xs: "column", sm: "row" }}
-              spacing={1}
-              alignItems={{ sm: "center" }}
-              justifyContent="space-between"
-            >
-              <Typography variant="caption" color="text.secondary">
-                `Ctrl/Cmd + Enter` 전송 · 빈 입력에서 `ArrowUp/Down` 최근 질문
-              </Typography>
-              {inputHistory.length > 0 ? (
-                <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
-                  {inputHistory.slice(0, 3).map((historyItem) => (
-                    <Chip
-                      key={historyItem}
-                      size="small"
-                      variant="outlined"
-                      label={historyItem.length > 18 ? `${historyItem.slice(0, 18)}…` : historyItem}
-                      onClick={() => onSelectHistory(historyItem)}
-                    />
-                  ))}
-                </Stack>
-              ) : null}
-            </Stack>
+                  <IconButton
+                    color="primary"
+                    onClick={onSubmit}
+                    disabled={sending || !input.trim() || configurationMissing}
+	                    sx={{
+	                      width: 34,
+	                      height: 34,
+	                      bgcolor: (theme) =>
+                          theme.palette.mode === "dark" ? "#0d47a1" : "#0b3d91",
+	                      color: "primary.contrastText",
+	                      "&:hover": {
+	                        bgcolor: (theme) =>
+	                          theme.palette.mode === "dark" ? "#1565c0" : "#072f70",
+	                        color: "primary.contrastText",
+	                      },
+                      "&.Mui-disabled": {
+                        bgcolor: "action.disabledBackground",
+                        color: "action.disabled",
+                      },
+                    }}
+	                  >
+	                    <ArrowUpwardOutlined sx={{ fontSize: 18 }} />
+	                  </IconButton>
+	                </span>
+	              </Tooltip>
           </Stack>
-        </CardContent>
-      </Card>
+        </Stack>
+      </Box>
+      <Menu
+        anchorEl={historyAnchorEl}
+        open={historyMenuOpen}
+        onClose={() => setHistoryAnchorEl(null)}
+        slotProps={{
+          paper: {
+            sx: {
+              width: 360,
+              maxWidth: "calc(100vw - 32px)",
+            },
+          },
+        }}
+      >
+        {inputHistory.slice(0, 8).map((historyItem) => (
+          <MenuItem key={historyItem} onClick={() => handleSelectHistory(historyItem)}>
+            <Typography variant="body2" noWrap title={historyItem}>
+              {historyItem}
+            </Typography>
+          </MenuItem>
+        ))}
+      </Menu>
       <Popover open={modelMenuOpen} anchorEl={modelAnchorEl} onClose={onCloseModelMenu} anchorOrigin={{ vertical: "top", horizontal: "right" }} transformOrigin={{ vertical: "bottom", horizontal: "right" }} PaperProps={{ sx: { width: 360, borderRadius: 2, p: 1, mb: 1 } }}>
         <Stack spacing={0.5}>
           {providers.filter((item) => item.chat.enabled).map((item) => {

--- a/src/react/pages/ai/components/ChatMessageList.tsx
+++ b/src/react/pages/ai/components/ChatMessageList.tsx
@@ -1,5 +1,6 @@
-import { Avatar, Box, CircularProgress, Stack, Typography } from "@mui/material";
-import { SmartToyOutlined } from "@mui/icons-material";
+import { useEffect, useRef, useState } from "react";
+import { ArrowDownwardOutlined } from "@mui/icons-material";
+import { Box, CircularProgress, Fab, Stack, Typography } from "@mui/material";
 import type { ChatMessage } from "@/react/pages/ai/components/chatTypes";
 import { SummaryCard } from "@/react/pages/ai/components/SummaryCard";
 import { UserMessageBubble } from "@/react/pages/ai/components/UserMessageBubble";
@@ -16,6 +17,28 @@ interface Props {
   onEditUser: (messageId: string | undefined, content: string) => void;
   onRegenerate: () => void;
   onRetryLastUser: () => void;
+  emptyTitle?: string;
+  emptyDescription?: string;
+}
+
+function EmptyChatIllustration() {
+  return (
+    <Box
+      component="svg"
+      viewBox="0 0 160 120"
+      role="img"
+      aria-label="질문과 답변"
+      sx={{ width: 120, height: 90 }}
+    >
+      <rect x="18" y="18" width="78" height="72" rx="10" fill="#F9FAFB" stroke="#D6E0F0" strokeWidth="2" />
+      <path d="M34 38h46M34 52h34M34 66h42" stroke="#6B7280" strokeWidth="5" strokeLinecap="round" />
+      <circle cx="104" cy="72" r="24" fill="#EDE9FE" stroke="#7C3AED" strokeWidth="2.5" />
+      <path d="M96 69a9 9 0 1 1 15 7c-3 2-5 4-5 8" fill="none" stroke="#7C3AED" strokeWidth="5" strokeLinecap="round" />
+      <circle cx="106" cy="92" r="3" fill="#7C3AED" />
+      <path d="M121 89l17 17" stroke="#2563EB" strokeWidth="6" strokeLinecap="round" />
+      <path d="M45 99c10 6 31 6 42 0" stroke="#93C5FD" strokeWidth="4" strokeLinecap="round" />
+    </Box>
+  );
 }
 
 export function ChatMessageList({
@@ -29,81 +52,149 @@ export function ChatMessageList({
   onEditUser,
   onRegenerate,
   onRetryLastUser,
+  emptyTitle = "궁금한 내용을 입력해 보세요.",
+  emptyDescription = "AI가 질문에 맞춰 답변합니다.",
 }: Props) {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const [isNearBottom, setIsNearBottom] = useState(true);
   const lastAssistantId = [...messages].reverse().find((item) => item.role === "assistant")?.id;
   const hasStreamingPlaceholder = messages.some(
     (message) => message.role === "assistant" && !message.content
   );
 
+  function checkNearBottom(container: HTMLDivElement) {
+    return container.scrollHeight - container.scrollTop - container.clientHeight < 96;
+  }
+
+  function scrollToBottom(behavior: ScrollBehavior = "smooth") {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior,
+    });
+  }
+
+  function handleScroll() {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+    setIsNearBottom(checkNearBottom(container));
+  }
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+    if (isNearBottom) {
+      scrollToBottom("smooth");
+    }
+  }, [messages.length, sending, isNearBottom]);
+
   return (
-    <Box sx={{ flex: 1, minHeight: 0, overflowY: "auto", px: { xs: 1, md: 4 }, py: 3 }}>
-      <Stack spacing={2}>
-        {summaryVisible ? (
-          <SummaryCard
-            collapsedMessageCount={collapsedMessageCount}
-            summaryText={summaryText}
-            onToggle={onToggleSummary ?? (() => {})}
-          />
-        ) : null}
-        {messages.length === 0 ? (
-          <Stack spacing={1} alignItems="center" justifyContent="center" sx={{ minHeight: 260 }}>
-            <Avatar sx={{ bgcolor: "primary.main" }}>
-              <SmartToyOutlined />
-            </Avatar>
-            <Typography color="text.secondary">메시지를 입력해 AI와 대화를 시작하세요.</Typography>
-          </Stack>
-        ) : (
-          messages.map((message, index) => (
-            <Stack
-              key={`${message.role}-${message.id ?? index}`}
-              direction="row"
-              justifyContent={message.role === "user" ? "flex-end" : "flex-start"}
-              sx={{
-                "& .user-message-actions": { opacity: 0 },
-                "&:hover .user-message-actions": { opacity: 1 },
-              }}
-            >
-              {message.role === "user" ? (
-                <UserMessageBubble
-                  message={message}
-                  onCopy={onCopy}
-                  onEdit={onEditUser}
-                />
-              ) : (
-                <AssistantMessageBubble
-                  message={message}
-                  sending={sending}
-                  isLastAssistant={message.id === lastAssistantId}
-                  onCopy={onCopy}
-                  onRegenerate={onRegenerate}
-                  onRetryLastUser={onRetryLastUser}
-                />
-              )}
-            </Stack>
-          ))
-        )}
-        {sending && !hasStreamingPlaceholder ? (
-          <Stack direction="row" justifyContent="flex-start">
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 1,
-                p: 1.5,
-                borderRadius: 2,
-                bgcolor: "background.paper",
-                border: "1px solid",
-                borderColor: "divider",
-              }}
-            >
-              <CircularProgress size={16} />
-              <Typography variant="body2" color="text.secondary">
-                응답 생성 중...
+    <Box sx={{ flex: 1, minHeight: 0, position: "relative" }}>
+      <Box
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        sx={{ height: "100%", minHeight: 0, overflowY: "auto", px: { xs: 1, md: 4 }, py: 3 }}
+      >
+        <Stack spacing={2}>
+          {summaryVisible ? (
+            <SummaryCard
+              collapsedMessageCount={collapsedMessageCount}
+              summaryText={summaryText}
+              onToggle={onToggleSummary ?? (() => {})}
+            />
+          ) : null}
+          {messages.length === 0 ? (
+            <Stack spacing={1.25} alignItems="center" justifyContent="center" sx={{ minHeight: 260, textAlign: "center" }}>
+              <EmptyChatIllustration />
+              <Typography variant="body1" color="text.primary" sx={{ fontWeight: 600 }}>
+                {emptyTitle}
               </Typography>
-            </Box>
-          </Stack>
-        ) : null}
-      </Stack>
+              <Typography variant="body2" color="text.secondary">
+                {emptyDescription}
+              </Typography>
+            </Stack>
+          ) : (
+            messages.map((message, index) => (
+              <Stack
+                key={`${message.role}-${message.id ?? index}`}
+                direction="row"
+                justifyContent={message.role === "user" ? "flex-end" : "flex-start"}
+                sx={{
+                  "& .user-message-actions": { opacity: 0 },
+                  "&:hover .user-message-actions": { opacity: 1 },
+                }}
+              >
+                {message.role === "user" ? (
+                  <UserMessageBubble
+                    message={message}
+                    onCopy={onCopy}
+                    onEdit={onEditUser}
+                  />
+                ) : (
+                  <AssistantMessageBubble
+                    message={message}
+                    sending={sending}
+                    isLastAssistant={message.id === lastAssistantId}
+                    onCopy={onCopy}
+                    onRegenerate={onRegenerate}
+                    onRetryLastUser={onRetryLastUser}
+                  />
+                )}
+              </Stack>
+            ))
+          )}
+          {sending && !hasStreamingPlaceholder ? (
+            <Stack direction="row" justifyContent="flex-start">
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  p: 1.5,
+                  borderRadius: 2,
+                  bgcolor: "background.paper",
+                  border: "1px solid",
+                  borderColor: "divider",
+                }}
+              >
+                <CircularProgress size={16} />
+                <Typography variant="body2" color="text.secondary">
+                  응답 생성 중...
+                </Typography>
+              </Box>
+            </Stack>
+          ) : null}
+        </Stack>
+      </Box>
+      {!isNearBottom && messages.length > 0 ? (
+        <Fab
+          size="small"
+          color="primary"
+          aria-label="최신 메시지로 이동"
+          onClick={() => {
+            scrollToBottom("smooth");
+            setIsNearBottom(true);
+          }}
+          sx={{
+            position: "absolute",
+            right: { xs: 16, md: 40 },
+            bottom: 16,
+            width: 34,
+            height: 34,
+            minHeight: 34,
+            boxShadow: 3,
+          }}
+        >
+          <ArrowDownwardOutlined fontSize="small" />
+        </Fab>
+      ) : null}
     </Box>
   );
 }

--- a/src/react/pages/ai/components/ChatMessageList.tsx
+++ b/src/react/pages/ai/components/ChatMessageList.tsx
@@ -36,7 +36,7 @@ export function ChatMessageList({
   );
 
   return (
-    <Box sx={{ flex: 1, overflowY: "auto", px: { xs: 1, md: 4 }, py: 3 }}>
+    <Box sx={{ flex: 1, minHeight: 0, overflowY: "auto", px: { xs: 1, md: 4 }, py: 3 }}>
       <Stack spacing={2}>
         {summaryVisible ? (
           <SummaryCard

--- a/src/react/pages/ai/components/ChatMessageList.tsx
+++ b/src/react/pages/ai/components/ChatMessageList.tsx
@@ -1,0 +1,109 @@
+import { Avatar, Box, CircularProgress, Stack, Typography } from "@mui/material";
+import { SmartToyOutlined } from "@mui/icons-material";
+import type { ChatMessage } from "@/react/pages/ai/components/chatTypes";
+import { SummaryCard } from "@/react/pages/ai/components/SummaryCard";
+import { UserMessageBubble } from "@/react/pages/ai/components/UserMessageBubble";
+import { AssistantMessageBubble } from "@/react/pages/ai/components/AssistantMessageBubble";
+
+interface Props {
+  messages: ChatMessage[];
+  sending: boolean;
+  collapsedMessageCount?: number;
+  summaryText?: string;
+  summaryVisible?: boolean;
+  onToggleSummary?: () => void;
+  onCopy: (content: string) => void;
+  onEditUser: (messageId: string | undefined, content: string) => void;
+  onRegenerate: () => void;
+  onRetryLastUser: () => void;
+}
+
+export function ChatMessageList({
+  messages,
+  sending,
+  collapsedMessageCount = 0,
+  summaryText,
+  summaryVisible = false,
+  onToggleSummary,
+  onCopy,
+  onEditUser,
+  onRegenerate,
+  onRetryLastUser,
+}: Props) {
+  const lastAssistantId = [...messages].reverse().find((item) => item.role === "assistant")?.id;
+  const hasStreamingPlaceholder = messages.some(
+    (message) => message.role === "assistant" && !message.content
+  );
+
+  return (
+    <Box sx={{ flex: 1, overflowY: "auto", px: { xs: 1, md: 4 }, py: 3 }}>
+      <Stack spacing={2}>
+        {summaryVisible ? (
+          <SummaryCard
+            collapsedMessageCount={collapsedMessageCount}
+            summaryText={summaryText}
+            onToggle={onToggleSummary ?? (() => {})}
+          />
+        ) : null}
+        {messages.length === 0 ? (
+          <Stack spacing={1} alignItems="center" justifyContent="center" sx={{ minHeight: 260 }}>
+            <Avatar sx={{ bgcolor: "primary.main" }}>
+              <SmartToyOutlined />
+            </Avatar>
+            <Typography color="text.secondary">메시지를 입력해 AI와 대화를 시작하세요.</Typography>
+          </Stack>
+        ) : (
+          messages.map((message, index) => (
+            <Stack
+              key={`${message.role}-${message.id ?? index}`}
+              direction="row"
+              justifyContent={message.role === "user" ? "flex-end" : "flex-start"}
+              sx={{
+                "& .user-message-actions": { opacity: 0 },
+                "&:hover .user-message-actions": { opacity: 1 },
+              }}
+            >
+              {message.role === "user" ? (
+                <UserMessageBubble
+                  message={message}
+                  onCopy={onCopy}
+                  onEdit={onEditUser}
+                />
+              ) : (
+                <AssistantMessageBubble
+                  message={message}
+                  sending={sending}
+                  isLastAssistant={message.id === lastAssistantId}
+                  onCopy={onCopy}
+                  onRegenerate={onRegenerate}
+                  onRetryLastUser={onRetryLastUser}
+                />
+              )}
+            </Stack>
+          ))
+        )}
+        {sending && !hasStreamingPlaceholder ? (
+          <Stack direction="row" justifyContent="flex-start">
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                p: 1.5,
+                borderRadius: 2,
+                bgcolor: "background.paper",
+                border: "1px solid",
+                borderColor: "divider",
+              }}
+            >
+              <CircularProgress size={16} />
+              <Typography variant="body2" color="text.secondary">
+                응답 생성 중...
+              </Typography>
+            </Box>
+          </Stack>
+        ) : null}
+      </Stack>
+    </Box>
+  );
+}

--- a/src/react/pages/ai/components/ConversationSidebar.tsx
+++ b/src/react/pages/ai/components/ConversationSidebar.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { DeleteOutlineOutlined, RefreshOutlined } from "@mui/icons-material";
+import { CloseOutlined, DeleteOutlineOutlined, RefreshOutlined } from "@mui/icons-material";
 import type { ConversationSummaryDto } from "@/react/pages/ai/components/chatTypes";
 
 function formatRelative(value?: string) {
@@ -29,6 +29,8 @@ interface Props {
   onOpen: (conversationId: string) => void;
   onDelete: (conversationId: string) => void;
   onRefresh: () => void;
+  onClose?: () => void;
+  drawer?: boolean;
 }
 
 export function ConversationSidebar({
@@ -38,13 +40,22 @@ export function ConversationSidebar({
   onOpen,
   onDelete,
   onRefresh,
+  onClose,
+  drawer = false,
 }: Props) {
   return (
     <Paper
       variant="outlined"
-      sx={{ width: { xs: "100%", md: 320 }, p: 1.5, borderRadius: 3, flexShrink: 0 }}
+      sx={{
+        width: drawer ? "100%" : { xs: "100%", md: 320 },
+        height: drawer ? "100%" : "auto",
+        p: 1.5,
+        borderRadius: drawer ? 0 : 3,
+        flexShrink: 0,
+        overflow: "hidden",
+      }}
     >
-      <Stack spacing={1}>
+      <Stack spacing={1} sx={{ height: "100%" }}>
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Typography variant="subtitle2">대화 목록</Typography>
           <Stack direction="row" spacing={0.5} alignItems="center">
@@ -54,9 +65,16 @@ export function ConversationSidebar({
                 <RefreshOutlined fontSize="small" />
               </IconButton>
             </Tooltip>
+            {onClose ? (
+              <Tooltip title="닫기">
+                <IconButton size="small" onClick={onClose}>
+                  <CloseOutlined fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            ) : null}
           </Stack>
         </Stack>
-        <List dense sx={{ py: 0 }}>
+        <List dense sx={{ py: 0, overflowY: "auto" }}>
           {conversations.map((conversation) => (
             <ListItemButton
               key={conversation.conversationId}

--- a/src/react/pages/ai/components/ConversationSidebar.tsx
+++ b/src/react/pages/ai/components/ConversationSidebar.tsx
@@ -1,0 +1,108 @@
+import {
+  CircularProgress,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { DeleteOutlineOutlined, RefreshOutlined } from "@mui/icons-material";
+import type { ConversationSummaryDto } from "@/react/pages/ai/components/chatTypes";
+
+function formatRelative(value?: string) {
+  if (!value) return "";
+  return new Date(value).toLocaleString("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+interface Props {
+  conversationId: string;
+  conversations: ConversationSummaryDto[];
+  loading: boolean;
+  onOpen: (conversationId: string) => void;
+  onDelete: (conversationId: string) => void;
+  onRefresh: () => void;
+}
+
+export function ConversationSidebar({
+  conversationId,
+  conversations,
+  loading,
+  onOpen,
+  onDelete,
+  onRefresh,
+}: Props) {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ width: { xs: "100%", md: 320 }, p: 1.5, borderRadius: 3, flexShrink: 0 }}
+    >
+      <Stack spacing={1}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between">
+          <Typography variant="subtitle2">대화 목록</Typography>
+          <Stack direction="row" spacing={0.5} alignItems="center">
+            {loading ? <CircularProgress size={16} /> : null}
+            <Tooltip title="목록 새로고침">
+              <IconButton size="small" onClick={onRefresh}>
+                <RefreshOutlined fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+        </Stack>
+        <List dense sx={{ py: 0 }}>
+          {conversations.map((conversation) => (
+            <ListItemButton
+              key={conversation.conversationId}
+              selected={conversation.conversationId === conversationId}
+              onClick={() => onOpen(conversation.conversationId)}
+              sx={{ borderRadius: 1, alignItems: "flex-start" }}
+            >
+              <ListItemText
+                primary={conversation.title || conversation.conversationId}
+                secondary={
+                  <>
+                    <Typography
+                      component="span"
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: "block" }}
+                    >
+                      {conversation.summary || "요약 없음"}
+                    </Typography>
+                    <Typography component="span" variant="caption" color="text.secondary">
+                      {conversation.messageCount ?? 0} messages ·{" "}
+                      {formatRelative(conversation.lastUpdatedAt)}
+                    </Typography>
+                  </>
+                }
+              />
+              <Tooltip title="대화 삭제">
+                <IconButton
+                  size="small"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onDelete(conversation.conversationId);
+                  }}
+                >
+                  <DeleteOutlineOutlined fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </ListItemButton>
+          ))}
+          {conversations.length === 0 ? (
+            <Typography variant="caption" color="text.secondary">
+              저장된 대화가 없습니다.
+            </Typography>
+          ) : null}
+        </List>
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/react/pages/ai/components/SummaryCard.tsx
+++ b/src/react/pages/ai/components/SummaryCard.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { alpha, Box, Button, Stack, Typography } from "@mui/material";
+import { NotesOutlined } from "@mui/icons-material";
 
 interface Props {
   collapsedMessageCount: number;
@@ -14,27 +15,31 @@ export function SummaryCard({
   return (
     <Box
       sx={{
-        border: "1px solid",
-        borderColor: "divider",
-        bgcolor: "background.paper",
+        borderLeft: "3px solid",
+        borderLeftColor: "primary.main",
+        bgcolor: (theme) =>
+          alpha(theme.palette.primary.main, theme.palette.mode === "dark" ? 0.12 : 0.06),
         borderRadius: 2,
-        px: 1.5,
-        py: 1.25,
+        px: 1.25,
+        py: 1,
       }}
     >
-      <Stack direction={{ xs: "column", sm: "row" }} spacing={1} justifyContent="space-between">
-        <Box sx={{ minWidth: 0 }}>
-          <Typography variant="caption" color="text.secondary" display="block">
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "flex-start" }}>
+        <NotesOutlined color="primary" sx={{ fontSize: 18, mt: 0.25 }} />
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography variant="caption" color="text.secondary" display="block" sx={{ fontWeight: 600 }}>
             대화 요약
           </Typography>
-          <Typography variant="body2" sx={{ mt: 0.5, whiteSpace: "pre-wrap" }}>
+          <Typography
+            variant="body2"
+            color="text.primary"
+            sx={{ mt: 0.25, whiteSpace: "pre-wrap", fontSize: 13, lineHeight: 1.6 }}
+          >
             {summaryText || "긴 대화의 최근 흐름을 요약합니다."}
           </Typography>
         </Box>
-        <Button size="small" variant="text" onClick={onToggle}>
-          {collapsedMessageCount > 0
-            ? `이전 메시지 ${collapsedMessageCount}개 펼치기`
-            : "이전 메시지 접기"}
+        <Button size="small" variant="text" onClick={onToggle} sx={{ flexShrink: 0, minWidth: 0 }}>
+          {collapsedMessageCount > 0 ? `펼치기 ${collapsedMessageCount}` : "접기"}
         </Button>
       </Stack>
     </Box>

--- a/src/react/pages/ai/components/SummaryCard.tsx
+++ b/src/react/pages/ai/components/SummaryCard.tsx
@@ -1,0 +1,42 @@
+import { Box, Button, Stack, Typography } from "@mui/material";
+
+interface Props {
+  collapsedMessageCount: number;
+  summaryText?: string;
+  onToggle: () => void;
+}
+
+export function SummaryCard({
+  collapsedMessageCount,
+  summaryText,
+  onToggle,
+}: Props) {
+  return (
+    <Box
+      sx={{
+        border: "1px solid",
+        borderColor: "divider",
+        bgcolor: "background.paper",
+        borderRadius: 2,
+        px: 1.5,
+        py: 1.25,
+      }}
+    >
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={1} justifyContent="space-between">
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="caption" color="text.secondary" display="block">
+            대화 요약
+          </Typography>
+          <Typography variant="body2" sx={{ mt: 0.5, whiteSpace: "pre-wrap" }}>
+            {summaryText || "긴 대화의 최근 흐름을 요약합니다."}
+          </Typography>
+        </Box>
+        <Button size="small" variant="text" onClick={onToggle}>
+          {collapsedMessageCount > 0
+            ? `이전 메시지 ${collapsedMessageCount}개 펼치기`
+            : "이전 메시지 접기"}
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/react/pages/ai/components/UserMessageBubble.tsx
+++ b/src/react/pages/ai/components/UserMessageBubble.tsx
@@ -1,0 +1,55 @@
+import { alpha, Box, IconButton, Stack, Tooltip, Typography } from "@mui/material";
+import { ContentCopyOutlined, EditNoteOutlined } from "@mui/icons-material";
+import type { ChatMessage } from "@/react/pages/ai/components/chatTypes";
+
+function formatMessageTime(value?: string) {
+  if (!value) return "";
+  return new Date(value).toLocaleTimeString("ko-KR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+interface Props {
+  message: ChatMessage;
+  onCopy: (content: string) => void;
+  onEdit: (messageId: string | undefined, content: string) => void;
+}
+
+export function UserMessageBubble({ message, onCopy, onEdit }: Props) {
+  return (
+    <Stack spacing={0.5} alignItems="flex-end" sx={{ width: "100%" }}>
+      <Box
+        sx={{
+          maxWidth: { xs: "92%", md: "86%" },
+          px: 1.75,
+          py: 1,
+          borderRadius: 2,
+          bgcolor: (theme) =>
+            alpha(theme.palette.info.main, theme.palette.mode === "dark" ? 0.18 : 0.1),
+          color: "info.main",
+          border: "none",
+        }}
+      >
+        <Typography sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: 14 }}>
+          {message.content}
+        </Typography>
+      </Box>
+      <Stack className="user-message-actions" direction="row" spacing={0.5} alignItems="center" sx={{ pr: 0.5 }}>
+        <Typography variant="caption" color="text.secondary">
+          {formatMessageTime(message.createdAt)}
+        </Typography>
+        <Tooltip title="복사">
+          <IconButton size="small" onClick={() => onCopy(message.content)}>
+            <ContentCopyOutlined fontSize="inherit" />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="편집">
+          <IconButton size="small" onClick={() => onEdit(message.id, message.content)}>
+            <EditNoteOutlined fontSize="inherit" />
+          </IconButton>
+        </Tooltip>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/components/chatTypes.ts
+++ b/src/react/pages/ai/components/chatTypes.ts
@@ -1,0 +1,14 @@
+import type {
+  ChatMessageDto,
+  ChatResponseMetadataDto,
+  ConversationSummaryDto,
+} from "@/types/studio/ai";
+
+export type ChatMessage = ChatMessageDto & {
+  id?: string;
+  createdAt?: string;
+  model?: string;
+  metadata?: ChatResponseMetadataDto;
+};
+
+export type { ChatResponseMetadataDto, ConversationSummaryDto };

--- a/src/react/pages/files/FileDetailDialog.tsx
+++ b/src/react/pages/files/FileDetailDialog.tsx
@@ -25,9 +25,13 @@ import {
 } from "@mui/icons-material";
 import dayjs from "dayjs";
 import { useToast } from "@/react/feedback";
+import { reactAiApi } from "@/react/pages/ai/api";
 import { reactFilesApi } from "@/react/pages/files/api";
 import type { AttachmentDto } from "@/types/studio/files";
 import { resolveAxiosError } from "@/utils/helpers";
+
+const THUMBNAIL_RETRY_INTERVAL_MS = 1500;
+const THUMBNAIL_RETRY_LIMIT = 8;
 
 interface Props {
   open: boolean;
@@ -55,6 +59,37 @@ function normalizeExtractedText(value: string) {
     .trim();
 }
 
+function ragObjectScopes(file: AttachmentDto | null, fallbackAttachmentId: number) {
+  const attachmentObjectId = String(fallbackAttachmentId);
+  const scopes: Array<{ objectType: string; objectId: string }> = [];
+  const append = (objectType?: string | number | null, objectId?: string | number | null) => {
+    const type = objectType == null ? "" : String(objectType).trim();
+    const id = objectId == null ? "" : String(objectId).trim();
+    if (!type || !id) {
+      return;
+    }
+    if (!scopes.some((scope) => scope.objectType === type && scope.objectId === id)) {
+      scopes.push({ objectType: type, objectId: id });
+    }
+  };
+
+  append(file?.objectType, attachmentObjectId);
+  append(file?.objectType, file?.objectId);
+  append("attachment", attachmentObjectId);
+
+  return scopes.length > 0 ? scopes : [{ objectType: "attachment", objectId: attachmentObjectId }];
+}
+
+function metadataMatchesAttachment(metadata: Record<string, unknown>, attachmentId: number) {
+  const expected = String(attachmentId);
+  const candidates = [
+    metadata.attachmentId,
+    metadata.sourceDocumentId,
+    metadata.documentId,
+  ];
+  return candidates.some((value) => value != null && String(value) === expected);
+}
+
 export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
   const toast = useToast();
   const [file, setFile] = useState<AttachmentDto | null>(null);
@@ -64,12 +99,20 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
   const [textExtracted, setTextExtracted] = useState(false);
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
   const [thumbnailAvailable, setThumbnailAvailable] = useState(false);
+  const [thumbnailReloadKey, setThumbnailReloadKey] = useState(0);
+  const [ragJobId, setRagJobId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [textExtracting, setTextExtracting] = useState(false);
   const [ragIndexing, setRagIndexing] = useState(false);
 
   const metadataEntries = Object.entries(ragMetadata ?? {});
-  const thumbnailEligible = Boolean(file?.contentType?.startsWith("image/"));
+  const ragIndexCompleted = ragIndexed || metadataEntries.length > 0;
+  const ragIndexDisabled = loading || ragIndexCompleted || ragIndexing || Boolean(ragJobId);
+  const ragIndexTooltip = ragIndexCompleted
+    ? "이미 RAG 인덱싱이 완료된 파일입니다."
+    : ragJobId
+      ? "이미 RAG 색인 작업이 생성되었습니다."
+      : "이 파일을 RAG 검색 대상으로 색인합니다.";
 
   function clearThumbnail() {
     setThumbnailAvailable(false);
@@ -81,12 +124,31 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
     });
   }
 
+  async function loadRagState(nextFile: AttachmentDto) {
+    for (const scope of ragObjectScopes(nextFile, nextFile.attachmentId)) {
+      const metadata = await reactAiApi.getRagObjectMetadata(scope.objectType, scope.objectId);
+      if (Object.keys(metadata ?? {}).length > 0 && metadataMatchesAttachment(metadata, nextFile.attachmentId)) {
+        return {
+          indexed: true,
+          metadata,
+        };
+      }
+    }
+
+    const indexed = await reactFilesApi.hasEmbedding(nextFile.attachmentId);
+    return {
+      indexed,
+      metadata: indexed ? await reactFilesApi.ragMetadata(nextFile.attachmentId) : null,
+    };
+  }
+
   useEffect(() => {
     setFile(null);
     setRagIndexed(false);
     setRagMetadata(null);
     setExtractedText("");
     setTextExtracted(false);
+    setRagJobId(null);
     clearThumbnail();
 
     if (!open || !attachmentId) {
@@ -108,20 +170,13 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
         setExtractedText("");
         setTextExtracted(false);
 
-        const indexed = await reactFilesApi.hasEmbedding(requestedId);
+        const ragState = await loadRagState(nextFile);
         if (ignored) {
           return;
         }
 
-        setRagIndexed(indexed);
-        if (indexed) {
-          const metadata = await reactFilesApi.ragMetadata(requestedId);
-          if (!ignored) {
-            setRagMetadata(metadata);
-          }
-        } else {
-          setRagMetadata(null);
-        }
+        setRagIndexed(ragState.indexed);
+        setRagMetadata(ragState.metadata);
       } catch (error) {
         if (!ignored) {
           toast.error(resolveAxiosError(error));
@@ -143,39 +198,60 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
   }, [open, attachmentId, toast]);
 
   useEffect(() => {
-    if (!open || !attachmentId || !thumbnailEligible) {
+    if (!open || !attachmentId) {
       clearThumbnail();
       return;
     }
 
     let ignored = false;
+    let timer: number | undefined;
     const requestedId = attachmentId;
 
-    reactFilesApi
-      .fetchThumbnail(requestedId)
-      .then((blob) => {
-        if (ignored || requestedId !== attachmentId || blob.size === 0) {
-          return;
-        }
-        const objectUrl = URL.createObjectURL(blob);
-        setThumbnailUrl((currentUrl) => {
-          if (currentUrl) {
-            URL.revokeObjectURL(currentUrl);
+    function loadThumbnail(attempt: number) {
+      reactFilesApi
+        .fetchThumbnail(requestedId, 512)
+        .then((blob) => {
+          if (ignored || requestedId !== attachmentId) {
+            return;
           }
-          return objectUrl;
+          if (blob.size === 0) {
+            if (attempt < THUMBNAIL_RETRY_LIMIT) {
+              timer = window.setTimeout(() => loadThumbnail(attempt + 1), THUMBNAIL_RETRY_INTERVAL_MS);
+            } else {
+              setThumbnailAvailable(false);
+            }
+            return;
+          }
+          const objectUrl = URL.createObjectURL(blob);
+          setThumbnailUrl((currentUrl) => {
+            if (currentUrl) {
+              URL.revokeObjectURL(currentUrl);
+            }
+            return objectUrl;
+          });
+          setThumbnailAvailable(true);
+        })
+        .catch(() => {
+          if (ignored) {
+            return;
+          }
+          if (attempt < THUMBNAIL_RETRY_LIMIT) {
+            timer = window.setTimeout(() => loadThumbnail(attempt + 1), THUMBNAIL_RETRY_INTERVAL_MS);
+          } else {
+            setThumbnailAvailable(false);
+          }
         });
-        setThumbnailAvailable(true);
-      })
-      .catch(() => {
-        if (!ignored) {
-          setThumbnailAvailable(false);
-        }
-      });
+    }
+
+    loadThumbnail(0);
 
     return () => {
       ignored = true;
+      if (timer) {
+        window.clearTimeout(timer);
+      }
     };
-  }, [open, attachmentId, thumbnailEligible]);
+  }, [open, attachmentId, thumbnailReloadKey]);
 
   async function refreshDetail() {
     if (!attachmentId) return;
@@ -184,14 +260,16 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
     setRagMetadata(null);
     setExtractedText("");
     setTextExtracted(false);
+    setRagJobId(null);
     clearThumbnail();
+    setThumbnailReloadKey((current) => current + 1);
     setLoading(true);
     try {
       const nextFile = await reactFilesApi.getById(attachmentId);
       setFile(nextFile);
-      const indexed = await reactFilesApi.hasEmbedding(attachmentId);
-      setRagIndexed(indexed);
-      setRagMetadata(indexed ? await reactFilesApi.ragMetadata(attachmentId) : null);
+      const ragState = await loadRagState(nextFile);
+      setRagIndexed(ragState.indexed);
+      setRagMetadata(ragState.metadata);
     } catch (error) {
       toast.error(resolveAxiosError(error));
     } finally {
@@ -237,15 +315,24 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
   }
 
   async function handleRagIndex() {
-    if (!attachmentId || !file || ragIndexed) return;
+    if (!attachmentId || !file || ragIndexCompleted) return;
 
     setRagIndexing(true);
     try {
-      await reactFilesApi.ragIndex(attachmentId, { useLlmKeywordExtraction: true });
-      setRagIndexed(true);
-      const metadata = await reactFilesApi.ragMetadata(attachmentId);
-      setRagMetadata(metadata);
-      toast.success(`${file.name} 파일은 문장(조각)으로 나눠 벡터 저장소에 저장되었습니다.`);
+      const [scope] = ragObjectScopes(file, attachmentId);
+      const job = await reactAiApi.createRagJob({
+        objectType: scope.objectType,
+        objectId: scope.objectId,
+        documentId: String(attachmentId),
+        sourceType: "attachment",
+        metadata: {
+          attachmentId: String(attachmentId),
+        },
+        forceReindex: true,
+        useLlmKeywordExtraction: true,
+      });
+      setRagJobId(job.jobId);
+      toast.success(`${file.name} 파일의 RAG 색인 작업이 생성되었습니다.`);
     } catch (error) {
       toast.error(resolveAxiosError(error));
     } finally {
@@ -331,7 +418,6 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
                     sx={{
                       width: "100%",
                       maxHeight: 220,
-                      bgcolor: "grey.100",
                       borderRadius: 1,
                       objectFit: "contain",
                     }}
@@ -398,20 +484,29 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
                   <Typography variant="caption" color="text.secondary">
                     RAG
                   </Typography>
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    color="error"
-                    startIcon={<TimelineOutlined fontSize="small" />}
-                    disabled={ragIndexed || ragIndexing}
-                    onClick={() => void handleRagIndex()}
-                  >
-                    RAG 인덱싱
-                  </Button>
+                  <Tooltip title={ragIndexTooltip}>
+                    <span>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        color="error"
+                        startIcon={<TimelineOutlined fontSize="small" />}
+                        disabled={ragIndexDisabled}
+                        onClick={() => void handleRagIndex()}
+                      >
+                        RAG 인덱싱
+                      </Button>
+                    </span>
+                  </Tooltip>
                 </Stack>
-                {ragIndexed ? (
+                {ragIndexCompleted ? (
                   <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
                     이 파일은 RAG 인덱싱이 완료되었습니다.
+                  </Typography>
+                ) : null}
+                {ragJobId ? (
+                  <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+                    RAG 색인 작업 ID: {ragJobId}
                   </Typography>
                 ) : null}
               </Box>

--- a/src/react/pages/files/FileDetailDialog.tsx
+++ b/src/react/pages/files/FileDetailDialog.tsx
@@ -50,7 +50,7 @@ function formatDate(value?: Date | string | null) {
 function normalizeExtractedText(value: string) {
   return value
     .replace(/\r\n?/g, "\n")
-    .replace(/\u0000/g, "")
+    .replaceAll(String.fromCharCode(0), "")
     .replace(/\f/g, "\n\n")
     .trim();
 }

--- a/src/react/pages/files/FileDetailDialog.tsx
+++ b/src/react/pages/files/FileDetailDialog.tsx
@@ -47,6 +47,14 @@ function formatDate(value?: Date | string | null) {
   return value ? dayjs(value).format("YYYY-MM-DD HH:mm:ss") : "";
 }
 
+function normalizeExtractedText(value: string) {
+  return value
+    .replace(/\r\n?/g, "\n")
+    .replace(/\u0000/g, "")
+    .replace(/\f/g, "\n\n")
+    .trim();
+}
+
 export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
   const toast = useToast();
   const [file, setFile] = useState<AttachmentDto | null>(null);
@@ -199,7 +207,7 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
     setTextExtracting(true);
     try {
       const text = await reactFilesApi.extractText(attachmentId);
-      setExtractedText(text);
+      setExtractedText(normalizeExtractedText(text));
       setTextExtracted(true);
     } catch (error) {
       toast.error(resolveAxiosError(error));
@@ -334,7 +342,7 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
               <Box>
                 <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
                   <Typography variant="caption" color="text.secondary">
-                    Text
+                    텍스트 추출 결과
                   </Typography>
                   {!textExtracted ? (
                     <Tooltip title="콘텐츠에서 텍스트를 추출합니다.">
@@ -359,12 +367,29 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
                   )}
                 </Stack>
                 {textExtracted ? (
-                  <Typography
-                    variant="body2"
-                    sx={{ mt: 0.75, whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}
+                  <Box
+                    component="pre"
+                    sx={{
+                      m: 0,
+                      mt: 0.75,
+                      maxHeight: 280,
+                      overflow: "auto",
+                      whiteSpace: "pre-wrap",
+                      overflowWrap: "anywhere",
+                      wordBreak: "break-word",
+                      border: "1px solid",
+                      borderColor: "divider",
+                      borderRadius: 1,
+                      bgcolor: "background.default",
+                      color: "text.primary",
+                      p: 1.25,
+                      fontFamily: (theme) => theme.typography.fontFamily,
+                      fontSize: 12,
+                      lineHeight: 1.7,
+                    }}
                   >
                     {extractedText || "-"}
-                  </Typography>
+                  </Box>
                 ) : null}
               </Box>
 

--- a/src/react/pages/files/FileDetailDialog.tsx
+++ b/src/react/pages/files/FileDetailDialog.tsx
@@ -126,12 +126,16 @@ export function FileDetailDialog({ open, onClose, attachmentId }: Props) {
 
   async function loadRagState(nextFile: AttachmentDto) {
     for (const scope of ragObjectScopes(nextFile, nextFile.attachmentId)) {
-      const metadata = await reactAiApi.getRagObjectMetadata(scope.objectType, scope.objectId);
-      if (Object.keys(metadata ?? {}).length > 0 && metadataMatchesAttachment(metadata, nextFile.attachmentId)) {
-        return {
-          indexed: true,
-          metadata,
-        };
+      try {
+        const metadata = await reactAiApi.getRagObjectMetadata(scope.objectType, scope.objectId);
+        if (Object.keys(metadata ?? {}).length > 0 && metadataMatchesAttachment(metadata, nextFile.attachmentId)) {
+          return {
+            indexed: true,
+            metadata,
+          };
+        }
+      } catch {
+        // Continue with the next possible object scope before using the attachment fallback.
       }
     }
 

--- a/src/react/pages/files/FileUploadDialog.tsx
+++ b/src/react/pages/files/FileUploadDialog.tsx
@@ -128,7 +128,7 @@ export function FileUploadDialog({
       autoProceed: false,
       locale: Korean,
       restrictions: {
-        maxFileSize: 20 * 1024 * 1024,
+        maxFileSize: 50 * 1024 * 1024,
         maxNumberOfFiles: 1,
       },
       onBeforeUpload: () => {

--- a/src/react/pages/files/FilesPage.tsx
+++ b/src/react/pages/files/FilesPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Alert, Avatar, Box, IconButton, Stack, TextField, Tooltip, Typography } from "@mui/material";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import InsertDriveFileOutlinedIcon from "@mui/icons-material/InsertDriveFileOutlined";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
 import type { SelectionChangedEvent } from "ag-grid-community";
@@ -26,6 +27,218 @@ class FilesDataSource extends ReactPageDataSource<AttachmentDto> {
   constructor() {
     super("/api/mgmt/files");
   }
+}
+
+type ThumbnailCacheEntry = {
+  url?: string | null;
+  promise?: Promise<string | null>;
+  unavailableUntil?: number;
+};
+
+const thumbnailCache = new Map<number, ThumbnailCacheEntry>();
+const THUMBNAIL_RETRY_INTERVAL_MS = 1500;
+const THUMBNAIL_RETRY_LIMIT = 6;
+const THUMBNAIL_MISSING_TTL_MS = 30_000;
+
+function getCachedThumbnailUrl(attachmentId: number) {
+  const entry = thumbnailCache.get(attachmentId);
+  if (!entry) {
+    return undefined;
+  }
+  if (entry.url === null && entry.unavailableUntil && entry.unavailableUntil < Date.now()) {
+    thumbnailCache.delete(attachmentId);
+    return undefined;
+  }
+  return entry.url;
+}
+
+async function requestThumbnail(attachmentId: number) {
+  const cached = getCachedThumbnailUrl(attachmentId);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const existing = thumbnailCache.get(attachmentId);
+  if (existing?.promise) {
+    return existing.promise;
+  }
+
+  const promise = new Promise<string | null>((resolve) => {
+    let attempt = 0;
+
+    function markUnavailable() {
+      thumbnailCache.set(attachmentId, {
+        url: null,
+        unavailableUntil: Date.now() + THUMBNAIL_MISSING_TTL_MS,
+      });
+      resolve(null);
+    }
+
+    function load() {
+      reactFilesApi
+        .fetchThumbnail(attachmentId, 128)
+        .then((blob) => {
+          if (blob.size === 0) {
+            if (attempt < THUMBNAIL_RETRY_LIMIT) {
+              attempt += 1;
+              window.setTimeout(load, THUMBNAIL_RETRY_INTERVAL_MS);
+            } else {
+              markUnavailable();
+            }
+            return;
+          }
+          const nextUrl = URL.createObjectURL(blob);
+          thumbnailCache.set(attachmentId, { url: nextUrl });
+          resolve(nextUrl);
+        })
+        .catch(() => {
+          if (attempt < THUMBNAIL_RETRY_LIMIT) {
+            attempt += 1;
+            window.setTimeout(load, THUMBNAIL_RETRY_INTERVAL_MS);
+          } else {
+            markUnavailable();
+          }
+        });
+    }
+
+    load();
+  });
+
+  thumbnailCache.set(attachmentId, { promise });
+  return promise;
+}
+
+const FileThumbnail = memo(function FileThumbnail({ attachmentId, name }: { attachmentId: number; name: string }) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [visible, setVisible] = useState(false);
+  const [thumbnailUrl, setThumbnailUrl] = useState<string | null | undefined>(() =>
+    getCachedThumbnailUrl(attachmentId)
+  );
+
+  useEffect(() => {
+    const node = rootRef.current;
+    if (!node || visible) {
+      return;
+    }
+
+    if (!("IntersectionObserver" in window)) {
+      setVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        setVisible(true);
+        observer.disconnect();
+      }
+    }, { rootMargin: "160px" });
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [visible]);
+
+  useEffect(() => {
+    let ignore = false;
+    const cached = getCachedThumbnailUrl(attachmentId);
+    setThumbnailUrl(cached);
+
+    if (!attachmentId || !visible || cached !== undefined) {
+      return;
+    }
+
+    requestThumbnail(attachmentId).then((nextUrl) => {
+      if (!ignore) {
+        setThumbnailUrl(nextUrl);
+      }
+    });
+
+    return () => {
+      ignore = true;
+    };
+  }, [attachmentId, visible]);
+
+  useEffect(() => {
+    setVisible(false);
+    setThumbnailUrl(getCachedThumbnailUrl(attachmentId));
+  }, [attachmentId]);
+
+  return (
+    <Box
+      ref={rootRef}
+      sx={{
+        width: 32,
+        height: 32,
+        borderRadius: "6px",
+        flex: "0 0 auto",
+        overflow: "hidden",
+        border: "1px solid",
+        borderColor: "divider",
+        bgcolor: "transparent",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {thumbnailUrl ? (
+        <Box
+          component="img"
+          src={thumbnailUrl}
+          alt={`${name} 썸네일`}
+          sx={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+        />
+      ) : (
+        <InsertDriveFileOutlinedIcon sx={{ fontSize: 18, color: "text.secondary" }} />
+      )}
+    </Box>
+  );
+});
+
+function FileNameCell({
+  file,
+  onOpen,
+}: {
+  file: AttachmentDto;
+  onOpen: (attachmentId: number) => void;
+}) {
+  return (
+    <Box
+      component="button"
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onOpen(file.attachmentId);
+      }}
+      sx={{
+        width: "100%",
+        height: "100%",
+        border: 0,
+        p: 0,
+        bgcolor: "transparent",
+        color: "primary.main",
+        cursor: "pointer",
+        font: "inherit",
+        textAlign: "left",
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        minWidth: 0,
+        "&:hover .file-name-text": { textDecoration: "underline" },
+      }}
+    >
+      <FileThumbnail attachmentId={file.attachmentId} name={file.name} />
+      <Typography
+        className="file-name-text"
+        variant="body2"
+        noWrap
+        sx={{ minWidth: 0, color: "primary.main" }}
+        title={file.name}
+      >
+        {file.name}
+      </Typography>
+    </Box>
+  );
 }
 
 function SelectionCheckbox({
@@ -201,28 +414,13 @@ export function FilesPage() {
         flex: 1.6,
         sortable: true,
         filter: false,
-        cellRenderer: (params: ICellRendererParams<AttachmentDto>) => (
-          <Box
-            component="button"
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              setDetailAttachmentId(params.data?.attachmentId ?? null);
-            }}
-            sx={{
-              border: 0,
-              p: 0,
-              bgcolor: "transparent",
-              color: "primary.main",
-              cursor: "pointer",
-              font: "inherit",
-              textAlign: "left",
-              "&:hover": { textDecoration: "underline" },
-            }}
-          >
-            {params.value}
-          </Box>
-        ),
+        cellRenderer: (params: ICellRendererParams<AttachmentDto>) =>
+          params.data ? (
+            <FileNameCell
+              file={params.data}
+              onOpen={(attachmentId) => setDetailAttachmentId(attachmentId)}
+            />
+          ) : null,
       },
       {
         field: "size",
@@ -272,6 +470,7 @@ export function FilesPage() {
       },
       suppressRowClickSelection: true,
       rowMultiSelectWithClick: true,
+      rowHeight: 48,
     }),
     []
   );

--- a/src/react/pages/files/FilesPage.tsx
+++ b/src/react/pages/files/FilesPage.tsx
@@ -61,6 +61,7 @@ function SelectionCheckbox({
         margin: 0,
         accentColor: "#1565c0",
         cursor: "pointer",
+        transform: ariaLabel === "행 선택" ? "translateY(2px)" : "none",
       }}
     />
   );
@@ -131,7 +132,7 @@ export function FilesPage() {
       currentState.selectedCount < currentState.displayedCount;
 
     return (
-      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+      <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
         <SelectionCheckbox
           ariaLabel="전체 선택"
           checked={allDisplayedSelected}
@@ -171,7 +172,7 @@ export function FilesPage() {
           const checked = params.node.isSelected();
 
           return (
-            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+            <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
               <SelectionCheckbox
                 ariaLabel="행 선택"
                 checked={checked}

--- a/src/react/pages/files/FilesPage.tsx
+++ b/src/react/pages/files/FilesPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Alert, Avatar, Box, IconButton, Stack, TextField, Tooltip, Typography } from "@mui/material";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
@@ -28,6 +28,80 @@ class FilesDataSource extends ReactPageDataSource<AttachmentDto> {
   }
 }
 
+function SelectionCheckbox({
+  checked,
+  indeterminate = false,
+  ariaLabel,
+  onChange,
+}: {
+  checked: boolean;
+  indeterminate?: boolean;
+  ariaLabel: string;
+  onChange: (checked: boolean) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked}
+      onChange={(event) => onChange(event.target.checked)}
+      onClick={(event) => event.stopPropagation()}
+      style={{
+        width: 16,
+        height: 16,
+        margin: 0,
+        accentColor: "#1565c0",
+        cursor: "pointer",
+      }}
+    />
+  );
+}
+
+function getDisplayedSelectionState(api: {
+  getLastDisplayedRowIndex: () => number;
+  getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+}) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  if (lastIndex < 0) {
+    return { displayedCount: 0, selectedCount: 0 };
+  }
+
+  let displayedCount = 0;
+  let selectedCount = 0;
+  for (let index = 0; index <= lastIndex; index += 1) {
+    const row = api.getDisplayedRowAtIndex(index);
+    if (!row) continue;
+    displayedCount += 1;
+    if (row.isSelected()) {
+      selectedCount += 1;
+    }
+  }
+
+  return { displayedCount, selectedCount };
+}
+
+function toggleDisplayedRows(
+  api: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  },
+  selected: boolean
+) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  for (let index = 0; index <= lastIndex; index += 1) {
+    api.getDisplayedRowAtIndex(index)?.setSelected(selected);
+  }
+}
+
 export function FilesPage() {
   const queryClient = useQueryClient();
   const gridRef = useRef<PageableGridContentHandle<AttachmentDto>>(null);
@@ -39,11 +113,87 @@ export function FilesPage() {
   const [detailAttachmentId, setDetailAttachmentId] = useState<number | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [displayedCount, setDisplayedCount] = useState(0);
   const selectedCount = selectedIds.length;
+
+  function renderHeaderCheckbox(api?: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  }) {
+    const currentState = api
+      ? getDisplayedSelectionState(api)
+      : { displayedCount, selectedCount };
+    const allDisplayedSelected =
+      currentState.displayedCount > 0 &&
+      currentState.selectedCount === currentState.displayedCount;
+    const partiallySelected =
+      currentState.selectedCount > 0 &&
+      currentState.selectedCount < currentState.displayedCount;
+
+    return (
+      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+        <SelectionCheckbox
+          ariaLabel="전체 선택"
+          checked={allDisplayedSelected}
+          indeterminate={partiallySelected}
+          onChange={() => {
+            if (api) {
+              toggleDisplayedRows(api, !allDisplayedSelected);
+            }
+          }}
+        />
+      </Box>
+    );
+  }
 
   const columnDefs = useMemo<ColDef<AttachmentDto>[]>(
     () => [
-      { field: "attachmentId", headerName: "ID", flex: 0.35, sortable: true, type: "number", filter: false },
+      {
+        colId: "rowSelect",
+        headerName: "",
+        width: 40,
+        minWidth: 40,
+        maxWidth: 40,
+        pinned: "left",
+        sortable: false,
+        resizable: false,
+        suppressMovable: true,
+        lockPosition: true,
+        cellClass: "selection-column-centered",
+        headerClass: "selection-column-centered",
+        headerComponent: (props: {
+          api: {
+            getLastDisplayedRowIndex: () => number;
+            getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+          };
+        }) => renderHeaderCheckbox(props.api),
+        cellRenderer: (params: ICellRendererParams<AttachmentDto>) => {
+          const checked = params.node.isSelected();
+
+          return (
+            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+              <SelectionCheckbox
+                ariaLabel="행 선택"
+                checked={checked}
+                onChange={(nextChecked) => params.node.setSelected(nextChecked)}
+              />
+            </Box>
+          );
+        },
+      },
+      {
+        field: "attachmentId",
+        headerName: "ID",
+        width: 64,
+        minWidth: 64,
+        maxWidth: 64,
+        sortable: true,
+        type: "number",
+        filter: false,
+        cellStyle: { textAlign: "center" },
+        headerClass: "id-column-centered",
+        cellClass: "id-column-centered",
+      },
       {
         field: "name",
         headerName: "파일",
@@ -108,22 +258,18 @@ export function FilesPage() {
       },
       { field: "createdAt", headerName: "생성일시", flex: 0.75, sortable: true, type: "datetime", filter: false },
     ],
-    []
+    [displayedCount, selectedCount]
   );
 
   const gridOptions = useMemo(
     () => ({
-      rowSelection: { mode: "multiRow" as const, enableClickSelection: false, checkboxes: true, headerCheckbox: false },
-      suppressRowClickSelection: true,
-      selectionColumnDef: {
-        width: 65,
-        minWidth: 65,
-        maxWidth: 65,
-        pinned: "left" as const,
-        sortable: false,
-        filter: false,
-        resizable: false,
+      rowSelection: {
+        mode: "multiRow" as const,
+        enableClickSelection: false,
+        checkboxes: false,
+        headerCheckbox: false,
       },
+      suppressRowClickSelection: true,
       rowMultiSelectWithClick: true,
     }),
     []
@@ -140,6 +286,14 @@ export function FilesPage() {
               .map((row) => Number(row.attachmentId))
               .filter((id) => Number.isFinite(id) && id > 0)
           );
+          setDisplayedCount((event as SelectionChangedEvent<AttachmentDto>).api.getDisplayedRowCount());
+        },
+      },
+      {
+        type: "modelUpdated",
+        listener: (event: { api: { getDisplayedRowCount: () => number; refreshHeader?: () => void } }) => {
+          setDisplayedCount(event.api.getDisplayedRowCount());
+          event.api.refreshHeader?.();
         },
       },
     ],

--- a/src/react/pages/files/api.ts
+++ b/src/react/pages/files/api.ts
@@ -63,7 +63,7 @@ export const reactFilesApi = {
     );
   },
   async fetchThumbnail(attachmentId: number, size = 256, format = "png") {
-    const response = await apiClient.get<Blob>(`/api/attachments/${attachmentId}/thumbnail`, {
+    const response = await apiClient.get<Blob>(`/api/mgmt/files/${attachmentId}/thumbnail`, {
       params: { size, format },
       responseType: "blob",
       withCredentials: true,

--- a/src/react/pages/mail/MailInboxPage.tsx
+++ b/src/react/pages/mail/MailInboxPage.tsx
@@ -184,6 +184,7 @@ function SelectionCheckbox({
         margin: 0,
         accentColor: "#1565c0",
         cursor: "pointer",
+        transform: ariaLabel === "행 선택" ? "translateY(2px)" : "none",
       }}
     />
   );
@@ -253,7 +254,7 @@ export function MailInboxPage() {
       currentSelectedCount > 0 && currentSelectedCount < currentDisplayedCount;
 
     return (
-      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+      <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
         <SelectionCheckbox
           ariaLabel="전체 선택"
           checked={allDisplayedSelected}
@@ -295,7 +296,7 @@ export function MailInboxPage() {
           const checked = params.node.isSelected();
 
           return (
-            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+            <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
               <SelectionCheckbox
                 ariaLabel="행 선택"
                 checked={checked}

--- a/src/react/pages/mail/MailInboxPage.tsx
+++ b/src/react/pages/mail/MailInboxPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   Box,
@@ -13,7 +13,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { DeleteOutlined, SelectAllOutlined, SyncOutlined } from "@mui/icons-material";
+import { DeleteOutlined, SyncOutlined } from "@mui/icons-material";
 import DOMPurify from "dompurify";
 import type { ColDef, ICellRendererParams, SelectionChangedEvent } from "ag-grid-community";
 import { useNavigate } from "react-router-dom";
@@ -151,6 +151,82 @@ function MailDetailDialog({
   );
 }
 
+function SelectionCheckbox({
+  checked,
+  indeterminate = false,
+  ariaLabel,
+  onChange,
+}: {
+  checked: boolean;
+  indeterminate?: boolean;
+  ariaLabel: string;
+  onChange: (checked: boolean) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked}
+      onChange={(event) => onChange(event.target.checked)}
+      onClick={(event) => event.stopPropagation()}
+      style={{
+        width: 16,
+        height: 16,
+        margin: 0,
+        accentColor: "#1565c0",
+        cursor: "pointer",
+      }}
+    />
+  );
+}
+
+function getDisplayedSelectionState(api: {
+  getLastDisplayedRowIndex: () => number;
+  getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+}) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  if (lastIndex < 0) {
+    return { displayedCount: 0, selectedCount: 0 };
+  }
+
+  let displayedCount = 0;
+  let selectedCount = 0;
+  for (let index = 0; index <= lastIndex; index += 1) {
+    const row = api.getDisplayedRowAtIndex(index);
+    if (!row) {
+      continue;
+    }
+    displayedCount += 1;
+    if (row.isSelected()) {
+      selectedCount += 1;
+    }
+  }
+
+  return { displayedCount, selectedCount };
+}
+
+function toggleDisplayedRows(
+  api: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  },
+  selected: boolean
+) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  for (let index = 0; index <= lastIndex; index += 1) {
+    api.getDisplayedRowAtIndex(index)?.setSelected(selected);
+  }
+}
+
 export function MailInboxPage() {
   const navigate = useNavigate();
   const gridRef = useRef<PageableGridContentHandle<MailMessageDto>>(null);
@@ -160,9 +236,88 @@ export function MailInboxPage() {
   const [selectedMessage, setSelectedMessage] = useState<MailMessageDto | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedCount, setSelectedCount] = useState(0);
+  const [displayedCount, setDisplayedCount] = useState(0);
+
+  function renderHeaderCheckbox(api?: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  }) {
+    const currentState = api
+      ? getDisplayedSelectionState(api)
+      : { displayedCount, selectedCount };
+    const currentDisplayedCount = currentState.displayedCount;
+    const currentSelectedCount = currentState.selectedCount;
+    const allDisplayedSelected =
+      currentDisplayedCount > 0 && currentSelectedCount === currentDisplayedCount;
+    const partiallySelected =
+      currentSelectedCount > 0 && currentSelectedCount < currentDisplayedCount;
+
+    return (
+      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+        <SelectionCheckbox
+          ariaLabel="전체 선택"
+          checked={allDisplayedSelected}
+          indeterminate={partiallySelected}
+          onChange={() => {
+            if (api) {
+              toggleDisplayedRows(api, !allDisplayedSelected);
+              return;
+            }
+            handleSelectAllToggle();
+          }}
+        />
+      </Box>
+    );
+  }
 
   const columnDefs = useMemo<ColDef<MailMessageDto>[]>(
     () => [
+      {
+        colId: "rowSelect",
+        headerName: "",
+        width: 40,
+        minWidth: 40,
+        maxWidth: 40,
+        pinned: "left",
+        sortable: false,
+        resizable: false,
+        suppressMovable: true,
+        lockPosition: true,
+        cellClass: "selection-column-centered",
+        headerClass: "selection-column-centered",
+        headerComponent: (props: {
+          api: {
+            getLastDisplayedRowIndex: () => number;
+            getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+          };
+        }) => renderHeaderCheckbox(props.api),
+        cellRenderer: (params: ICellRendererParams<MailMessageDto>) => {
+          const checked = params.node.isSelected();
+
+          return (
+            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+              <SelectionCheckbox
+                ariaLabel="행 선택"
+                checked={checked}
+                onChange={(nextChecked) => params.node.setSelected(nextChecked)}
+              />
+            </Box>
+          );
+        },
+      },
+      {
+        field: "mailId",
+        headerName: "ID",
+        width: 64,
+        minWidth: 64,
+        maxWidth: 64,
+        sortable: true,
+        type: "number",
+        filter: false,
+        cellStyle: { textAlign: "center" },
+        headerClass: "id-column-centered",
+        cellClass: "id-column-centered",
+      },
       {
         field: "fromAddress",
         headerName: "보낸 사람",
@@ -212,15 +367,24 @@ export function MailInboxPage() {
         type: "datetime",
       },
     ],
-    []
+    [displayedCount, selectedCount]
   );
 
   const gridEvents = useMemo(
     () => [
       {
         type: "selectionChanged",
-        listener: (event: SelectionChangedEvent<MailMessageDto>) => {
+        listener: (event: SelectionChangedEvent<MailMessageDto> & { api: { refreshHeader?: () => void } }) => {
           setSelectedCount(event.api.getSelectedRows().length);
+          setDisplayedCount(event.api.getDisplayedRowCount());
+          event.api.refreshHeader?.();
+        },
+      },
+      {
+        type: "modelUpdated",
+        listener: (event: { api: { getDisplayedRowCount: () => number; refreshHeader?: () => void } }) => {
+          setDisplayedCount(event.api.getDisplayedRowCount());
+          event.api.refreshHeader?.();
         },
       },
     ],
@@ -292,11 +456,6 @@ export function MailInboxPage() {
           onSearch={handleSearch}
           actions={
             <Stack direction="row" spacing={0.5}>
-              <Tooltip title="전체 선택 / 선택 해제">
-                <IconButton size="small" onClick={handleSelectAllToggle}>
-                  <SelectAllOutlined fontSize="small" />
-                </IconButton>
-              </Tooltip>
               <Tooltip title="메일 동기화 화면으로 이동합니다.">
                 <IconButton size="small" onClick={() => navigate("/application/mail/sync")}>
                   <SyncOutlined fontSize="small" />
@@ -325,7 +484,15 @@ export function MailInboxPage() {
           datasource={dataSource}
           columns={columnDefs}
           events={gridEvents}
-          rowSelection="multiple"
+          rowSelection={{
+            mode: "multiRow",
+            enableClickSelection: false,
+            checkboxes: false,
+            headerCheckbox: false,
+          }}
+          options={{
+            suppressRowClickSelection: true,
+          }}
         />
       </Stack>
 

--- a/src/react/pages/templates/TemplatesPage.tsx
+++ b/src/react/pages/templates/TemplatesPage.tsx
@@ -31,6 +31,80 @@ class TemplatesDataSource extends ReactPageDataSource<TemplateSummaryDto> {
   }
 }
 
+function SelectionCheckbox({
+  checked,
+  indeterminate = false,
+  ariaLabel,
+  onChange,
+}: {
+  checked: boolean;
+  indeterminate?: boolean;
+  ariaLabel: string;
+  onChange: (checked: boolean) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked}
+      onChange={(event) => onChange(event.target.checked)}
+      onClick={(event) => event.stopPropagation()}
+      style={{
+        width: 16,
+        height: 16,
+        margin: 0,
+        accentColor: "#1565c0",
+        cursor: "pointer",
+      }}
+    />
+  );
+}
+
+function getDisplayedSelectionState(api: {
+  getLastDisplayedRowIndex: () => number;
+  getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+}) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  if (lastIndex < 0) {
+    return { displayedCount: 0, selectedCount: 0 };
+  }
+
+  let displayedCount = 0;
+  let selectedCount = 0;
+  for (let index = 0; index <= lastIndex; index += 1) {
+    const row = api.getDisplayedRowAtIndex(index);
+    if (!row) continue;
+    displayedCount += 1;
+    if (row.isSelected()) {
+      selectedCount += 1;
+    }
+  }
+
+  return { displayedCount, selectedCount };
+}
+
+function toggleDisplayedRows(
+  api: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  },
+  selected: boolean
+) {
+  const lastIndex = api.getLastDisplayedRowIndex();
+  for (let index = 0; index <= lastIndex; index += 1) {
+    api.getDisplayedRowAtIndex(index)?.setSelected(selected);
+  }
+}
+
 export function TemplatesPage() {
   const navigate = useNavigate();
   const confirm = useConfirm();
@@ -43,6 +117,7 @@ export function TemplatesPage() {
   const [objectId, setObjectId] = useState("");
   const [objectTypes, setObjectTypes] = useState<ObjectTypeDto[]>([]);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [displayedCount, setDisplayedCount] = useState(0);
   const selectedCount = selectedIds.length;
 
   useEffect(() => {
@@ -52,9 +127,84 @@ export function TemplatesPage() {
       .catch(() => {});
   }, []);
 
+  function renderHeaderCheckbox(api?: {
+    getLastDisplayedRowIndex: () => number;
+    getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+  }) {
+    const currentState = api
+      ? getDisplayedSelectionState(api)
+      : { displayedCount, selectedCount };
+    const allDisplayedSelected =
+      currentState.displayedCount > 0 &&
+      currentState.selectedCount === currentState.displayedCount;
+    const partiallySelected =
+      currentState.selectedCount > 0 &&
+      currentState.selectedCount < currentState.displayedCount;
+
+    return (
+      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+        <SelectionCheckbox
+          ariaLabel="전체 선택"
+          checked={allDisplayedSelected}
+          indeterminate={partiallySelected}
+          onChange={() => {
+            if (api) {
+              toggleDisplayedRows(api, !allDisplayedSelected);
+            }
+          }}
+        />
+      </Box>
+    );
+  }
+
   const columnDefs = useMemo<ColDef<TemplateSummaryDto>[]>(
     () => [
-      { field: "templateId", headerName: "ID", type: "number", maxWidth: 90, sortable: true, filter: false },
+      {
+        colId: "rowSelect",
+        headerName: "",
+        width: 40,
+        minWidth: 40,
+        maxWidth: 40,
+        pinned: "left",
+        sortable: false,
+        resizable: false,
+        suppressMovable: true,
+        lockPosition: true,
+        cellClass: "selection-column-centered",
+        headerClass: "selection-column-centered",
+        headerComponent: (props: {
+          api: {
+            getLastDisplayedRowIndex: () => number;
+            getDisplayedRowAtIndex: (index: number) => { isSelected: () => boolean; setSelected: (selected: boolean) => void } | undefined;
+          };
+        }) => renderHeaderCheckbox(props.api),
+        cellRenderer: (params: ICellRendererParams<TemplateSummaryDto>) => {
+          const checked = params.node.isSelected();
+
+          return (
+            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+              <SelectionCheckbox
+                ariaLabel="행 선택"
+                checked={checked}
+                onChange={(nextChecked) => params.node.setSelected(nextChecked)}
+              />
+            </Box>
+          );
+        },
+      },
+      {
+        field: "templateId",
+        headerName: "ID",
+        width: 64,
+        minWidth: 64,
+        maxWidth: 64,
+        sortable: true,
+        type: "number",
+        filter: false,
+        cellStyle: { textAlign: "center" },
+        headerClass: "id-column-centered",
+        cellClass: "id-column-centered",
+      },
       { field: "objectType", headerName: "유형", type: "number", maxWidth: 90, sortable: true, filter: false },
       { field: "objectId", headerName: "식별자", type: "number", maxWidth: 100, sortable: true, filter: false },
       {
@@ -148,22 +298,18 @@ export function TemplatesPage() {
       },
       { field: "updatedAt", headerName: "수정일시", type: "datetime", flex: 1, sortable: true, filter: false },
     ],
-    [navigate]
+    [displayedCount, navigate, selectedCount]
   );
 
   const gridOptions = useMemo(
     () => ({
-      rowSelection: { mode: "multiRow" as const, enableClickSelection: false, checkboxes: true, headerCheckbox: false },
-      suppressRowClickSelection: true,
-      selectionColumnDef: {
-        width: 65,
-        minWidth: 65,
-        maxWidth: 65,
-        pinned: "left" as const,
-        sortable: false,
-        filter: false,
-        resizable: false,
+      rowSelection: {
+        mode: "multiRow" as const,
+        enableClickSelection: false,
+        checkboxes: false,
+        headerCheckbox: false,
       },
+      suppressRowClickSelection: true,
       rowMultiSelectWithClick: true,
     }),
     []
@@ -180,6 +326,14 @@ export function TemplatesPage() {
               .map((row) => Number(row.templateId))
               .filter((id) => Number.isFinite(id) && id > 0)
           );
+          setDisplayedCount((event as SelectionChangedEvent<TemplateSummaryDto>).api.getDisplayedRowCount());
+        },
+      },
+      {
+        type: "modelUpdated",
+        listener: (event: { api: { getDisplayedRowCount: () => number; refreshHeader?: () => void } }) => {
+          setDisplayedCount(event.api.getDisplayedRowCount());
+          event.api.refreshHeader?.();
         },
       },
     ],

--- a/src/react/pages/templates/TemplatesPage.tsx
+++ b/src/react/pages/templates/TemplatesPage.tsx
@@ -64,6 +64,7 @@ function SelectionCheckbox({
         margin: 0,
         accentColor: "#1565c0",
         cursor: "pointer",
+        transform: ariaLabel === "행 선택" ? "translateY(2px)" : "none",
       }}
     />
   );
@@ -142,7 +143,7 @@ export function TemplatesPage() {
       currentState.selectedCount < currentState.displayedCount;
 
     return (
-      <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+      <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
         <SelectionCheckbox
           ariaLabel="전체 선택"
           checked={allDisplayedSelected}
@@ -182,7 +183,7 @@ export function TemplatesPage() {
           const checked = params.node.isSelected();
 
           return (
-            <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
+            <Box sx={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
               <SelectionCheckbox
                 ariaLabel="행 선택"
                 checked={checked}

--- a/src/react/router/AppRouter.tsx
+++ b/src/react/router/AppRouter.tsx
@@ -8,7 +8,9 @@ import { ForumTopicDetailPage } from "@/react/pages/community/ForumTopicDetailPa
 import { ForumTopicListPage } from "@/react/pages/community/ForumTopicListPage";
 import { DashboardPage } from "@/react/pages/DashboardPage";
 import { ChatPage } from "@/react/pages/ai/ChatPage";
-import { RagPage } from "@/react/pages/ai/RagPage";
+import { RagChatPage } from "@/react/pages/ai/RagChatPage";
+import { RagJobDetailPage } from "@/react/pages/ai/RagJobDetailPage";
+import { RagJobListPage } from "@/react/pages/ai/RagJobListPage";
 import { DocumentListPage } from "@/react/pages/documents/DocumentListPage";
 import { DocumentEditorPage } from "@/react/pages/documents/DocumentEditorPage";
 import { FilesPage } from "@/react/pages/files/FilesPage";
@@ -76,7 +78,9 @@ export function AppRouter() {
             element={<ObjectStoragePage />}
           />
           <Route path="services/ai/chat" element={<ChatPage />} />
-          <Route path="services/ai/rag" element={<RagPage />} />
+          <Route path="services/ai/rag-chat" element={<RagChatPage />} />
+          <Route path="services/ai/rag" element={<RagJobListPage />} />
+          <Route path="services/ai/rag/jobs/:jobId" element={<RagJobDetailPage />} />
           {/* Admin and Security Pages */}
           <Route path="admin/*" element={<AdminRoutes />} />
         </Route>

--- a/src/react/theme/AppThemeProvider.tsx
+++ b/src/react/theme/AppThemeProvider.tsx
@@ -1,10 +1,9 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import {
   CssBaseline,
-  ThemeProvider,
-  createTheme,
   useMediaQuery,
 } from "@mui/material";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
 
 const THEME_MODE_KEY = "theme_mode";
 
@@ -38,8 +37,8 @@ export function AppThemeProvider({ children }: { children: React.ReactNode }) {
             main: "#1565c0",
           },
           background: {
-            default: resolvedMode === "dark" ? "#0f172a" : "#f5f7fb",
-            paper: resolvedMode === "dark" ? "#111827" : "#ffffff",
+            default: resolvedMode === "dark" ? "#182230" : "#f5f7fb",
+            paper: resolvedMode === "dark" ? "#1f2836" : "#ffffff",
           },
         },
         components: {
@@ -68,6 +67,12 @@ export function AppThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     window.localStorage.setItem(THEME_MODE_KEY, mode);
   }, [mode]);
+
+  useEffect(() => {
+    document.documentElement.dataset.themeMode = resolvedMode;
+    document.documentElement.dataset.agThemeMode = resolvedMode;
+    document.documentElement.style.colorScheme = resolvedMode;
+  }, [resolvedMode]);
 
   const value = useMemo(
     () => ({ mode, setMode, resolvedMode }),

--- a/src/types/studio/ai.ts
+++ b/src/types/studio/ai.ts
@@ -1,8 +1,10 @@
 export type Role = "system" | "user" | "assistant";
 
 export interface ChatMessageDto {
+  messageId?: string;
   role: Role;
   content: string;
+  createdAt?: string;
 }
 
 export interface ChatRequestDto {
@@ -24,9 +26,24 @@ export interface ChatMemoryOptionsDto {
 }
 
 export interface ChatResponseDto {
+  conversationId?: string;
   messages: ChatMessageDto[];
   model?: string;
-  metadata?: Record<string, any>;
+  metadata?: ChatResponseMetadataDto;
+}
+
+export interface ChatResponseMetadataDto {
+  provider?: string;
+  resolvedModel?: string;
+  tokenUsage?: TokenUsageDto;
+  latencyMs?: number;
+  memoryUsed?: boolean;
+  conversationId?: string;
+  memoryEnabled?: boolean;
+  memoryMessageCount?: number;
+  responseId?: string;
+  finishReason?: string;
+  [key: string]: unknown;
 }
 
 export interface ChatRagRequestDto {
@@ -79,6 +96,43 @@ export interface ChatMemoryInfo {
   readonly maxMessages?: number;
   readonly maxConversations?: number;
   readonly ttl?: string;
+}
+
+export interface ChatStreamDeltaEventDto {
+  content?: string;
+}
+
+export type ChatStreamUsageEventDto = TokenUsageDto;
+
+export interface ChatStreamCompleteEventDto {
+  requestId?: string;
+  provider?: string;
+  resolvedModel?: string;
+  conversationId?: string;
+  latencyMs?: number;
+  fallbackUsed?: boolean;
+  finishReason?: string;
+}
+
+export interface ConversationSummaryDto {
+  conversationId: string;
+  title?: string;
+  summary?: string;
+  messageCount?: number;
+  lastUpdatedAt?: string;
+}
+
+export interface ConversationDetailDto extends ConversationSummaryDto {
+  messages: ChatMessageDto[];
+}
+
+export interface ConversationDeleteResponseDto {
+  conversationId: string;
+  deleted: boolean;
+}
+
+export interface RegenerateRequestDto {
+  conversationId: string;
 }
 
 export interface AclActionMaskDto {

--- a/src/types/studio/ai.ts
+++ b/src/types/studio/ai.ts
@@ -43,7 +43,26 @@ export interface ChatResponseMetadataDto {
   memoryMessageCount?: number;
   responseId?: string;
   finishReason?: string;
+  ragReferences?: RagReferenceDto[];
   [key: string]: unknown;
+}
+
+export interface RagReferenceDto {
+  index?: number;
+  documentId?: string;
+  sourceName?: string;
+  chunkId?: string;
+  chunkOrder?: number | string;
+  score?: number;
+  content?: string;
+  page?: number | string;
+  pageNumber?: number | string;
+  slide?: number | string;
+  slideNumber?: number | string;
+  sourceRef?: string;
+  section?: string;
+  heading?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ChatRagRequestDto {

--- a/src/types/studio/ai.ts
+++ b/src/types/studio/ai.ts
@@ -60,6 +60,7 @@ export interface RagReferenceDto {
   slide?: number | string;
   slideNumber?: number | string;
   sourceRef?: string;
+  sourceRefs?: string;
   section?: string;
   heading?: string;
   metadata?: Record<string, unknown>;

--- a/src/types/studio/ai.ts
+++ b/src/types/studio/ai.ts
@@ -99,19 +99,27 @@ export interface ChatMemoryInfo {
 }
 
 export interface ChatStreamDeltaEventDto {
+  delta?: string;
   content?: string;
 }
 
-export type ChatStreamUsageEventDto = TokenUsageDto;
+export interface ChatStreamUsageEventDto extends Partial<TokenUsageDto> {
+  type?: string;
+  requestId?: string;
+  metadata?: ChatResponseMetadataDto;
+}
 
 export interface ChatStreamCompleteEventDto {
+  type?: string;
   requestId?: string;
+  model?: string;
   provider?: string;
   resolvedModel?: string;
   conversationId?: string;
   latencyMs?: number;
   fallbackUsed?: boolean;
   finishReason?: string;
+  metadata?: ChatResponseMetadataDto;
 }
 
 export interface ConversationSummaryDto {

--- a/src/types/studio/ai.ts
+++ b/src/types/studio/ai.ts
@@ -47,11 +47,16 @@ export interface ChatResponseMetadataDto {
 }
 
 export interface ChatRagRequestDto {
-  chat:ChatRequestDto;
-  ragQuery?:string;
+  chat: ChatRequestDto;
+  ragQuery?: string;
   ragTopK?: number; // 선택
   objectType?: string;
   objectId?: string;
+  embeddingProfileId?: string;
+  embeddingProvider?: string;
+  embeddingModel?: string;
+  topK?: number;
+  minScore?: number;
   debug?: boolean;
 }
 
@@ -152,6 +157,9 @@ export interface SearchRequestDto {
   query?: string | null;
   topK?: number;
   hybrid?:boolean
+  objectType?: string;
+  objectId?: string;
+  minScore?: number;
 }
 
 export interface SearchResultDto {
@@ -204,4 +212,178 @@ export interface RagIndexRequestDto {
   metadata?: Record<string, any>;
   keywords?: string[];
   useLlmKeywordExtraction?: boolean;
+}
+
+export type RagIndexJobStatus =
+  | "PENDING"
+  | "RUNNING"
+  | "SUCCEEDED"
+  | "WARNING"
+  | "FAILED"
+  | "CANCELLED";
+
+export type RagIndexJobStep =
+  | "EXTRACTING"
+  | "CHUNKING"
+  | "EMBEDDING"
+  | "INDEXING"
+  | "COMPLETED";
+
+export type RagIndexJobLogLevel = "INFO" | "WARN" | "ERROR";
+
+export interface RagIndexJobCreateRequestDto extends RagIndexRequestDto {
+  text?: string;
+  sourceType?: string;
+  forceReindex?: boolean;
+  chunkingStrategy?: string;
+  chunkMaxSize?: number;
+  chunkOverlap?: number;
+  chunkUnit?: string;
+}
+
+export interface RagIndexJobDto {
+  jobId: string;
+  objectType: string;
+  objectId: string;
+  documentId?: string;
+  sourceType?: string;
+  sourceName?: string;
+  status: RagIndexJobStatus;
+  currentStep?: RagIndexJobStep;
+  chunkCount: number;
+  embeddedCount: number;
+  indexedCount: number;
+  warningCount: number;
+  errorMessage?: string;
+  chunkingStrategy?: string;
+  chunkMaxSize?: number;
+  chunkOverlap?: number;
+  chunkUnit?: string;
+  createdAt?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  durationMs?: number;
+}
+
+export interface RagIndexJobListResponseDto {
+  items: RagIndexJobDto[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+export interface RagIndexJobLogDto {
+  logId: string;
+  jobId: string;
+  level: RagIndexJobLogLevel;
+  step?: RagIndexJobStep;
+  code?: string;
+  message?: string;
+  detail?: string;
+  createdAt?: string;
+}
+
+export interface RagIndexChunkDto {
+  chunkId: string;
+  documentId: string;
+  parentChunkId?: string;
+  chunkOrder?: number;
+  chunkType?: string;
+  content: string;
+  score?: number;
+  headingPath?: string;
+  sourceRef?: string;
+  page?: number;
+  slide?: number;
+  metadata?: Record<string, unknown>;
+  createdAt?: string;
+  indexedAt?: string;
+}
+
+export interface RagIndexChunkPageResponseDto {
+  items: RagIndexChunkDto[];
+  offset: number;
+  limit: number;
+  returned: number;
+  hasMore: boolean;
+}
+
+export interface RagChunkPreviewRequestDto {
+  text: string;
+  documentId?: string;
+  objectType?: string;
+  objectId?: string;
+  contentType?: string;
+  filename?: string;
+  strategy?: string;
+  maxSize?: number;
+  overlap?: number;
+  unit?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RagChunkPreviewItemDto {
+  chunkId: string;
+  content: string;
+  contentLength: number;
+  chunkOrder?: number;
+  chunkType?: string;
+  parentChunkId?: string;
+  previousChunkId?: string;
+  nextChunkId?: string;
+  headingPath?: string;
+  section?: string;
+  sourceRef?: string;
+  page?: number;
+  slide?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RagChunkPreviewResponseDto {
+  chunks: RagChunkPreviewItemDto[];
+  totalChunks: number;
+  totalChars: number;
+  strategy: string;
+  maxSize: number;
+  overlap: number;
+  unit: string;
+  warnings: string[];
+}
+
+export interface RagChunkConfigResponseDto {
+  chunking: {
+    available: boolean;
+    enabled: boolean;
+    strategy: string;
+    previewStrategy?: string | null;
+    defaultStrategyPreviewSupported: boolean;
+    maxSize: number;
+    overlap: number;
+    availableStrategies: string[];
+    registeredChunkers: string[];
+    chunkingOrchestratorAvailable: boolean;
+  };
+  legacyFallback: {
+    chunkSize: number;
+    chunkOverlap: number;
+    textChunkerAvailable: boolean;
+  };
+  ragContext: {
+    maxChunks: number;
+    maxChars: number;
+    includeScores: boolean;
+    expansion: {
+      enabled: boolean;
+      candidateMultiplier: number;
+      maxCandidates: number;
+      previousWindow: number;
+      nextWindow: number;
+      includeParentContent: boolean;
+    };
+  };
+  limits: {
+    enabled: boolean;
+    maxInputChars: number;
+    maxPreviewChunks: number;
+  };
 }


### PR DESCRIPTION
## Why

- AI RAG 운영 화면, RAG Chat, 파일 썸네일, 관리 그리드 선택 UX를 실제 사용 흐름에 맞게 정리하기 위해 반영했습니다.
- 사용자가 RAG 색인 작업 목록, 상세 Chunk 검수, 검색 검증, 문맥 기반 답변 생성, RAG Chat 출처 확인을 한 흐름 안에서 사용할 수 있어야 했습니다.

## What

- AI RAG 작업 목록/상세 화면을 추가하고, 검색 검증과 청킹 시뮬레이션을 운영 화면 기준으로 재구성했습니다.
- AI RAG Chat 메뉴와 설정, 입력 UX, 출처 팝업, 하단 이동 버튼, 토큰/시간 표시를 개선했습니다.
- 파일 목록/상세에 thumbnail 표시를 추가하고 RAG 인덱싱 상태 기반 버튼 제어를 보강했습니다.
- ADMIN 사용자/역할/그룹 및 공통 grid checkbox 선택/정렬 UX를 조정했습니다.
- 변경 이력을 CHANGELOG.md에 기록하고 로컬 임시 디렉터리 ignore 규칙을 추가했습니다.

## Related Issues

- 별도 Issue 없음: 장기간의 화면 개선 요청을 같은 작업 단위로 누적 반영했으며, Issue 생성 예외 사유를 commit body에 기록했습니다.

## Validation

- Command: `npm run typecheck`
- Result: passed
- Command: `git diff --check -- . ':!dist'`
- Result: passed

## Risk / Rollback

- Risk: AI RAG 화면과 Chat 화면의 UI 상태 관리 범위가 넓어 일부 서버 응답 조합에서 표시 상태가 어긋날 수 있습니다.
- Rollback: 이 PR의 merge commit 또는 `[ai-assisted] feat(ai-rag): RAG 운영과 대화 UI 개선` 커밋을 revert합니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: `npm run typecheck`, `git diff --check -- . ':!dist'`

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
