### PR TITLE
[ai-assisted] feat(ai): 외부 URL RAG 참고자료 기능 노출 및 사용성 개선

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 2026-07-27
+
+### Changed
+
+- RAG 답변 방식과 별도로 `문서만 사용 | 문서 + 공식 외부 자료` 검색 자료 범위를 선택하고,
+  서버 capabilities에 따라 사용할 수 없는 외부 자료 모드를 안내한다. 범위 변경 시 이전 대화와
+  근거가 섞이지 않도록 새 대화를 시작하며 공식 외부 근거는 발행기관·기준일·검증된 HTTPS 링크를 표시한다.
+- RAG canonical 답변을 제목·문단·목록·인용문·코드·수식 구조가 구분되는 안전한 Markdown으로
+  표시한다. 원문 HTML은 실행하지 않으며 검증 완료된 근거 번호만 기존 근거 상세 동작에 연결한다.
+- RAG 응답의 `ANSWERED | EVIDENCE_ONLY | ABSTAINED` outcome을 공통 view model로 해석하고 검색 실패,
+  packing 실패, 인용 실패를 구분해 표시한다.
+- 검증 실패 시 inline citation 대신 “검색된 근거 후보”와 500자 이하 `exactText`를 표시하며 검색
+  score는 백분율 관련도가 아닌 raw 값으로 표시한다.
+- RAG SSE는 `complete.canonicalContent` 수신 전 답변 본문과 citation을 표시하지 않는다.
+- 첨부 상세 Q&A의 고정 `minScore=0.35`와 일반 사용자 요청의 `debug=true`를 제거해 서버 검색
+  기본값과 공개 응답 계약을 사용한다.
+- `FACTUAL_LIST` 부분 답변의 `partial`과 제외 항목 수를 표시하면서 검증된 canonical 인용 링크는
+  정상적으로 활성화한다.
+
+### Verification
+
+- `npm test` 통과
+- `npm run typecheck` 통과
+- `npm run build` 통과
+
 ## 2026-07-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,8 @@
             },
             "devDependencies": {
                 "@eslint/js": "^10.0.1",
+                "@testing-library/jest-dom": "^7.0.0",
+                "@testing-library/react": "^16.3.2",
                 "@tsconfig/node22": "^22.0.5",
                 "@types/chance": "1.1.8",
                 "@types/node": "^25.9.5",
@@ -81,12 +83,72 @@
                 "@types/react-dom": "^19.2.3",
                 "eslint": "^10.7.0",
                 "globals": "^17.7.0",
+                "jsdom": "^29.1.1",
                 "prettier": "3.9.6",
                 "sass": "1.101.3",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.65.0",
-                "vite": "^8.1.5"
+                "vite": "^8.1.5",
+                "vitest": "^4.1.10"
             }
+        },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+            "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.2.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
@@ -247,6 +309,19 @@
                 "@types/react": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
             }
         },
         "node_modules/@codemirror/autocomplete": {
@@ -420,6 +495,146 @@
                 "crelt": "^1.0.6",
                 "style-mod": "^4.1.0",
                 "w3c-keyname": "^2.2.4"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+            "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+            "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+            "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.1.0",
+                "@csstools/css-calc": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+            "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@emnapi/core": {
@@ -721,6 +936,24 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+            "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@floating-ui/core": {
@@ -2007,6 +2240,13 @@
             "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "license": "MIT"
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@standard-schema/utils": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -2043,6 +2283,85 @@
             },
             "peerDependencies": {
                 "react": "^18 || ^19"
+            }
+        },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+            "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@adobe/css-tools": "^4.4.0",
+                "aria-query": "^5.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.6.3",
+                "picocolors": "^1.1.1",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=22",
+                "npm": ">=6",
+                "yarn": ">=1"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=10 <11"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+            "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@testing-library/react": {
+            "version": "16.3.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+            "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@tiptap/core": {
@@ -2622,6 +2941,25 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
         "node_modules/@types/chance": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/@types/chance/-/chance-1.1.8.tgz",
@@ -2637,6 +2975,13 @@
             "dependencies": {
                 "@types/ms": "*"
             }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
@@ -3298,6 +3643,126 @@
                 }
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3386,11 +3851,56 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/apexcharts": {
             "version": "5.16.0",
             "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.16.0.tgz",
             "integrity": "sha512-ULO3Gqrm0/26uwBcYz49u181uIp8Fy6BQQgg9QUDajs+JAs/EbXxiAmdc6BLy1JY29/JXroM7P0j0t2JPDApdg==",
             "license": "SEE LICENSE IN LICENSE"
+        },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -3445,17 +3955,27 @@
                 "node": "18 || 20 || >=22"
             }
         },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
+            }
+        },
         "node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -3501,6 +4021,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/character-entities": {
@@ -3691,6 +4221,27 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/csstype": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3708,6 +4259,30 @@
             },
             "engines": {
                 "node": ">=0.12"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/dayjs": {
@@ -3732,6 +4307,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/decode-named-character-reference": {
             "version": "1.3.0",
@@ -3797,6 +4379,14 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/dom-helpers": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -3828,6 +4418,19 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/epubjs": {
@@ -3871,6 +4474,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -4147,6 +4757,16 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4193,6 +4813,16 @@
             "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
             "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
             "license": "MIT"
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/ext": {
             "version": "1.7.0",
@@ -4366,9 +4996,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+            "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -4393,16 +5023,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -4565,9 +5195,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -4783,6 +5413,19 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "license": "MIT"
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/html-url-attributes": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4829,9 +5472,9 @@
             "license": "MIT"
         },
         "node_modules/immutable": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -4859,6 +5502,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/inherits": {
@@ -4995,6 +5648,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -5013,6 +5673,70 @@
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "29.1.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+            "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.1.11",
+                "@asamuzakjp/dom-selector": "^7.1.1",
+                "@bramus/specificity": "^2.4.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+                "@exodus/bytes": "^1.15.0",
+                "css-tree": "^3.2.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.3.5",
+                "parse5": "^8.0.1",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.1",
+                "undici": "^7.25.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.1",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/jsdom/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
@@ -5413,9 +6137,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/longest-streak": {
@@ -5453,6 +6177,37 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/marks-pane": {
@@ -5641,6 +6396,13 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/micromark": {
             "version": "4.0.2",
@@ -6163,6 +6925,16 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/minimatch": {
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -6236,6 +7008,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/obug": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/optionator": {
@@ -6465,6 +7251,13 @@
             "integrity": "sha512-AmeDxedoo5svf7aB3FYqSAKqMxys014lVKBzy1o/5vv9CtU7U4wgGWL1dA2o6MOzcD53ScN4Jmiq6VbtLz1vIQ==",
             "license": "MIT"
         },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6472,9 +7265,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -6553,6 +7346,30 @@
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
+        },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
@@ -6916,6 +7733,20 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/rehype-katex": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
@@ -7012,6 +7843,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/requires-port": {
@@ -7144,6 +7985,19 @@
                 "@parcel/watcher": "^2.4.1"
             }
         },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
         "node_modules/scheduler": {
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7204,6 +8058,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/sockjs-client": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
@@ -7251,6 +8112,20 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/stream-browserify": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -7288,6 +8163,19 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "min-indent": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/style-mod": {
@@ -7332,11 +8220,35 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tiny-case": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
             "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
             "license": "MIT"
+        },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
@@ -7383,6 +8295,36 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tldts": {
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+            "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.4.9"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+            "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7401,6 +8343,32 @@
             "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
             "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
             "license": "MIT"
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+            "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
         },
         "node_modules/trim-lines": {
             "version": "3.0.1",
@@ -7497,6 +8465,16 @@
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/undici": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
@@ -7786,11 +8764,127 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/w3c-keyname": {
             "version": "2.2.8",
             "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
             "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
             "license": "MIT"
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/web-namespaces": {
             "version": "2.0.1",
@@ -7802,10 +8896,20 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/websocket-driver": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+            "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "http-parser-js": ">=0.5.1",
@@ -7835,6 +8939,21 @@
                 "node": ">=12"
             }
         },
+        "node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7849,6 +8968,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wildcard": {
@@ -7868,9 +9004,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -7888,6 +9024,23 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/xmldom": {
             "version": "0.1.31",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "dev": "vite --host --port 3000",
         "build": "tsc --noEmit && vite build",
         "preview": "vite preview --port 5050",
+        "test": "vitest run",
         "typecheck": "tsc --noEmit",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix"
@@ -77,6 +78,8 @@
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
         "@tsconfig/node22": "^22.0.5",
         "@types/chance": "1.1.8",
         "@types/node": "^25.9.5",
@@ -84,10 +87,12 @@
         "@types/react-dom": "^19.2.3",
         "eslint": "^10.7.0",
         "globals": "^17.7.0",
+        "jsdom": "^29.1.1",
         "prettier": "3.9.6",
         "sass": "1.101.3",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.65.0",
-        "vite": "^8.1.5"
+        "vite": "^8.1.5",
+        "vitest": "^4.1.10"
     }
 }

--- a/src/react/pages/ai/RagChatPage.tsx
+++ b/src/react/pages/ai/RagChatPage.tsx
@@ -24,6 +24,9 @@ import { ChatComposer } from "@/react/pages/ai/components/ChatComposer";
 import { ChatMessageList } from "@/react/pages/ai/components/ChatMessageList";
 import { AiProviderSelect } from "@/react/components/ai/AiProviderSelect";
 import { RagAnswerModeSelector } from "@/react/pages/ai/components/RagAnswerModeSelector";
+import { RagSourceScopeSelector } from "@/react/pages/ai/components/RagSourceScopeSelector";
+import { RagEvidenceSourceDrawer } from "@/react/pages/ai/components/RagEvidenceSourceDrawer";
+import { reactWorkspaceApi } from "@/react/pages/workspaces/api";
 import type { ChatMessage } from "@/react/pages/ai/components/chatTypes";
 import type {
   AiInfoResponse,
@@ -33,8 +36,13 @@ import type {
   ProviderInfo,
   RagAnswerMode,
   RagAnswerPolicyCapabilitiesDto,
+  RagSourcePolicyCapabilitiesDto,
+  RagSourceScope,
   TokenUsageDto,
+  IndexedWebCapabilitiesDto,
+  IndexedWebSourceRefDto,
 } from "@/types/studio/ai";
+import type { WorkspaceRef } from "@/types/studio/workspace";
 import { resolveAxiosError } from "@/utils/helpers";
 
 const RAG_CHAT_INPUT_HISTORY_KEY = "ai_rag_chat_input_history";
@@ -78,6 +86,16 @@ export function RagChatPage() {
   const [systemPrompt, setSystemPrompt] = useState("");
   const [answerPolicy, setAnswerPolicy] = useState<RagAnswerPolicyCapabilitiesDto | null>(null);
   const [answerMode, setAnswerMode] = useState<RagAnswerMode | null>(null);
+  const [sourcePolicy, setSourcePolicy] = useState<RagSourcePolicyCapabilitiesDto | null>(null);
+  const [sourceScope, setSourceScope] = useState<RagSourceScope | null>(null);
+  const [indexedWebCapabilities, setIndexedWebCapabilities] =
+    useState<IndexedWebCapabilitiesDto | null>(null);
+  const [indexedWebCapabilitiesLoading, setIndexedWebCapabilitiesLoading] = useState(true);
+  const [indexedWebCapabilitiesError, setIndexedWebCapabilitiesError] = useState<string | null>(null);
+  const [indexedWebSources, setIndexedWebSources] = useState<IndexedWebSourceRefDto[]>([]);
+  const [evidenceDrawerOpen, setEvidenceDrawerOpen] = useState(false);
+  const [workspaces, setWorkspaces] = useState<WorkspaceRef[]>([]);
+  const [workspaceId, setWorkspaceId] = useState<number | null>(null);
   const [memoryEnabled, setMemoryEnabled] = useState(false);
   const [conversationId, setConversationId] = useState<string>(() => crypto.randomUUID());
   const [input, setInput] = useState("");
@@ -88,8 +106,8 @@ export function RagChatPage() {
   const [error, setError] = useState<string | null>(null);
   const [streamStatus, setStreamStatus] = useState<string | null>(null);
   const [topK, setTopK] = useState("5"); // changed default topK to 5
-  const [minScore, setMinScore] = useState("0.35");
-  const [debug, setDebug] = useState(true); // changed default debug to true for leg visualization
+  const [minScore, setMinScore] = useState("");
+  const [debug, setDebug] = useState(false);
   const [retrievalStrategy, setRetrievalStrategy] = useState("hybrid");
   const [structureTopK, setStructureTopK] = useState("5");
   const [ideaBlockTopK, setIdeaBlockTopK] = useState("5");
@@ -144,13 +162,36 @@ export function RagChatPage() {
         // ignore
       });
 
+    setIndexedWebCapabilitiesLoading(true);
     reactAiApi
-      .fetchRagAnswerPolicy()
-      .then((policy) => {
-        setAnswerPolicy(policy);
-        setAnswerMode(policy.defaultMode);
+      .fetchRagCapabilities()
+      .then((capabilities) => {
+        setAnswerPolicy(capabilities.answerPolicy);
+        setAnswerMode(capabilities.answerPolicy.defaultMode);
+        setSourcePolicy(capabilities.sourcePolicy);
+        setSourceScope(capabilities.sourcePolicy.defaultScope);
+        setIndexedWebCapabilities(capabilities.indexedWeb);
+        setIndexedWebCapabilitiesError(null);
       })
-      .catch((loadError) => setError(resolveAxiosError(loadError)));
+      .catch((loadError) => {
+        const message = resolveAxiosError(loadError);
+        setError(message);
+        setIndexedWebCapabilitiesError(message);
+      })
+      .finally(() => {
+        setIndexedWebCapabilitiesLoading(false);
+      });
+
+    reactWorkspaceApi
+      .list({ archived: false, page: 0, size: 100, sort: "name,asc" })
+      .then((response) => {
+        const items = response.content ?? [];
+        setWorkspaces(items);
+        setWorkspaceId((current) => current ?? items[0]?.id ?? null);
+      })
+      .catch(() => {
+        // URL 자료 기능만 비활성화하고 기존 RAG 채팅은 유지합니다.
+      });
   }, []);
 
   useEffect(() => {
@@ -204,7 +245,11 @@ export function RagChatPage() {
     setInput("");
     setSending(true);
     setError(null);
-    setStreamStatus("문서 근거를 검색하고 있습니다.");
+    setStreamStatus(
+      sourceScope === "DOCUMENT_AND_OFFICIAL_EXTERNAL"
+        ? "문서와 공식 외부 자료를 검색하고 있습니다."
+        : "문서 근거를 검색하고 있습니다."
+    );
     setInput("");
 
     try {
@@ -226,12 +271,14 @@ export function RagChatPage() {
           structureTopK: numberOrUndefined(structureTopK) ?? 5,
           ideaBlockTopK: numberOrUndefined(ideaBlockTopK) ?? 5,
           finalTopK: numberOrUndefined(finalTopK) ?? 5,
-          minScore: numericMinScore ?? 0.35,
+          minScore: numericMinScore,
           dedupe,
           includeDebugChunks,
         },
         debug,
         answerMode: answerMode ?? undefined,
+        sourceScope: sourceScope ?? undefined,
+        indexedWebSources: indexedWebSources.length > 0 ? indexedWebSources : undefined,
       };
       if (selectedOption) {
         if (selectedOption.deploymentId) {
@@ -249,20 +296,21 @@ export function RagChatPage() {
           if (streamPayload.stage === "retrieval_complete") {
             const count = streamPayload.resultCount ?? 0;
             setStreamStatus(`근거 ${count}건 검색 완료 · 답변을 생성하고 있습니다.`);
+          } else if (streamPayload.stage === "generation_started") {
+            setStreamStatus("근거를 바탕으로 답변을 생성하고 검증하고 있습니다.");
+          } else if (streamPayload.stage === "external_search") {
+            setStreamStatus("공식 외부 자료를 검색하고 출처를 확인하고 있습니다.");
           } else {
-            setStreamStatus("문서 근거를 검색하고 있습니다.");
+            setStreamStatus(
+              sourceScope === "DOCUMENT_AND_OFFICIAL_EXTERNAL"
+                ? "문서와 공식 외부 자료를 검색하고 있습니다."
+                : "문서 근거를 검색하고 있습니다."
+            );
           }
         },
-        onDelta: (streamPayload) => {
+        onDelta: () => {
           if (activeRequestIdRef.current !== requestId) return;
-          setStreamStatus(null);
-          setMessages((current) =>
-            current.map((message) =>
-              message.id === assistantMessageId
-                ? { ...message, content: `${message.content}${streamPayload.delta ?? streamPayload.content ?? ""}` }
-                : message
-            )
-          );
+          setStreamStatus("답변을 검증하고 있습니다.");
         },
         onUsage: (streamPayload) => {
           if (activeRequestIdRef.current !== requestId) return;
@@ -364,6 +412,20 @@ export function RagChatPage() {
     if (nextMode === answerMode) return;
     handleNewConversation();
     setAnswerMode(nextMode);
+  }
+
+  function handleSourceScopeChange(nextScope: RagSourceScope) {
+    if (nextScope === sourceScope) return;
+    handleNewConversation();
+    setSourceScope(nextScope);
+  }
+
+  function handleIndexedWebSourcesChange(nextSources: IndexedWebSourceRefDto[]) {
+    const current = JSON.stringify(indexedWebSources);
+    const next = JSON.stringify(nextSources);
+    if (current === next) return;
+    handleNewConversation();
+    setIndexedWebSources(nextSources);
   }
 
   async function handleCopyMessage(content: string) {
@@ -497,6 +559,12 @@ export function RagChatPage() {
               value={answerMode}
               disabled={sending}
               onChange={handleAnswerModeChange}
+            />
+            <RagSourceScopeSelector
+              capabilities={sourcePolicy}
+              value={sourceScope}
+              disabled={sending}
+              onChange={handleSourceScopeChange}
             />
             <TextField
               select
@@ -652,6 +720,57 @@ export function RagChatPage() {
             latencyMs={lastAssistantMessage?.metadata?.latencyMs}
             tokenUsage={lastAssistantMessage?.metadata?.tokenUsage}
             inputHistory={inputHistory}
+            selectedWebSourcesCount={indexedWebSources.length}
+            onOpenEvidenceDrawer={() => setEvidenceDrawerOpen(true)}
+            controls={
+              <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap>
+                <RagAnswerModeSelector
+                  capabilities={answerPolicy}
+                  value={answerMode}
+                  disabled={sending}
+                  hideHelperText
+                  variant="compact-pill"
+                  onChange={(mode) => {
+                    if (mode === answerMode) return;
+                    setAnswerMode(mode);
+                    setError(null);
+                  }}
+                />
+                <RagSourceScopeSelector
+                  capabilities={sourcePolicy}
+                  value={sourceScope}
+                  disabled={sending}
+                  hideHelperText
+                  variant="compact-pill"
+                  onChange={(scope) => {
+                    if (scope === sourceScope) return;
+                    setSourceScope(scope);
+                    setError(null);
+                  }}
+                />
+                {selectedOption ? (
+                  <Tooltip title="이 대화에 사용되는 RAG 임베딩 모델입니다">
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        px: 1,
+                        py: 0.3,
+                        borderRadius: "16px",
+                        fontSize: 12,
+                        fontWeight: 500,
+                        color: "text.secondary",
+                        bgcolor: (theme) =>
+                          theme.palette.mode === "dark" ? "rgba(255, 255, 255, 0.06)" : "rgba(0, 0, 0, 0.04)",
+                      }}
+                    >
+                      (임베딩 : {selectedOption.displayName || selectedOption.model})
+                    </Typography>
+                  </Tooltip>
+                ) : null}
+              </Stack>
+            }
             onInputChange={setInput}
             onSubmit={() => void handleSend()}
             onKeyDown={(event) => {
@@ -692,6 +811,26 @@ export function RagChatPage() {
           />
         </Paper>
       </Stack>
+
+      <RagEvidenceSourceDrawer
+        open={evidenceDrawerOpen}
+        onClose={() => setEvidenceDrawerOpen(false)}
+        workspaceId={workspaceId}
+        workspaces={workspaces}
+        onWorkspaceChange={(nextWorkspaceId) => {
+          handleNewConversation();
+          setWorkspaceId(nextWorkspaceId);
+          setIndexedWebSources([]);
+        }}
+        embeddingDeploymentId={selectedOption?.deploymentId}
+        value={indexedWebSources}
+        maxSelectedSources={indexedWebCapabilities?.maxSelectedSources}
+        capabilities={indexedWebCapabilities}
+        capabilitiesLoading={indexedWebCapabilitiesLoading}
+        capabilitiesError={indexedWebCapabilitiesError}
+        disabled={sending}
+        onChange={handleIndexedWebSourcesChange}
+      />
     </Stack>
   );
 }

--- a/src/react/pages/ai/api.ts
+++ b/src/react/pages/ai/api.ts
@@ -41,6 +41,7 @@ import type {
   RegenerateRequestDto,
   RagRegenerateRequestDto,
   RagAnswerPolicyCapabilitiesDto,
+  RagChatCapabilitiesDto,
   RagStreamStatusEventDto,
   VectorItemDetail,
   VectorProjection,
@@ -56,6 +57,8 @@ import type {
   VectorSearchVisualizationResponseDto,
   VectorProjectionEstimateRequest,
   VectorProjectionEstimateResponse,
+  WebKnowledgeSourceCreateRequest,
+  WebKnowledgeSourceDto,
 } from "@/types/studio/ai";
 
 const BASE = "/api/ai";
@@ -187,6 +190,50 @@ export const reactAiApi = {
 
   fetchRagAnswerPolicy() {
     return apiRequest<RagAnswerPolicyCapabilitiesDto>("get", `${BASE}/chat/rag/answer-policy`);
+  },
+
+  fetchRagCapabilities() {
+    return apiRequest<RagChatCapabilitiesDto>("get", `${BASE}/chat/rag/capabilities`);
+  },
+
+  listWebKnowledgeSources(workspaceId: number, embeddingDeploymentId?: string) {
+    return apiRequest<WebKnowledgeSourceDto[]>(
+      "get",
+      `/api/workspaces/${workspaceId}/ai/rag/web-sources`,
+      { params: { embeddingDeploymentId } }
+    );
+  },
+
+  createWebKnowledgeSource(
+    workspaceId: number,
+    payload: WebKnowledgeSourceCreateRequest
+  ) {
+    return apiRequest<WebKnowledgeSourceDto, WebKnowledgeSourceCreateRequest>(
+      "post",
+      `/api/workspaces/${workspaceId}/ai/rag/web-sources`,
+      { data: payload }
+    );
+  },
+
+  refreshWebKnowledgeSource(workspaceId: number, sourceId: string) {
+    return apiRequest<WebKnowledgeSourceDto>(
+      "post",
+      `/api/workspaces/${workspaceId}/ai/rag/web-sources/${encodeURIComponent(sourceId)}/refresh`
+    );
+  },
+
+  cancelWebKnowledgeSource(workspaceId: number, sourceId: string) {
+    return apiRequest<WebKnowledgeSourceDto>(
+      "post",
+      `/api/workspaces/${workspaceId}/ai/rag/web-sources/${encodeURIComponent(sourceId)}/cancel`
+    );
+  },
+
+  archiveWebKnowledgeSource(workspaceId: number, sourceId: string) {
+    return apiRequest<void>(
+      "delete",
+      `/api/workspaces/${workspaceId}/ai/rag/web-sources/${encodeURIComponent(sourceId)}`
+    );
   },
 
   fetchProviders() {

--- a/src/react/pages/ai/components/AssistantMessageBubble.tsx
+++ b/src/react/pages/ai/components/AssistantMessageBubble.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { alpha, Avatar, Box, Chip, Divider, IconButton, Paper, Popover, Stack, Tooltip, Typography } from "@mui/material";
-import { CloseOutlined, ContentCopyOutlined, DescriptionOutlined, RefreshOutlined, SyncOutlined } from "@mui/icons-material";
+import { CloseOutlined, ContentCopyOutlined, DescriptionOutlined, OpenInNewOutlined, PublicOutlined, RefreshOutlined, SyncOutlined } from "@mui/icons-material";
 import type { ChatMessage, ChatResponseMetadataDto } from "@/react/pages/ai/components/chatTypes";
 import type { RagReferenceDto } from "@/types/studio/ai";
 import { deriveRagOutcome } from "@/react/pages/ai/components/ragOutcome";
@@ -20,6 +20,11 @@ interface NormalizedRagReference {
   score?: number;
   content?: string;
   supportStatus?: string;
+  origin?: "DOCUMENT" | "INDEXED_WEB" | "OFFICIAL_EXTERNAL";
+  sourceType?: string;
+  publisher?: string;
+  canonicalUrl?: string;
+  sourceDate?: string;
   raw?: RagReferenceDto;
 }
 
@@ -218,6 +223,14 @@ function normalizeReference(reference: RagReferenceDto, fallbackIndex: number): 
     score: reference.score,
     content,
     supportStatus: reference.supportStatus,
+    origin: reference.origin,
+    sourceType: reference.sourceType,
+    publisher: reference.publisher,
+    canonicalUrl:
+      typeof reference.canonicalUrl === "string" && reference.canonicalUrl.startsWith("https://")
+        ? reference.canonicalUrl
+        : undefined,
+    sourceDate: reference.effectiveDate ?? reference.publishedDate ?? reference.retrievedAt,
     raw: reference,
   };
 }
@@ -237,6 +250,19 @@ function formatReferenceTitle(reference: NormalizedRagReference) {
 
 function formatReferenceSummary(reference: NormalizedRagReference) {
   return (reference.content ?? "").replace(/\s+/g, " ").trim();
+}
+
+function isWebReference(reference: NormalizedRagReference) {
+  return reference.origin === "INDEXED_WEB" || reference.origin === "OFFICIAL_EXTERNAL";
+}
+
+function referenceOriginLabel(reference: NormalizedRagReference) {
+  if (reference.origin === "INDEXED_WEB") return "수집한 웹";
+  if (reference.origin !== "OFFICIAL_EXTERNAL") return "문서";
+  if (reference.sourceType === "STATUTE") return "법령";
+  if (reference.sourceType === "CASE") return "판례";
+  if (reference.sourceType === "ACADEMIC") return "논문";
+  return "공식 외부 자료";
 }
 
 function renderTokenUsage(metadata?: ChatResponseMetadataDto) {
@@ -332,6 +358,7 @@ export function AssistantMessageBubble({
     message.metadata?.finishReason === "error" || message.content.startsWith("오류:");
   const ragReferences = getRagReferences(message.metadata);
   const answerPolicy = message.metadata?.answerPolicy;
+  const sourcePolicy = message.metadata?.sourcePolicy;
   const outcomeView = deriveRagOutcome(message.metadata, sending);
   const citationsReady = outcomeView.citationsReady;
   const referencesVisible =
@@ -399,6 +426,27 @@ export function AssistantMessageBubble({
                   answerPolicy.effectiveMode === "STRICT_GROUNDED"
                     ? "문서 직접 근거"
                     : "문서 기반 해석"
+                }
+                sx={{ height: 18, fontSize: 10, fontWeight: 600 }}
+              />
+            </Tooltip>
+          ) : null}
+          {sourcePolicy?.effectiveScope ? (
+            <Tooltip
+              title={
+                sourcePolicy.clamped
+                  ? `요청한 자료 범위가 서버 정책에 의해 조정되었습니다. (${sourcePolicy.reasonCode})`
+                  : "서버가 실제 적용한 참고 자료 범위입니다."
+              }
+            >
+              <Chip
+                size="small"
+                variant="outlined"
+                icon={<PublicOutlined sx={{ fontSize: 13 }} />}
+                label={
+                  sourcePolicy.effectiveScope === "DOCUMENT_AND_OFFICIAL_EXTERNAL"
+                    ? "공식 외부 자료 참고"
+                    : "첨부 문서만"
                 }
                 sx={{ height: 18, fontSize: 10, fontWeight: 600 }}
               />
@@ -560,7 +608,9 @@ export function AssistantMessageBubble({
                           flex: "0 0 auto",
                         }}
                       >
-                        <DescriptionOutlined sx={{ fontSize: 18 }} />
+                        {isWebReference(reference)
+                          ? <PublicOutlined sx={{ fontSize: 18 }} />
+                          : <DescriptionOutlined sx={{ fontSize: 18 }} />}
                       </Box>
                       <Stack spacing={0.75} sx={{ minWidth: 0, flex: 1 }}>
                         <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
@@ -581,10 +631,23 @@ export function AssistantMessageBubble({
                               sx={{ height: 18, fontSize: 10 }}
                             />
                           ) : null}
+                          <Chip
+                            size="small"
+                            variant="outlined"
+                            label={referenceOriginLabel(reference)}
+                            sx={{ height: 18, fontSize: 10 }}
+                          />
                         </Stack>
                         <Typography variant="body2" sx={{ fontWeight: 700, color: "text.primary", fontSize: 13.5, overflowWrap: "anywhere", lineHeight: 1.5 }}>
                           {formatReferenceTitle(reference)}
                         </Typography>
+                        {isWebReference(reference) && (reference.publisher || reference.sourceDate) ? (
+                          <Typography variant="caption" color="text.secondary">
+                            {[reference.publisher, reference.sourceDate ? `기준 ${reference.sourceDate.slice(0, 10)}` : null]
+                              .filter(Boolean)
+                              .join(" · ")}
+                          </Typography>
+                        ) : null}
                         {(() => {
                           const summary = formatReferenceSummary(reference);
                           const fallbackText =
@@ -617,6 +680,28 @@ export function AssistantMessageBubble({
                             </Paper>
                           );
                         })()}
+                        {reference.canonicalUrl ? (
+                          <Box
+                            component="a"
+                            href={reference.canonicalUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            sx={{
+                              display: "inline-flex",
+                              alignItems: "center",
+                              gap: 0.5,
+                              color: "primary.main",
+                              fontSize: 12,
+                              fontWeight: 700,
+                              textDecoration: "none",
+                              width: "fit-content",
+                              "&:hover": { textDecoration: "underline" },
+                            }}
+                          >
+                            공식 원문 열기
+                            <OpenInNewOutlined sx={{ fontSize: 14 }} />
+                          </Box>
+                        ) : null}
 
                         {/* IdeaBlock 특정 필드 노출 */}
                         {(() => {

--- a/src/react/pages/ai/components/ChatComposer.tsx
+++ b/src/react/pages/ai/components/ChatComposer.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ArrowUpwardOutlined, CheckOutlined, ExpandMoreOutlined, HistoryOutlined } from "@mui/icons-material";
+import { AddOutlined, ArrowUpwardOutlined, CheckOutlined, ExpandMoreOutlined, HistoryOutlined, LanguageOutlined } from "@mui/icons-material";
 import { alpha, Box, Button, IconButton, Menu, MenuItem, Popover, Stack, Tooltip, Typography } from "@mui/material";
 import type { ProviderInfo } from "@/types/studio/ai";
 
@@ -29,6 +29,8 @@ interface Props {
     totalTokens?: number;
   };
   inputHistory: string[];
+  selectedWebSourcesCount?: number;
+  onOpenEvidenceDrawer?: () => void;
   onInputChange: (value: string) => void;
   onSubmit: () => void;
   onKeyDown: (event: React.KeyboardEvent) => void;
@@ -57,6 +59,8 @@ export function ChatComposer({
   latencyMs,
   tokenUsage,
   inputHistory,
+  selectedWebSourcesCount = 0,
+  onOpenEvidenceDrawer,
   onInputChange,
   onSubmit,
   onKeyDown,
@@ -73,7 +77,9 @@ export function ChatComposer({
   settingsMenuDescription = "provider와 model을 직접 설정합니다.",
 }: Props) {
   const [historyAnchorEl, setHistoryAnchorEl] = useState<HTMLElement | null>(null);
+  const [contextAnchorEl, setContextAnchorEl] = useState<HTMLElement | null>(null);
   const historyMenuOpen = Boolean(historyAnchorEl);
+  const contextMenuOpen = Boolean(contextAnchorEl);
 
   function handleSelectHistory(value: string) {
     onSelectHistory(value);
@@ -120,15 +126,70 @@ export function ChatComposer({
               lineHeight: 1.55,
             }}
           />
-          {controls ? <Box>{controls}</Box> : null}
-          <Stack direction="row" spacing={0.75} alignItems="center">
+          <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap>
+            {onOpenEvidenceDrawer ? (
+              <Tooltip title="자료 추가 (+)">
+                <IconButton
+                  size="small"
+                  onClick={(event) => setContextAnchorEl(event.currentTarget)}
+                  sx={{
+                    width: 30,
+                    height: 30,
+                    borderRadius: "50%",
+                    bgcolor: (theme) =>
+                      theme.palette.mode === "dark"
+                        ? "rgba(255, 255, 255, 0.12)"
+                        : "rgba(0, 0, 0, 0.08)",
+                    color: "text.primary",
+                    "&:hover": {
+                      bgcolor: (theme) =>
+                        theme.palette.mode === "dark"
+                          ? "rgba(255, 255, 255, 0.2)"
+                          : "rgba(0, 0, 0, 0.14)",
+                    },
+                  }}
+                >
+                  <AddOutlined fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            ) : null}
+            <Tooltip title="모델 선택">
+              <Button
+                size="small"
+                variant="text"
+                endIcon={<ExpandMoreOutlined fontSize="small" />}
+                onClick={onOpenModelMenu}
+                sx={{
+                  color: "text.primary",
+                  px: 1.25,
+                  py: 0.3,
+                  borderRadius: "16px",
+                  fontSize: 12.5,
+                  fontWeight: 500,
+                  textTransform: "none",
+                  bgcolor: (theme) =>
+                    theme.palette.mode === "dark"
+                      ? "rgba(255, 255, 255, 0.06)"
+                      : "rgba(0, 0, 0, 0.04)",
+                  "&:hover": {
+                    bgcolor: (theme) =>
+                      theme.palette.mode === "dark"
+                        ? "rgba(255, 255, 255, 0.1)"
+                        : "rgba(0, 0, 0, 0.08)",
+                  },
+                }}
+              >
+                {model || "모델 설정"}
+              </Button>
+            </Tooltip>
+            {controls ? <Box sx={{ display: "inline-flex", alignItems: "center" }}>{controls}</Box> : null}
             <Tooltip title="최근 질문">
               <span>
                 <IconButton
                   size="small"
                   onClick={(event) => setHistoryAnchorEl(event.currentTarget)}
                   disabled={inputHistory.length === 0}
-                  sx={{ width: 32, height: 32 }}
+                  sx={{ width: 30, height: 30 }}
                 >
                   <HistoryOutlined fontSize="small" />
                 </IconButton>
@@ -164,11 +225,6 @@ export function ChatComposer({
                 ) : null}
               </Stack>
             </Box>
-              <Tooltip title="모델 선택">
-                <Button size="small" variant="text" endIcon={<ExpandMoreOutlined fontSize="small" />} onClick={onOpenModelMenu} sx={{ color: "text.primary", px: 1, minWidth: 0 }}>
-                  {model || "모델 설정"}
-                </Button>
-              </Tooltip>
               <Tooltip title="보내기">
                 <span>
                   <IconButton
@@ -242,6 +298,35 @@ export function ChatComposer({
             <ExpandMoreOutlined fontSize="small" sx={{ transform: "rotate(-90deg)" }} />
           </Button>
         </Stack>
+      </Popover>
+
+      <Popover
+        open={contextMenuOpen}
+        anchorEl={contextAnchorEl}
+        onClose={() => setContextAnchorEl(null)}
+        anchorOrigin={{ vertical: "top", horizontal: "left" }}
+        transformOrigin={{ vertical: "bottom", horizontal: "left" }}
+        PaperProps={{ sx: { width: 280, borderRadius: 2.5, p: 0.75, mb: 1 } }}
+      >
+        <MenuItem
+          onClick={() => {
+            setContextAnchorEl(null);
+            onOpenEvidenceDrawer?.();
+          }}
+          sx={{ borderRadius: 1.5, gap: 1.5, py: 1.2 }}
+        >
+          <LanguageOutlined fontSize="small" color="primary" />
+          <Box>
+            <Typography variant="body2" sx={{ fontWeight: 700 }}>
+              웹 참고자료 (URL 수집·선택)
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+              {selectedWebSourcesCount > 0
+                ? `${selectedWebSourcesCount}개 웹 자료 선택됨`
+                : "공개 HTTPS URL 수집 및 색인 자료 선택"}
+            </Typography>
+          </Box>
+        </MenuItem>
       </Popover>
     </Box>
   );

--- a/src/react/pages/ai/components/RagAnswerModeSelector.test.tsx
+++ b/src/react/pages/ai/components/RagAnswerModeSelector.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RagAnswerModeSelector } from "./RagAnswerModeSelector";
+
+describe("RagAnswerModeSelector", () => {
+  it("explains that answer mode does not change retrieval or indexing", () => {
+    render(
+      <RagAnswerModeSelector
+        capabilities={{
+          defaultMode: "GROUNDED_INFERENCE",
+          maximumMode: "GROUNDED_INFERENCE",
+          clientSelectionEnabled: true,
+          policyVersion: "test",
+          availableModes: ["STRICT_GROUNDED", "GROUNDED_INFERENCE"],
+        }}
+        value="GROUNDED_INFERENCE"
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(/답변 모드는 검색 결과나 색인을 변경하지 않습니다/)
+    ).toBeTruthy();
+  });
+});

--- a/src/react/pages/ai/components/RagAnswerModeSelector.tsx
+++ b/src/react/pages/ai/components/RagAnswerModeSelector.tsx
@@ -149,7 +149,7 @@ export function RagAnswerModeSelector({
         </Alert>
       ) : !hideHelperText ? (
         <Typography variant="caption" color="text.secondary" noWrap sx={{ display: "block" }}>
-          답변 모드는 검색 결과나 색인을 변경하지 않으며, 변경 이후 질문부터 적용됩니다.
+        답변 모드는 검색 결과나 색인을 변경하지 않습니다. 변경 이후 질문부터 적용됩니다.
         </Typography>
       ) : null}
     </Stack>

--- a/src/react/pages/ai/components/RagEvidenceSourceDrawer.test.tsx
+++ b/src/react/pages/ai/components/RagEvidenceSourceDrawer.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { RagEvidenceSourceDrawer } from "./RagEvidenceSourceDrawer";
+import type { WorkspaceRef } from "@/types/studio/workspace";
+
+vi.mock("@/react/pages/ai/api", () => ({
+  reactAiApi: {
+    listWebKnowledgeSources: vi.fn().mockResolvedValue([]),
+    createWebKnowledgeSource: vi.fn(),
+    refreshWebKnowledgeSource: vi.fn(),
+    cancelWebKnowledgeSource: vi.fn(),
+    archiveWebKnowledgeSource: vi.fn(),
+  },
+}));
+
+describe("RagEvidenceSourceDrawer", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders drawer header", () => {
+    render(
+      <RagEvidenceSourceDrawer
+        open={true}
+        onClose={vi.fn()}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("참고자료 관리")).toBeDefined();
+  });
+
+  it("displays status notices for capability loading, disabled, missing workspace", () => {
+    render(
+      <RagEvidenceSourceDrawer
+        open={true}
+        onClose={vi.fn()}
+        capabilitiesLoading={true}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText("URL 자료 기능을 확인하고 있습니다")).toBeDefined();
+    cleanup();
+
+    render(
+      <RagEvidenceSourceDrawer
+        open={true}
+        onClose={vi.fn()}
+        capabilitiesError="Network Error"
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText("URL 자료 기능 상태를 확인하지 못했습니다: Network Error")).toBeDefined();
+    cleanup();
+
+    render(
+      <RagEvidenceSourceDrawer
+        open={true}
+        onClose={vi.fn()}
+        capabilities={{ enabled: false, maxSelectedSources: 10, supportedSchemes: ["https"], maxUrlLength: 2048 }}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText("서버에서 URL 수집 기능이 비활성화되어 있습니다")).toBeDefined();
+    cleanup();
+
+    render(
+      <RagEvidenceSourceDrawer
+        open={true}
+        onClose={vi.fn()}
+        capabilities={{ enabled: true, maxSelectedSources: 10, supportedSchemes: ["https"], maxUrlLength: 2048 }}
+        workspaceId={null}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText("자료를 저장할 workspace를 선택하세요")).toBeDefined();
+    cleanup();
+
+    render(
+      <RagEvidenceSourceDrawer
+        open={true}
+        onClose={vi.fn()}
+        capabilities={{ enabled: true, maxSelectedSources: 10, supportedSchemes: ["https"], maxUrlLength: 2048 }}
+        workspaceId={1}
+        embeddingDeploymentId={null}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText("공개 HTTPS URL")).toBeDefined();
+  });
+
+  it("allows selecting workspace if workspaces list is provided", () => {
+    const onWorkspaceChange = vi.fn();
+    const mockWorkspaces: WorkspaceRef[] = [
+      { id: 1, name: "Workspace 1", slug: "ws-1", path: "/ws-1", depth: 0, visibility: "PRIVATE", archived: false },
+      { id: 2, name: "Workspace 2", slug: "ws-2", path: "/ws-2", depth: 0, visibility: "PRIVATE", archived: false },
+    ];
+    render(
+      <RagEvidenceSourceDrawer
+        open={true}
+        onClose={vi.fn()}
+        workspaceId={1}
+        workspaces={mockWorkspaces}
+        onWorkspaceChange={onWorkspaceChange}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+
+    const select = screen.getByLabelText("웹 자료 workspace");
+    expect(select).toBeDefined();
+  });
+});

--- a/src/react/pages/ai/components/RagEvidenceSourceDrawer.tsx
+++ b/src/react/pages/ai/components/RagEvidenceSourceDrawer.tsx
@@ -1,0 +1,137 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  IconButton,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { CloseOutlined } from "@mui/icons-material";
+import type { IndexedWebCapabilitiesDto, IndexedWebSourceRefDto } from "@/types/studio/ai";
+import type { WorkspaceRef } from "@/types/studio/workspace";
+import { RagEvidenceSourcePicker } from "./RagEvidenceSourcePicker";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  workspaceId?: number | null;
+  workspaces?: WorkspaceRef[];
+  onWorkspaceChange?: (workspaceId: number | null) => void;
+  embeddingDeploymentId?: string | null;
+  value: IndexedWebSourceRefDto[];
+  maxSelectedSources?: number;
+  capabilities?: IndexedWebCapabilitiesDto | null;
+  capabilitiesLoading?: boolean;
+  capabilitiesError?: string | null;
+  disabled?: boolean;
+  onChange: (value: IndexedWebSourceRefDto[]) => void;
+};
+
+export function RagEvidenceSourceDrawer({
+  open,
+  onClose,
+  workspaceId,
+  workspaces,
+  onWorkspaceChange,
+  embeddingDeploymentId,
+  value,
+  maxSelectedSources,
+  capabilities,
+  capabilitiesLoading = false,
+  capabilitiesError = null,
+  disabled = false,
+  onChange,
+}: Props) {
+  const isCapabilityDisabled = capabilities && capabilities.enabled === false;
+  const showPicker = Boolean(!isCapabilityDisabled && workspaceId);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "16px",
+          p: 3,
+          maxHeight: "85vh",
+        },
+      }}
+    >
+      <Stack spacing={2.5} sx={{ height: "100%", overflowY: "auto" }}>
+        {/* Header */}
+        <Stack direction="row" alignItems="center" justifyContent="space-between">
+          <Typography variant="h6" sx={{ fontWeight: 800 }}>
+            참고자료 관리
+          </Typography>
+          <IconButton size="small" onClick={onClose} aria-label="닫기">
+            <CloseOutlined fontSize="small" />
+          </IconButton>
+        </Stack>
+
+        {/* Capability / Workspace status alerts */}
+        {capabilitiesLoading ? (
+          <Alert severity="info">URL 자료 기능을 확인하고 있습니다</Alert>
+        ) : null}
+
+        {capabilitiesError ? (
+          <Alert severity="error">
+            URL 자료 기능 상태를 확인하지 못했습니다: {capabilitiesError}
+          </Alert>
+        ) : null}
+
+        {capabilities && !capabilities.enabled ? (
+          <Alert severity="warning">서버에서 URL 수집 기능이 비활성화되어 있습니다</Alert>
+        ) : null}
+
+        {/* Workspace Selector */}
+        {workspaces && workspaces.length > 0 && onWorkspaceChange ? (
+          <TextField
+            select
+            label="웹 자료 workspace"
+            size="small"
+            value={workspaceId ?? ""}
+            onChange={(event) => {
+              const val = event.target.value;
+              onWorkspaceChange(val ? Number(val) : null);
+            }}
+            disabled={disabled}
+            fullWidth
+          >
+            {workspaces.map((workspace) => (
+              <MenuItem key={workspace.id} value={workspace.id}>
+                {workspace.name}
+              </MenuItem>
+            ))}
+          </TextField>
+        ) : null}
+
+        {!workspaceId ? (
+          <Alert severity="info">자료를 저장할 workspace를 선택하세요</Alert>
+        ) : null}
+
+        {/* Picker */}
+        {showPicker ? (
+          <RagEvidenceSourcePicker
+            workspaceId={workspaceId}
+            embeddingDeploymentId={embeddingDeploymentId}
+            value={value}
+            maxSelectedSources={maxSelectedSources ?? capabilities?.maxSelectedSources ?? 10}
+            disabled={disabled}
+            onChange={onChange}
+          />
+        ) : null}
+
+        <Box sx={{ flex: 1 }} />
+
+        <Button variant="outlined" onClick={onClose} fullWidth>
+          닫기
+        </Button>
+      </Stack>
+    </Dialog>
+  );
+}

--- a/src/react/pages/ai/components/RagEvidenceSourcePicker.test.tsx
+++ b/src/react/pages/ai/components/RagEvidenceSourcePicker.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { RagEvidenceSourcePicker } from "./RagEvidenceSourcePicker";
+
+const { listWebKnowledgeSources, createWebKnowledgeSource } = vi.hoisted(() => ({
+  listWebKnowledgeSources: vi.fn(),
+  createWebKnowledgeSource: vi.fn(),
+}));
+
+vi.mock("@/react/pages/ai/api", () => ({
+  reactAiApi: {
+    listWebKnowledgeSources,
+    createWebKnowledgeSource,
+    refreshWebKnowledgeSource: vi.fn(),
+    cancelWebKnowledgeSource: vi.fn(),
+    archiveWebKnowledgeSource: vi.fn(),
+  },
+}));
+
+describe("RagEvidenceSourcePicker", () => {
+  beforeEach(() => {
+    listWebKnowledgeSources.mockReset();
+    createWebKnowledgeSource.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("allows only completed revisions to be selected", async () => {
+    listWebKnowledgeSources.mockResolvedValue([
+      {
+        sourceId: "wsrc-ready",
+        workspaceId: 2,
+        url: "https://example.org/ready",
+        canonicalUrl: "https://example.org/ready",
+        host: "example.org",
+        displayName: "사용 가능 자료",
+        embeddingDeploymentId: "embedding-default",
+        status: "COMPLETED",
+        currentRevisionId: "wrev-ready",
+        createdAt: "2026-07-28T00:00:00Z",
+        updatedAt: "2026-07-28T00:00:00Z",
+      },
+      {
+        sourceId: "wsrc-pending",
+        workspaceId: 2,
+        url: "https://example.org/pending",
+        host: "example.org",
+        displayName: "수집 중 자료",
+        embeddingDeploymentId: "embedding-default",
+        status: "PENDING",
+        createdAt: "2026-07-28T00:00:00Z",
+        updatedAt: "2026-07-28T00:00:00Z",
+      },
+    ]);
+    const onChange = vi.fn();
+
+    render(
+      <RagEvidenceSourcePicker
+        workspaceId={2}
+        embeddingDeploymentId="embedding-default"
+        value={[]}
+        onChange={onChange}
+      />
+    );
+
+    await screen.findByText("사용 가능 자료");
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect((checkboxes[0] as HTMLInputElement).disabled).toBe(false);
+    expect((checkboxes[1] as HTMLInputElement).disabled).toBe(true);
+
+    fireEvent.click(checkboxes[0]);
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith([
+        { sourceId: "wsrc-ready", revisionId: "wrev-ready" },
+      ])
+    );
+  });
+
+  it("displays read error when list request fails with 403 Forbidden", async () => {
+    const error = new Error("Forbidden");
+    (error as any).status = 403;
+    listWebKnowledgeSources.mockRejectedValue(error);
+
+    render(
+      <RagEvidenceSourcePicker
+        workspaceId={2}
+        embeddingDeploymentId="embedding-default"
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+
+    await screen.findByText("이 workspace의 URL 자료를 조회할 수 없습니다.");
+  });
+
+  it("displays write warning when create request fails with 403 Forbidden", async () => {
+    listWebKnowledgeSources.mockResolvedValue([
+      {
+        sourceId: "wsrc-ready",
+        workspaceId: 2,
+        url: "https://example.org/ready",
+        host: "example.org",
+        displayName: "기존 자료",
+        embeddingDeploymentId: "embedding-default",
+        status: "COMPLETED",
+        currentRevisionId: "wrev-ready",
+        createdAt: "2026-07-28T00:00:00Z",
+        updatedAt: "2026-07-28T00:00:00Z",
+      },
+    ]);
+    const createError = new Error("Forbidden");
+    (createError as any).status = 403;
+    createWebKnowledgeSource.mockRejectedValue(createError);
+
+    render(
+      <RagEvidenceSourcePicker
+        workspaceId={2}
+        embeddingDeploymentId="embedding-default"
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+
+    await screen.findByText("기존 자료");
+
+    const input = screen.getByLabelText("공개 HTTPS URL");
+    fireEvent.change(input, { target: { value: "https://example.org/new" } });
+
+    const submitBtn = screen.getByRole("button", { name: "수집 시작" });
+    fireEvent.click(submitBtn);
+
+    await screen.findByText("기존 자료만 사용할 수 있으며 새 URL을 등록할 수 없습니다.");
+
+    // Checkbox for completed existing source should remain enabled
+    const checkbox = screen.getByRole("checkbox");
+    expect((checkbox as HTMLInputElement).disabled).toBe(false);
+  });
+
+  it("renders external links with target=_blank and rel=noopener noreferrer", async () => {
+    listWebKnowledgeSources.mockResolvedValue([
+      {
+        sourceId: "wsrc-link",
+        workspaceId: 2,
+        url: "https://example.org/link",
+        canonicalUrl: "https://example.org/link",
+        host: "example.org",
+        displayName: "링크 자료",
+        embeddingDeploymentId: "embedding-default",
+        status: "COMPLETED",
+        currentRevisionId: "wrev-link",
+        createdAt: "2026-07-28T00:00:00Z",
+        updatedAt: "2026-07-28T00:00:00Z",
+      },
+    ]);
+
+    render(
+      <RagEvidenceSourcePicker
+        workspaceId={2}
+        embeddingDeploymentId="embedding-default"
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+
+    const link = await screen.findByText("example.org");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+});

--- a/src/react/pages/ai/components/RagEvidenceSourcePicker.tsx
+++ b/src/react/pages/ai/components/RagEvidenceSourcePicker.tsx
@@ -1,0 +1,384 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  FormControlLabel,
+  IconButton,
+  Link,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { CancelOutlined, DeleteOutline, RefreshOutlined } from "@mui/icons-material";
+import { reactAiApi } from "@/react/pages/ai/api";
+import type {
+  IndexedWebSourceRefDto,
+  WebKnowledgeSourceDto,
+} from "@/types/studio/ai";
+import { resolveAxiosError } from "@/utils/helpers";
+
+type Props = {
+  workspaceId?: number | null;
+  embeddingDeploymentId?: string | null;
+  value: IndexedWebSourceRefDto[];
+  maxSelectedSources?: number;
+  disabled?: boolean;
+  onChange: (value: IndexedWebSourceRefDto[]) => void;
+};
+
+const ACTIVE = new Set(["PENDING", "FETCHING", "NORMALIZING", "INDEXING"]);
+
+function statusLabel(status: string) {
+  switch (status) {
+    case "PENDING": return "대기 중";
+    case "FETCHING": return "수집 중";
+    case "NORMALIZING": return "정규화 중";
+    case "INDEXING": return "색인 중";
+    case "COMPLETED": return "사용 가능";
+    case "UNCHANGED": return "변경 없음";
+    case "FAILED": return "실패";
+    case "CANCELLED": return "취소됨";
+    default: return status;
+  }
+}
+
+function isForbiddenError(err: unknown) {
+  if (!err) return false;
+  if (typeof err === "object" && "status" in err && (err as { status?: number }).status === 403) return true;
+  if (typeof err === "object" && "response" in err && (err as { response?: { status?: number } }).response?.status === 403) return true;
+  const msg = resolveAxiosError(err);
+  return msg.includes("403") || msg.toLowerCase().includes("forbidden") || msg.includes("권한");
+}
+
+export function RagEvidenceSourcePicker({
+  workspaceId,
+  embeddingDeploymentId,
+  value,
+  maxSelectedSources = 10,
+  disabled = false,
+  onChange,
+}: Props) {
+  const [sources, setSources] = useState<WebKnowledgeSourceDto[]>([]);
+  const [url, setUrl] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [readError, setReadError] = useState<string | null>(null);
+  const [writeError, setWriteError] = useState<string | null>(null);
+  const [writeDisabled, setWriteDisabled] = useState(false);
+  const valueRef = useRef(value);
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    valueRef.current = value;
+    onChangeRef.current = onChange;
+  }, [value, onChange]);
+
+  const effectiveDeploymentId = embeddingDeploymentId || "embedding-default";
+
+  const load = useCallback(async () => {
+    if (!workspaceId) {
+      setSources([]);
+      return;
+    }
+    try {
+      setLoading(true);
+      const result = await reactAiApi.listWebKnowledgeSources(
+        workspaceId,
+        effectiveDeploymentId
+      );
+      setSources(result);
+      setReadError(null);
+      const usable = new Set(
+        result
+          .filter((item) => item.currentRevisionId)
+          .map((item) => `${item.sourceId}:${item.currentRevisionId}`)
+      );
+      const retained = valueRef.current.filter((item) =>
+        usable.has(`${item.sourceId}:${item.revisionId}`)
+      );
+      if (retained.length !== valueRef.current.length) onChangeRef.current(retained);
+    } catch (loadError) {
+      if (isForbiddenError(loadError)) {
+        setReadError("이 workspace의 URL 자료를 조회할 수 없습니다.");
+      } else {
+        setReadError(resolveAxiosError(loadError));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId, effectiveDeploymentId]);
+
+  useEffect(() => {
+    setWriteError(null);
+    setWriteDisabled(false);
+    void load();
+  }, [workspaceId, effectiveDeploymentId, load]);
+
+  useEffect(() => {
+    if (!sources.some((source) => ACTIVE.has(source.status))) return;
+    const timer = window.setInterval(() => void load(), 2000);
+    return () => window.clearInterval(timer);
+  }, [sources, load]);
+
+  const selectedKeys = useMemo(
+    () => new Set(value.map((item) => `${item.sourceId}:${item.revisionId}`)),
+    [value]
+  );
+
+  async function createSource() {
+    if (!workspaceId || !url.trim() || writeDisabled) return;
+    try {
+      setSubmitting(true);
+      setWriteError(null);
+      await reactAiApi.createWebKnowledgeSource(workspaceId, {
+        url: url.trim(),
+        displayName: displayName.trim() || undefined,
+        embeddingDeploymentId: effectiveDeploymentId,
+      });
+      setUrl("");
+      setDisplayName("");
+      await load();
+    } catch (createErr) {
+      if (isForbiddenError(createErr)) {
+        setWriteDisabled(true);
+        setWriteError("기존 자료만 사용할 수 있으며 새 URL을 등록할 수 없습니다.");
+      } else {
+        setWriteError(resolveAxiosError(createErr));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function toggle(source: WebKnowledgeSourceDto) {
+    if (!source.currentRevisionId) return;
+    const key = `${source.sourceId}:${source.currentRevisionId}`;
+    if (selectedKeys.has(key)) {
+      onChange(value.filter((item) => `${item.sourceId}:${item.revisionId}` !== key));
+      return;
+    }
+    if (value.length >= maxSelectedSources) return;
+    onChange([
+      ...value,
+      { sourceId: source.sourceId, revisionId: source.currentRevisionId },
+    ]);
+  }
+
+  async function refreshSource(sourceId: string) {
+    if (!workspaceId || writeDisabled) return;
+    try {
+      setWriteError(null);
+      await reactAiApi.refreshWebKnowledgeSource(workspaceId, sourceId);
+      await load();
+    } catch (refreshErr) {
+      if (isForbiddenError(refreshErr)) {
+        setWriteDisabled(true);
+        setWriteError("기존 자료만 사용할 수 있으며 새 URL을 등록할 수 없습니다.");
+      } else {
+        setWriteError(resolveAxiosError(refreshErr));
+      }
+    }
+  }
+
+  async function cancelSource(sourceId: string) {
+    if (!workspaceId || writeDisabled) return;
+    try {
+      setWriteError(null);
+      await reactAiApi.cancelWebKnowledgeSource(workspaceId, sourceId);
+      await load();
+    } catch (cancelErr) {
+      if (isForbiddenError(cancelErr)) {
+        setWriteDisabled(true);
+        setWriteError("기존 자료만 사용할 수 있으며 새 URL을 등록할 수 없습니다.");
+      } else {
+        setWriteError(resolveAxiosError(cancelErr));
+      }
+    }
+  }
+
+  async function archiveSource(sourceId: string) {
+    if (!workspaceId || writeDisabled) return;
+    try {
+      setWriteError(null);
+      await reactAiApi.archiveWebKnowledgeSource(workspaceId, sourceId);
+      onChange(value.filter((item) => item.sourceId !== sourceId));
+      await load();
+    } catch (archiveErr) {
+      if (isForbiddenError(archiveErr)) {
+        setWriteDisabled(true);
+        setWriteError("기존 자료만 사용할 수 있으며 새 URL을 등록할 수 없습니다.");
+      } else {
+        setWriteError(resolveAxiosError(archiveErr));
+      }
+    }
+  }
+
+  if (!workspaceId) {
+    return (
+      <Alert severity="info">
+        자료를 저장할 workspace를 선택하세요.
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack spacing={1.25}>
+      <Box>
+        <Typography variant="subtitle2" sx={{ fontWeight: 800 }}>
+          수집한 웹 자료
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          공개 HTTPS 페이지를 수집·색인한 뒤 문서와 함께 근거로 사용합니다.
+        </Typography>
+      </Box>
+
+      {writeError ? <Alert severity="warning">{writeError}</Alert> : null}
+      {readError ? <Alert severity="error">{readError}</Alert> : null}
+
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+        <TextField
+          size="small"
+          type="url"
+          label="공개 HTTPS URL"
+          value={url}
+          onChange={(event) => setUrl(event.target.value)}
+          disabled={disabled || submitting || writeDisabled}
+          fullWidth
+        />
+        <TextField
+          size="small"
+          label="표시 이름 (선택)"
+          value={displayName}
+          onChange={(event) => setDisplayName(event.target.value)}
+          disabled={disabled || submitting || writeDisabled}
+          sx={{ minWidth: 180 }}
+        />
+        <Button
+          variant="outlined"
+          onClick={() => void createSource()}
+          disabled={disabled || submitting || writeDisabled || !url.trim()}
+          sx={{ whiteSpace: "nowrap" }}
+        >
+          {submitting ? <CircularProgress size={18} /> : "수집 시작"}
+        </Button>
+      </Stack>
+
+      {loading && sources.length === 0 ? <CircularProgress size={20} /> : null}
+
+      <Stack spacing={0.75}>
+        {sources.map((source) => {
+          const selectable = Boolean(source.currentRevisionId)
+            && (source.status === "COMPLETED" || source.status === "UNCHANGED");
+          const key = source.currentRevisionId
+            ? `${source.sourceId}:${source.currentRevisionId}`
+            : source.sourceId;
+          return (
+            <Box
+              key={source.sourceId}
+              sx={{
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 1.5,
+                px: 1.25,
+                py: 0.75,
+              }}
+            >
+              <Stack direction="row" spacing={1} alignItems="flex-start">
+                <FormControlLabel
+                  sx={{ m: 0, flex: 1, alignItems: "flex-start" }}
+                  control={
+                    <Checkbox
+                      size="small"
+                      checked={selectedKeys.has(key)}
+                      onChange={() => toggle(source)}
+                      disabled={disabled || !selectable}
+                    />
+                  }
+                  label={
+                    <Box sx={{ pt: 0.3 }}>
+                      <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap">
+                        <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                          {source.displayName || source.title || source.host}
+                        </Typography>
+                        <Chip size="small" label={statusLabel(source.status)} />
+                      </Stack>
+                      <Link
+                        href={source.canonicalUrl || source.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        variant="caption"
+                        sx={{ overflowWrap: "anywhere" }}
+                      >
+                        {source.host}
+                      </Link>
+                      {source.contentPreview ? (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ display: "block", mt: 0.35 }}
+                        >
+                          {source.contentPreview}
+                        </Typography>
+                      ) : null}
+                      {source.errorCode ? (
+                        <Typography variant="caption" color="error" sx={{ display: "block", mt: 0.25 }}>
+                          오류 ({source.errorCode})
+                        </Typography>
+                      ) : null}
+                    </Box>
+                  }
+                />
+                {ACTIVE.has(source.status) ? (
+                  <Tooltip title="수집 취소">
+                    <span>
+                      <IconButton
+                        size="small"
+                        disabled={disabled || writeDisabled}
+                        onClick={() => void cancelSource(source.sourceId)}
+                      >
+                        <CancelOutlined fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <Tooltip title="새로 수집">
+                    <span>
+                      <IconButton
+                        size="small"
+                        disabled={disabled || writeDisabled}
+                        onClick={() => void refreshSource(source.sourceId)}
+                      >
+                        <RefreshOutlined fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                )}
+                <Tooltip title="보관">
+                  <span>
+                    <IconButton
+                      size="small"
+                      disabled={disabled || writeDisabled || ACTIVE.has(source.status)}
+                      onClick={() => void archiveSource(source.sourceId)}
+                    >
+                      <DeleteOutline fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Stack>
+            </Box>
+          );
+        })}
+      </Stack>
+
+      <Typography variant="caption" color="text.secondary">
+        {value.length}/{maxSelectedSources}개 선택 · 답변 범위는 검색 결과가 아니라 답변 허용 수준만 변경합니다.
+      </Typography>
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/components/RagEvidenceSourceSummary.test.tsx
+++ b/src/react/pages/ai/components/RagEvidenceSourceSummary.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { RagEvidenceSourceSummary } from "./RagEvidenceSourceSummary";
+
+describe("RagEvidenceSourceSummary", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders summary with attached document and web sources count", () => {
+    const onOpenDrawer = vi.fn();
+    render(
+      <RagEvidenceSourceSummary
+        attachedDocumentName="report.pdf"
+        selectedWebSourcesCount={2}
+        onOpenDrawer={onOpenDrawer}
+      />
+    );
+
+    expect(screen.getAllByText("참고자료")[0]).toBeDefined();
+    expect(screen.getByText("문서 1개 (report.pdf)")).toBeDefined();
+    expect(screen.getByText("수집한 웹 2개")).toBeDefined();
+
+    const button = screen.getByRole("button", { name: "자료 관리" });
+    fireEvent.click(button);
+    expect(onOpenDrawer).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders summary without attached document", () => {
+    const onOpenDrawer = vi.fn();
+    render(
+      <RagEvidenceSourceSummary
+        selectedWebSourcesCount={0}
+        onOpenDrawer={onOpenDrawer}
+      />
+    );
+
+    expect(screen.getAllByText("참고자료")[0]).toBeDefined();
+    expect(screen.queryByText(/문서 1개/)).toBeNull();
+    expect(screen.getByText("수집한 웹 0개")).toBeDefined();
+  });
+});

--- a/src/react/pages/ai/components/RagEvidenceSourceSummary.tsx
+++ b/src/react/pages/ai/components/RagEvidenceSourceSummary.tsx
@@ -1,0 +1,77 @@
+import { Box, Button, Chip, Stack, Typography } from "@mui/material";
+import { DescriptionOutlined, LanguageOutlined, TuneOutlined } from "@mui/icons-material";
+
+type Props = {
+  attachedDocumentName?: string | null;
+  selectedWebSourcesCount: number;
+  onOpenDrawer: () => void;
+  disabled?: boolean;
+};
+
+export function RagEvidenceSourceSummary({
+  attachedDocumentName,
+  selectedWebSourcesCount,
+  onOpenDrawer,
+  disabled = false,
+}: Props) {
+  return (
+    <Box
+      sx={{
+        px: 2,
+        py: 1,
+        borderRadius: 2,
+        border: "1px solid",
+        borderColor: "divider",
+        bgcolor: "background.paper",
+      }}
+    >
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        spacing={1.5}
+        alignItems={{ xs: "flex-start", sm: "center" }}
+        justifyContent="space-between"
+      >
+        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" sx={{ rowGap: 0.75 }}>
+          <Typography variant="body2" sx={{ fontWeight: 700, color: "text.primary", mr: 0.5 }}>
+            참고자료
+          </Typography>
+
+          {attachedDocumentName ? (
+            <Chip
+              size="small"
+              icon={<DescriptionOutlined fontSize="small" />}
+              label={`문서 1개 (${attachedDocumentName})`}
+              variant="outlined"
+              color="primary"
+              sx={{ fontWeight: 600 }}
+            />
+          ) : null}
+
+          <Chip
+            size="small"
+            icon={<LanguageOutlined fontSize="small" />}
+            label={
+              selectedWebSourcesCount > 0
+                ? `수집한 웹 ${selectedWebSourcesCount}개`
+                : "수집한 웹 0개"
+            }
+            variant="outlined"
+            color={selectedWebSourcesCount > 0 ? "secondary" : "default"}
+            sx={{ fontWeight: 600 }}
+          />
+        </Stack>
+
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<TuneOutlined fontSize="small" />}
+          onClick={onOpenDrawer}
+          disabled={disabled}
+          sx={{ whiteSpace: "nowrap", borderRadius: 1.5, textTransform: "none", fontWeight: 600 }}
+        >
+          자료 관리
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/react/pages/ai/components/RagMarkdownRenderer.test.tsx
+++ b/src/react/pages/ai/components/RagMarkdownRenderer.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { encodeRagCitations, RagMarkdownRenderer } from "./RagMarkdownRenderer";
+
+describe("RagMarkdownRenderer", () => {
+  it("renders structured answers and keeps validated citations interactive", () => {
+    const onCitationClick = vi.fn();
+    render(
+      <RagMarkdownRenderer
+        content={"## 관련 과학자\n\n- **니컬러스 P. 머니** — 진균학자입니다. [1]\n- **로베르트 레마크** — 백선증 연구자입니다. [2]"}
+        references={[
+          { index: 1, title: "진균의 역사", content: "니컬러스 P. 머니는 진균학자이다." },
+          { index: 2, title: "진균의 역사", content: "로베르트 레마크는 백선증을 연구했다." },
+        ]}
+        onCitationClick={onCitationClick}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "관련 과학자" })).toBeTruthy();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(screen.getByText("니컬러스 P. 머니").tagName).toBe("STRONG");
+
+    fireEvent.click(screen.getByRole("button", { name: "근거 1" }));
+    expect(onCitationClick).toHaveBeenCalledWith([1], expect.anything());
+  });
+
+  it("does not interpret raw html or citation-shaped text inside code", () => {
+    const content = "<script>alert('unsafe')</script>\n\n`[1]`과 다음 코드를 설명합니다.\n\n```\n[2]\n```";
+    const { container } = render(
+      <RagMarkdownRenderer content={content} references={[]} />
+    );
+
+    expect(container.querySelector("script")).toBeNull();
+    expect(within(container).queryByRole("button", { name: "근거 1" })).toBeNull();
+    expect(within(container).queryByRole("button", { name: "근거 2" })).toBeNull();
+    expect(within(container).getByText("[1]")).toBeTruthy();
+    expect(within(container).getByText("[2]")).toBeTruthy();
+  });
+
+  it("encodes citations outside code blocks only", () => {
+    expect(encodeRagCitations("설명 [1, 2]\n\n```\n[3]\n```"))
+      .toBe("설명 [1, 2](#rag-citation-1,2)\n\n```\n[3]\n```");
+  });
+
+  it("does not activate citation labels that are absent from validated references", () => {
+    const { container } = render(
+      <RagMarkdownRenderer
+        content={"검증된 근거 [1], 범위 밖 표기 [999]"}
+        references={[{ index: 1, title: "문서" }]}
+      />
+    );
+
+    expect(within(container).getByRole("button", { name: "근거 1" })).toBeTruthy();
+    expect(within(container).queryByRole("button", { name: "근거 999" })).toBeNull();
+    expect(within(container).getByText(/범위 밖 표기 \[999\]/)).toBeTruthy();
+  });
+
+  it("blocks executable links supplied by model output", () => {
+    const { container } = render(
+      <RagMarkdownRenderer
+        content={"[위험 링크](javascript:alert('unsafe'))"}
+        references={[]}
+      />
+    );
+
+    expect(container.querySelector("a")?.getAttribute("href")).toBeNull();
+  });
+});

--- a/src/react/pages/ai/components/RagMarkdownRenderer.tsx
+++ b/src/react/pages/ai/components/RagMarkdownRenderer.tsx
@@ -1,0 +1,270 @@
+import type { MouseEvent, ReactNode } from "react";
+import { alpha, Box, Tooltip, Typography } from "@mui/material";
+import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
+import rehypeKatex from "rehype-katex";
+import rehypeSanitize from "rehype-sanitize";
+import remarkMath from "remark-math";
+import "katex/dist/katex.min.css";
+
+const CITATION_PATTERN = /\[(\d+(?:\s*,\s*\d+)*)\]/g;
+const CITATION_TARGET = "#rag-citation-";
+const FENCE_PATTERN = /^\s{0,3}(`{3,}|~{3,})/;
+
+export interface RagMarkdownReference {
+  index?: number;
+  title?: string;
+  chunk?: string;
+  content?: string;
+}
+
+interface Props {
+  content: string;
+  references: RagMarkdownReference[];
+  onCitationClick?: (indices: number[], event: MouseEvent<HTMLElement>) => void;
+}
+
+function encodeInlineCitations(line: string, allowedIndices?: ReadonlySet<number>) {
+  const parts = line.split(/(`+)/);
+  let inlineCodeDelimiter = "";
+
+  return parts
+    .map((part) => {
+      if (/^`+$/.test(part)) {
+        if (!inlineCodeDelimiter) {
+          inlineCodeDelimiter = part;
+        } else if (part.length === inlineCodeDelimiter.length) {
+          inlineCodeDelimiter = "";
+        }
+        return part;
+      }
+      if (inlineCodeDelimiter) {
+        return part;
+      }
+      return part.replace(CITATION_PATTERN, (_match, value: string) => {
+        const indices = value
+          .split(",")
+          .map((item) => Number.parseInt(item.trim(), 10));
+        if (allowedIndices && !indices.every((index) => allowedIndices.has(index))) {
+          return _match;
+        }
+        const compact = value.replace(/\s+/g, "");
+        return `[${value}](${CITATION_TARGET}${compact})`;
+      });
+    })
+    .join("");
+}
+
+/**
+ * Converts validated citation labels into safe fragment links that ReactMarkdown
+ * can hand to the citation component. Code blocks and inline code stay untouched.
+ */
+export function encodeRagCitations(content: string, allowedIndices?: ReadonlySet<number>) {
+  let fenceMarker = "";
+  return content
+    .split(/\r?\n/)
+    .map((line) => {
+      const fence = line.match(FENCE_PATTERN)?.[1] ?? "";
+      if (fence) {
+        if (!fenceMarker) {
+          fenceMarker = fence[0];
+        } else if (fence[0] === fenceMarker) {
+          fenceMarker = "";
+        }
+        return line;
+      }
+      return fenceMarker ? line : encodeInlineCitations(line, allowedIndices);
+    })
+    .join("\n");
+}
+
+function citationIndices(href?: string) {
+  if (!href?.startsWith(CITATION_TARGET)) {
+    return [];
+  }
+  return href
+    .slice(CITATION_TARGET.length)
+    .split(",")
+    .map((value) => Number.parseInt(value, 10))
+    .filter((value) => Number.isInteger(value) && value > 0);
+}
+
+function CitationLink({
+  indices,
+  references,
+  onCitationClick,
+}: {
+  indices: number[];
+  references: RagMarkdownReference[];
+  onCitationClick?: Props["onCitationClick"];
+}) {
+  const matchingReferences = references.filter((reference) => indices.includes(reference.index ?? -1));
+  const label = `[${indices.join(", ")}]`;
+  const badge = (
+    <Box
+      component="button"
+      type="button"
+      aria-label={`근거 ${indices.join(", ")}`}
+      onClick={(event) => onCitationClick?.(indices, event)}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        mx: 0.3,
+        px: 0.6,
+        py: 0.1,
+        border: 0,
+        borderRadius: "4px",
+        bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+        color: "primary.main",
+        font: "inherit",
+        fontWeight: 700,
+        fontSize: "0.82em",
+        cursor: onCitationClick ? "pointer" : "default",
+        verticalAlign: "baseline",
+        lineHeight: 1.2,
+        transition: "all 120ms ease",
+        "&:hover": onCitationClick
+          ? { bgcolor: "primary.main", color: "#fff" }
+          : {},
+      }}
+    >
+      {label}
+    </Box>
+  );
+
+  if (matchingReferences.length === 0) {
+    return badge;
+  }
+
+  return (
+    <Tooltip
+      arrow
+      placement="top"
+      title={
+        <Box sx={{ p: 0.5, maxWidth: 320 }}>
+          {matchingReferences.map((reference, index) => (
+            <Box key={`${reference.index}-${reference.title}-${index}`} sx={{ mb: index < matchingReferences.length - 1 ? 1 : 0 }}>
+              <Typography variant="caption" component="div" sx={{ fontWeight: 800, fontSize: 11.5, color: "#fff" }}>
+                근거 {reference.index ?? index + 1}: {reference.title}
+                {reference.chunk ? ` (${reference.chunk})` : ""}
+              </Typography>
+              {reference.content ? (
+                <Typography
+                  variant="caption"
+                  component="div"
+                  sx={{
+                    color: "rgba(255, 255, 255, 0.85)",
+                    fontSize: 11,
+                    mt: 0.25,
+                    lineHeight: 1.45,
+                    display: "-webkit-box",
+                    WebkitLineClamp: 3,
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                  }}
+                >
+                  “{reference.content.trim()}”
+                </Typography>
+              ) : null}
+            </Box>
+          ))}
+        </Box>
+      }
+    >
+      {badge}
+    </Tooltip>
+  );
+}
+
+function safeUrlTransform(url: string) {
+  return url.startsWith(CITATION_TARGET) ? url : defaultUrlTransform(url);
+}
+
+export function RagMarkdownRenderer({ content, references, onCitationClick }: Props) {
+  const allowedCitationIndices = new Set(
+    references
+      .map((reference) => reference.index)
+      .filter((index): index is number => Number.isInteger(index) && (index ?? 0) > 0)
+  );
+  const components: Components = {
+    a: ({ href, children }) => {
+      const indices = citationIndices(href);
+      if (indices.length > 0) {
+        return (
+          <CitationLink
+            indices={indices}
+            references={references}
+            onCitationClick={onCitationClick}
+          />
+        );
+      }
+      return (
+        <a href={href} target="_blank" rel="noreferrer noopener">
+          {children as ReactNode}
+        </a>
+      );
+    },
+  };
+
+  return (
+    <Box
+      data-testid="rag-markdown"
+      sx={{
+        overflowWrap: "anywhere",
+        fontSize: 14.5,
+        lineHeight: 1.75,
+        "& > :first-of-type": { mt: 0 },
+        "& > :last-child": { mb: 0 },
+        "& p": { mt: 0, mb: 1.25 },
+        "& h1, & h2, & h3, & h4": {
+          mt: 2,
+          mb: 0.75,
+          lineHeight: 1.4,
+          fontWeight: 800,
+          color: "text.primary",
+        },
+        "& h1": { fontSize: "1.2rem" },
+        "& h2": { fontSize: "1.08rem" },
+        "& h3, & h4": { fontSize: "1rem" },
+        "& ul, & ol": { mt: 0.5, mb: 1.25, pl: 3 },
+        "& li": { mb: 0.75, pl: 0.25 },
+        "& li:last-child": { mb: 0 },
+        "& li > p": { mb: 0.4 },
+        "& blockquote": {
+          m: "12px 0",
+          px: 1.5,
+          py: 0.75,
+          borderLeft: "3px solid",
+          borderColor: "primary.light",
+          bgcolor: (theme) => alpha(theme.palette.primary.main, 0.04),
+          color: "text.secondary",
+        },
+        "& pre": {
+          my: 1.25,
+          p: 1.5,
+          overflowX: "auto",
+          borderRadius: 1.5,
+          bgcolor: (theme) => alpha(theme.palette.text.primary, 0.06),
+        },
+        "& code": {
+          px: 0.45,
+          py: 0.1,
+          borderRadius: 0.5,
+          bgcolor: (theme) => alpha(theme.palette.text.primary, 0.06),
+          fontSize: "0.9em",
+        },
+        "& pre code": { p: 0, bgcolor: "transparent" },
+        "& a": { color: "primary.main", textDecorationColor: "currentColor" },
+      }}
+    >
+      <ReactMarkdown
+        skipHtml
+        remarkPlugins={[remarkMath]}
+        rehypePlugins={[rehypeSanitize, rehypeKatex]}
+        urlTransform={safeUrlTransform}
+        components={components}
+      >
+        {encodeRagCitations(content, allowedCitationIndices)}
+      </ReactMarkdown>
+    </Box>
+  );
+}

--- a/src/react/pages/ai/components/RagSourceScopeSelector.test.tsx
+++ b/src/react/pages/ai/components/RagSourceScopeSelector.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RagSourceScopeSelector } from "./RagSourceScopeSelector";
+
+describe("RagSourceScopeSelector", () => {
+  it("keeps source scope separate from answer interpretation mode", () => {
+    render(
+      <RagSourceScopeSelector
+        capabilities={{
+          defaultScope: "DOCUMENT_ONLY",
+          maximumScope: "DOCUMENT_AND_OFFICIAL_EXTERNAL",
+          clientSelectionEnabled: true,
+          externalProviderAvailable: true,
+          policyVersion: "test",
+          availableScopes: ["DOCUMENT_ONLY", "DOCUMENT_AND_OFFICIAL_EXTERNAL"],
+        }}
+        value="DOCUMENT_ONLY"
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(/참고 자료 범위는 검색 대상을 결정하며 답변의 해석 허용 범위와는 별개입니다/)
+    ).toBeTruthy();
+  });
+
+  it("explains why official external sources are unavailable", () => {
+    render(
+      <RagSourceScopeSelector
+        capabilities={{
+          defaultScope: "DOCUMENT_ONLY",
+          maximumScope: "DOCUMENT_ONLY",
+          clientSelectionEnabled: true,
+          externalProviderAvailable: false,
+          policyVersion: "test",
+          availableScopes: ["DOCUMENT_ONLY"],
+        }}
+        value="DOCUMENT_ONLY"
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(/서버에 공식 외부 자료 공급자가 설정되지 않아 첨부 문서만 사용할 수 있습니다/)
+    ).toBeTruthy();
+  });
+});

--- a/src/react/pages/ai/components/RagSourceScopeSelector.tsx
+++ b/src/react/pages/ai/components/RagSourceScopeSelector.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { Alert, Box, Button, Menu, MenuItem, Stack, TextField, Typography } from "@mui/material";
+import { CheckOutlined, ExpandMoreOutlined, PublicOutlined } from "@mui/icons-material";
+import type {
+  RagSourcePolicyCapabilitiesDto,
+  RagSourceScope,
+} from "@/types/studio/ai";
+
+interface Props {
+  capabilities: RagSourcePolicyCapabilitiesDto | null;
+  value: RagSourceScope | null;
+  onChange: (scope: RagSourceScope) => void;
+  disabled?: boolean;
+  hideHelperText?: boolean;
+  variant?: "standard" | "compact-pill";
+}
+
+const labels: Record<RagSourceScope, string> = {
+  DOCUMENT_ONLY: "첨부 문서만",
+  DOCUMENT_AND_OFFICIAL_EXTERNAL: "공식 외부 자료도 참고",
+};
+
+const descriptions: Record<RagSourceScope, string> = {
+  DOCUMENT_ONLY: "첨부 문서에서 확인된 근거만 검색합니다.",
+  DOCUMENT_AND_OFFICIAL_EXTERNAL:
+    "문서 근거와 검증된 공식 외부 자료를 분리하여 검색하고 비교합니다.",
+};
+
+export function RagSourceScopeSelector({
+  capabilities,
+  value,
+  onChange,
+  disabled,
+  hideHelperText,
+  variant = "standard",
+}: Props) {
+  const scopes = capabilities?.availableScopes ?? [];
+  const selected =
+    capabilities && !capabilities.clientSelectionEnabled
+      ? capabilities.defaultScope
+      : value ?? capabilities?.defaultScope ?? "";
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const unavailableReason =
+    capabilities && !capabilities.externalProviderAvailable
+      ? "서버에 공식 외부 자료 공급자가 설정되지 않아 첨부 문서만 사용할 수 있습니다."
+      : null;
+
+  if (variant === "compact-pill") {
+    return (
+      <>
+        <Button
+          size="small"
+          disabled={disabled || !capabilities || !capabilities.clientSelectionEnabled}
+          onClick={(event) => setAnchorEl(event.currentTarget)}
+          startIcon={<PublicOutlined sx={{ fontSize: 15 }} />}
+          endIcon={<ExpandMoreOutlined sx={{ fontSize: 16, color: "text.secondary" }} />}
+          sx={{
+            textTransform: "none",
+            fontWeight: 500,
+            fontSize: 12.5,
+            color: "text.secondary",
+            px: 1,
+            py: 0.3,
+            borderRadius: "16px",
+          }}
+        >
+          {selected ? labels[selected as RagSourceScope] : "참고 자료"}
+        </Button>
+        <Menu
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={() => setAnchorEl(null)}
+          slotProps={{ paper: { sx: { minWidth: 300, borderRadius: "12px" } } }}
+        >
+          <Box sx={{ px: 2, py: 1, borderBottom: "1px solid", borderColor: "divider" }}>
+            <Typography variant="caption" color="text.secondary" fontWeight={700}>
+              참고 자료 범위
+            </Typography>
+          </Box>
+          {scopes.map((scope) => {
+            const isSelected = scope === selected;
+            return (
+              <MenuItem
+                key={scope}
+                selected={isSelected}
+                onClick={() => {
+                  onChange(scope);
+                  setAnchorEl(null);
+                }}
+                sx={{ py: 1.2, px: 2 }}
+              >
+                <Stack spacing={0.25} sx={{ width: "100%" }}>
+                  <Stack direction="row" alignItems="center" justifyContent="space-between">
+                    <Typography variant="body2" fontWeight={isSelected ? 700 : 500}>
+                      {labels[scope]}
+                    </Typography>
+                    {isSelected ? <CheckOutlined fontSize="small" color="primary" /> : null}
+                  </Stack>
+                  <Typography variant="caption" color="text.secondary" sx={{ fontSize: 11 }}>
+                    {descriptions[scope]}
+                  </Typography>
+                </Stack>
+              </MenuItem>
+            );
+          })}
+          {unavailableReason ? (
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block", px: 2, py: 1 }}>
+              {unavailableReason}
+            </Typography>
+          ) : null}
+        </Menu>
+      </>
+    );
+  }
+
+  return (
+    <Stack spacing={0.75}>
+      <TextField
+        select
+        label="참고 자료 범위"
+        size="small"
+        value={selected}
+        disabled={disabled || !capabilities || !capabilities.clientSelectionEnabled}
+        onChange={(event) => onChange(event.target.value as RagSourceScope)}
+        helperText={
+          selected
+            ? descriptions[selected as RagSourceScope]
+            : "서버의 자료 범위 정책을 확인하고 있습니다."
+        }
+        fullWidth
+      >
+        {scopes.map((scope) => (
+          <MenuItem key={scope} value={scope}>
+            {labels[scope]}
+          </MenuItem>
+        ))}
+      </TextField>
+      {!hideHelperText && unavailableReason ? (
+        <Alert severity="info" sx={{ py: 0 }}>
+          {unavailableReason}
+        </Alert>
+      ) : !hideHelperText ? (
+        <Typography variant="caption" color="text.secondary">
+          참고 자료 범위는 검색 대상을 결정하며 답변의 해석 허용 범위와는 별개입니다.
+        </Typography>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/components/ragOutcome.test.ts
+++ b/src/react/pages/ai/components/ragOutcome.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { deriveRagOutcome } from "./ragOutcome";
+import type { ChatResponseMetadataDto } from "@/types/studio/ai";
+
+function metadata(
+  type: "ANSWERED" | "EVIDENCE_ONLY" | "ABSTAINED",
+  reasonCode:
+    | "NONE"
+    | "NO_RETRIEVAL_RESULTS"
+    | "NO_PACKED_EVIDENCE"
+    | "MISSING_CITATION"
+): ChatResponseMetadataDto {
+  return {
+    canonicalContent: "canonical",
+    ragReferences:
+      type === "ABSTAINED"
+        ? []
+        : [
+            {
+              citationIndex: 1,
+              evidenceId: "evidence-1",
+              usageStatus: type === "ANSWERED" ? "CITED" : "RETRIEVED_ONLY",
+              exactText: "verified excerpt",
+            },
+          ],
+    ragAnswerOutcome: {
+      type,
+      stage: type === "ANSWERED" ? "NONE" : "VALIDATION",
+      reasonCode,
+      retrievedResultCount: type === "ABSTAINED" ? 0 : 1,
+      acceptedResultCount: type === "ABSTAINED" ? 0 : 1,
+      packedEvidenceCount: type === "ABSTAINED" ? 0 : 1,
+      usedEvidenceIndexes: type === "ABSTAINED" ? [] : [1],
+      citationValidationStatus: type === "ANSWERED" ? "INDEX_VALID" : "MISSING_CITATION",
+      policyValidationStatus: type === "ANSWERED" ? "STRUCTURE_VALID" : "CITATION_INVALID",
+      validationUnitCount: 1,
+      citedValidationUnitCount: type === "ANSWERED" ? 1 : 0,
+    },
+  };
+}
+
+describe("deriveRagOutcome", () => {
+  it("activates inline citations only for canonical answered results", () => {
+    const view = deriveRagOutcome(metadata("ANSWERED", "NONE"));
+
+    expect(view.citationsReady).toBe(true);
+    expect(view.referencesTitle).toBe("답변에 사용된 근거");
+  });
+
+  it("shows evidence candidates without activating inline citations", () => {
+    const view = deriveRagOutcome(metadata("EVIDENCE_ONLY", "MISSING_CITATION"));
+
+    expect(view.citationsReady).toBe(false);
+    expect(view.referencesTitle).toBe("검색된 근거 후보");
+    expect(view.notice).toContain("인용 검증에 실패");
+  });
+
+  it.each([
+    ["NO_RETRIEVAL_RESULTS", "검색 기준을 통과한 문서 구간이 없습니다."],
+    ["NO_PACKED_EVIDENCE", "관련 구간은 찾았지만 답변 근거로 구성하지 못했습니다."],
+  ] as const)("maps %s to its reader-facing notice", (reasonCode, expected) => {
+    const view = deriveRagOutcome(metadata("ABSTAINED", reasonCode));
+
+    expect(view.notice).toBe(expected);
+    expect(view.citationsReady).toBe(false);
+  });
+
+  it("keeps citations disabled while the request is pending", () => {
+    expect(deriveRagOutcome(metadata("ANSWERED", "NONE"), true).citationsReady).toBe(false);
+  });
+
+  it("keeps citations active and explains omitted factual-list items", () => {
+    const value = metadata("ANSWERED", "NONE");
+    if (value.ragAnswerOutcome) {
+      value.ragAnswerOutcome.partial = true;
+      value.ragAnswerOutcome.originalValidationUnitCount = 3;
+      value.ragAnswerOutcome.omittedValidationUnitCount = 1;
+    }
+
+    const view = deriveRagOutcome(value);
+
+    expect(view.citationsReady).toBe(true);
+    expect(view.referencesTitle).toBe("답변에 사용된 근거");
+    expect(view.notice).toContain("1개는 제외");
+  });
+});

--- a/src/react/pages/ai/components/ragOutcome.ts
+++ b/src/react/pages/ai/components/ragOutcome.ts
@@ -1,0 +1,49 @@
+import type {
+  ChatResponseMetadataDto,
+  RagAnswerOutcomeDto,
+  RagReferenceDto,
+} from "@/types/studio/ai";
+
+export interface RagOutcomeViewModel {
+  outcome?: RagAnswerOutcomeDto;
+  references: RagReferenceDto[];
+  citationsReady: boolean;
+  referencesTitle: string;
+  notice?: string;
+}
+
+export function deriveRagOutcome(
+  metadata?: ChatResponseMetadataDto,
+  sending = false
+): RagOutcomeViewModel {
+  const references = Array.isArray(metadata?.ragReferences) ? metadata.ragReferences : [];
+  const outcome = metadata?.ragAnswerOutcome;
+  const answered = outcome?.type === "ANSWERED";
+  const evidenceOnly = outcome?.type === "EVIDENCE_ONLY";
+
+  let notice: string | undefined;
+  if (outcome?.reasonCode === "NO_RETRIEVAL_RESULTS") {
+    notice = "검색 기준을 통과한 문서 구간이 없습니다.";
+  } else if (outcome?.reasonCode === "NO_PACKED_EVIDENCE") {
+    notice = "관련 구간은 찾았지만 답변 근거로 구성하지 못했습니다.";
+  } else if (evidenceOnly) {
+    notice = "관련 근거는 찾았지만 생성 답변의 인용 검증에 실패했습니다.";
+  } else if (answered && outcome?.partial) {
+    const omitted = Math.max(0, outcome.omittedValidationUnitCount ?? 0);
+    notice = omitted > 0
+      ? `문서 근거가 확인된 항목을 표시했습니다. 인용이 불완전한 항목 ${omitted}개는 제외했습니다.`
+      : "문서 근거가 확인된 항목만 표시했습니다.";
+  }
+
+  return {
+    outcome,
+    references,
+    citationsReady:
+      !sending &&
+      answered &&
+      references.some((reference) => reference.usageStatus === "CITED") &&
+      typeof metadata?.canonicalContent === "string",
+    referencesTitle: evidenceOnly ? "검색된 근거 후보" : "답변에 사용된 근거",
+    notice,
+  };
+}

--- a/src/react/pages/files/FileDetailDialog.tsx
+++ b/src/react/pages/files/FileDetailDialog.tsx
@@ -38,6 +38,7 @@ import {
   Tabs,
 } from "@mui/material";
 import {
+  AddOutlined,
   CloseOutlined,
   ContentCopyOutlined,
   ExpandMoreOutlined,
@@ -70,6 +71,8 @@ import type {
   RagAnswerPolicyCapabilitiesDto,
   RagSourcePolicyCapabilitiesDto,
   RagSourceScope,
+  IndexedWebCapabilitiesDto,
+  IndexedWebSourceRefDto,
 } from "@/types/studio/ai";
 import {
   reactFilesApi,
@@ -102,6 +105,9 @@ import { AiProviderSelect } from "@/react/components/ai/AiProviderSelect";
 import { AssistantMessageBubble } from "../ai/components/AssistantMessageBubble";
 import { RagAnswerModeSelector } from "../ai/components/RagAnswerModeSelector";
 import { RagSourceScopeSelector } from "../ai/components/RagSourceScopeSelector";
+import { RagEvidenceSourceDrawer } from "../ai/components/RagEvidenceSourceDrawer";
+import { reactWorkspaceApi } from "@/react/pages/workspaces/api";
+import type { WorkspaceRef } from "@/types/studio/workspace";
 import { UserMessageBubble } from "../ai/components/UserMessageBubble";
 import type { ChatMessage } from "../ai/components/chatTypes";
 import { PageToolbar } from "@/react/components/page/PageToolbar";
@@ -148,6 +154,7 @@ interface Props {
   open: boolean;
   onClose: () => void;
   attachmentId: number;
+  workspaceId?: number;
 }
 
 function ragObjectScopes(file: AttachmentDto | null, fallbackAttachmentId: number) {
@@ -199,12 +206,6 @@ function normalizeExtractedText(value: string) {
     .replaceAll(String.fromCharCode(0), "")
     .replace(/\f/g, "\n\n")
     .trim();
-}
-
-interface Props {
-  open: boolean;
-  attachmentId: number;
-  onClose: () => void;
 }
 
 const knownMetadataLabels: Record<string, string> = {
@@ -328,7 +329,7 @@ function RagMetadataAccordion({ entries }: { entries: Array<[string, unknown]> }
   );
 }
 
-export function FileDetailDialog({ open, attachmentId, onClose }: Props) {
+export function FileDetailDialog({ open, attachmentId, onClose, workspaceId }: Props) {
   const toast = useToast();
   
   const [file, setFile] = useState<AttachmentDto | null>(null);
@@ -719,9 +720,31 @@ export function FileDetailDialog({ open, attachmentId, onClose }: Props) {
   const [qaAnswerMode, setQaAnswerMode] = useState<RagAnswerMode>("STRICT_GROUNDED");
   const [qaSourcePolicy, setQaSourcePolicy] = useState<RagSourcePolicyCapabilitiesDto | null>(null);
   const [qaSourceScope, setQaSourceScope] = useState<RagSourceScope>("DOCUMENT_ONLY");
+  const [qaIndexedWebCapabilities, setQaIndexedWebCapabilities] =
+    useState<IndexedWebCapabilitiesDto | null>(null);
+  const [qaIndexedWebCapabilitiesLoading, setQaIndexedWebCapabilitiesLoading] = useState(false);
+  const [qaIndexedWebCapabilitiesError, setQaIndexedWebCapabilitiesError] = useState<string | null>(null);
+  const [qaIndexedWebSources, setQaIndexedWebSources] = useState<IndexedWebSourceRefDto[]>([]);
+  const [workspaces, setWorkspaces] = useState<WorkspaceRef[]>([]);
+  const [userSelectedWorkspaceId, setUserSelectedWorkspaceId] = useState<number | null>(null);
+  const [evidenceDrawerOpen, setEvidenceDrawerOpen] = useState(false);
   const [showScrollToBottomBtn, setShowScrollToBottomBtn] = useState<boolean>(false);
   const qaMessageListRef = useRef<HTMLDivElement | null>(null);
   const canManage = roles.includes("ROLE_ADMIN") || roles.includes("ADMIN") || roles.includes("features:document-convert/manage");
+
+  const effectiveWorkspaceId = useMemo(() => {
+    if (workspaceId) return workspaceId;
+    if (file) {
+      const typeStr = String(file.objectType);
+      if (typeStr === "2103" || typeStr.toLowerCase() === "workspace") {
+        const objId = Number(file.objectId);
+        if (Number.isFinite(objId) && objId > 0) {
+          return objId;
+        }
+      }
+    }
+    return userSelectedWorkspaceId;
+  }, [workspaceId, file, userSelectedWorkspaceId]);
 
   function clearThumbnail() {
     setThumbnailAvailable(false);
@@ -782,14 +805,28 @@ export function FileDetailDialog({ open, attachmentId, onClose }: Props) {
 
   const loadRagAnswerPolicy = useCallback(async () => {
     try {
+      setQaIndexedWebCapabilitiesLoading(true);
       const capabilities = await reactAiApi.fetchRagCapabilities();
       setQaAnswerPolicy(capabilities.answerPolicy);
       setQaSourcePolicy(capabilities.sourcePolicy);
       setQaSourceScope(capabilities.sourcePolicy.defaultScope);
-    } catch {
-      // The server still enforces its default policy if capabilities cannot be loaded.
+      setQaIndexedWebCapabilities(capabilities.indexedWeb);
+      setQaIndexedWebCapabilitiesError(null);
+    } catch (err) {
+      setQaIndexedWebCapabilitiesError(resolveAxiosError(err));
+    } finally {
+      setQaIndexedWebCapabilitiesLoading(false);
     }
   }, []);
+
+  useEffect(() => {
+    if (open) {
+      reactWorkspaceApi
+        .list({ archived: false, page: 0, size: 100, sort: "name,asc" })
+        .then((res) => setWorkspaces(res.content ?? []))
+        .catch(() => {});
+    }
+  }, [open]);
 
   useEffect(() => {
     if (open && attachmentId) {
@@ -809,6 +846,7 @@ export function FileDetailDialog({ open, attachmentId, onClose }: Props) {
       setQaError(null);
       setQaAnswerMode("STRICT_GROUNDED");
       setQaSourceScope("DOCUMENT_ONLY");
+      setQaIndexedWebSources([]);
     }
   }, [open]);
 
@@ -2786,6 +2824,7 @@ export function FileDetailDialog({ open, attachmentId, onClose }: Props) {
         topK: 5,
         answerMode: qaAnswerMode,
         sourceScope: qaSourceScope,
+        indexedWebSources: qaIndexedWebSources.length > 0 ? qaIndexedWebSources : undefined,
       };
 
       if (embeddingDeploymentId) {
@@ -4493,6 +4532,37 @@ export function FileDetailDialog({ open, attachmentId, onClose }: Props) {
 
           {currentTab === "qa" && file && (
             <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1, height: "calc(100vh - 120px)", overflow: "hidden" }}>
+              <RagEvidenceSourceDrawer
+                open={evidenceDrawerOpen}
+                onClose={() => setEvidenceDrawerOpen(false)}
+                workspaceId={effectiveWorkspaceId}
+                workspaces={workspaces}
+                onWorkspaceChange={(nextWorkspaceId) => {
+                  setUserSelectedWorkspaceId(nextWorkspaceId);
+                  setQaIndexedWebSources([]);
+                  setQaMessages([]);
+                  setQaInput("");
+                  setQaError(null);
+                }}
+                embeddingDeploymentId={
+                  latestRagJob?.embeddingDeploymentId
+                  || (ragMetadata as any)?.embeddingDeploymentId
+                  || selectedEmbeddingOption?.deploymentId
+                }
+                value={qaIndexedWebSources}
+                maxSelectedSources={qaIndexedWebCapabilities?.maxSelectedSources}
+                capabilities={qaIndexedWebCapabilities}
+                capabilitiesLoading={qaIndexedWebCapabilitiesLoading}
+                capabilitiesError={qaIndexedWebCapabilitiesError}
+                disabled={qaSending}
+                onChange={(sources) => {
+                  if (JSON.stringify(sources) === JSON.stringify(qaIndexedWebSources)) return;
+                  setQaIndexedWebSources(sources);
+                  setQaMessages([]);
+                  setQaInput("");
+                  setQaError(null);
+                }}
+              />
               {/* Chat messages list */}
               <Box sx={{ flex: 1, minHeight: 0, position: "relative", display: "flex", flexDirection: "column" }}>
                 <Box
@@ -4653,6 +4723,30 @@ export function FileDetailDialog({ open, attachmentId, onClose }: Props) {
                   >
                     {/* Controls on left */}
                     <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap">
+                      <Tooltip title="Add Context (자료 추가)">
+                        <IconButton
+                          size="small"
+                          onClick={() => setEvidenceDrawerOpen(true)}
+                          sx={{
+                            width: 30,
+                            height: 30,
+                            borderRadius: "50%",
+                            bgcolor: (theme) =>
+                              theme.palette.mode === "dark"
+                                ? "rgba(255, 255, 255, 0.12)"
+                                : "rgba(0, 0, 0, 0.08)",
+                            color: "text.primary",
+                            "&:hover": {
+                              bgcolor: (theme) =>
+                                theme.palette.mode === "dark"
+                                  ? "rgba(255, 255, 255, 0.2)"
+                                  : "rgba(0, 0, 0, 0.14)",
+                            },
+                          }}
+                        >
+                          <AddOutlined fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
                       <AiProviderSelect
                         provider={qaProvider}
                         model={qaModel}

--- a/src/react/pages/workspaces/WorkspaceFilesPanel.tsx
+++ b/src/react/pages/workspaces/WorkspaceFilesPanel.tsx
@@ -492,6 +492,7 @@ export function WorkspaceFilesPanel({ workspaceId, archived = false }: Props) {
       <FileDetailDialog
         open={selectedAttachmentId !== null}
         attachmentId={selectedAttachmentId || 0}
+        workspaceId={workspaceId}
         onClose={() => setSelectedAttachmentId(null)}
       />
     </Stack>

--- a/src/types/studio/ai.ts
+++ b/src/types/studio/ai.ts
@@ -67,7 +67,10 @@ export interface ChatResponseMetadataDto {
   ragReferences?: RagReferenceDto[];
   canonicalContent?: string;
   answerPolicy?: ResolvedRagAnswerPolicyDto;
+  sourcePolicy?: ResolvedRagSourcePolicyDto;
+  externalSourceReview?: ExternalSourceReviewDto;
   answerPolicyValidationStatus?: string;
+  ragAnswerOutcome?: RagAnswerOutcomeDto;
   [key: string]: unknown;
 }
 
@@ -90,10 +93,91 @@ export interface RagAnswerPolicyCapabilitiesDto {
   availableModes: RagAnswerMode[];
 }
 
+export type RagSourceScope = "DOCUMENT_ONLY" | "DOCUMENT_AND_OFFICIAL_EXTERNAL";
+
+export interface ResolvedRagSourcePolicyDto {
+  requestedScope?: RagSourceScope | null;
+  effectiveScope: RagSourceScope;
+  source: "SERVER_DEFAULT" | "REQUEST";
+  clamped: boolean;
+  reasonCode:
+    | "NONE"
+    | "SERVER_MAXIMUM"
+    | "CLIENT_SELECTION_DISABLED"
+    | "EXTERNAL_PROVIDER_UNAVAILABLE"
+    | string;
+  policyVersion: string;
+}
+
+export interface RagSourcePolicyCapabilitiesDto {
+  defaultScope: RagSourceScope;
+  maximumScope: RagSourceScope;
+  clientSelectionEnabled: boolean;
+  externalProviderAvailable: boolean;
+  policyVersion: string;
+  availableScopes: RagSourceScope[];
+}
+
+export interface RagChatCapabilitiesDto {
+  answerPolicy: RagAnswerPolicyCapabilitiesDto;
+  sourcePolicy: RagSourcePolicyCapabilitiesDto;
+  indexedWeb: IndexedWebCapabilitiesDto;
+}
+
+export interface IndexedWebCapabilitiesDto {
+  enabled: boolean;
+  maxSelectedSources: number;
+  supportedSchemes: string[];
+  maxUrlLength: number;
+}
+
+export interface IndexedWebSourceRefDto {
+  sourceId: string;
+  revisionId: string;
+}
+
+export interface WebKnowledgeSourceDto {
+  sourceId: string;
+  workspaceId: number;
+  url: string;
+  canonicalUrl?: string | null;
+  host: string;
+  displayName?: string | null;
+  embeddingDeploymentId: string;
+  embeddingSpaceId?: string | null;
+  status: "PENDING" | "FETCHING" | "NORMALIZING" | "INDEXING" | "COMPLETED" | "UNCHANGED" | "FAILED" | "CANCELLED" | string;
+  currentRevisionId?: string | null;
+  revisionStatus?: string | null;
+  title?: string | null;
+  publisher?: string | null;
+  language?: string | null;
+  publishedAt?: string | null;
+  modifiedAt?: string | null;
+  retrievedAt?: string | null;
+  contentPreview?: string | null;
+  errorCode?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WebKnowledgeSourceCreateRequest {
+  url: string;
+  displayName?: string;
+  embeddingDeploymentId: string;
+}
+
+export interface ExternalSourceReviewDto {
+  status: "NOT_REQUESTED" | "COMPLETE" | "NO_RESULTS" | "UNAVAILABLE" | "FAILED" | string;
+  reasonCode: string;
+  evidenceCount: number;
+}
+
 export interface RagReferenceDto {
   index?: number;
   citationIndex?: number;
   evidenceId?: string;
+  usageStatus?: "CITED" | "RETRIEVED_ONLY";
+  locator?: string;
   documentId?: string;
   revisionId?: string;
   sourceName?: string;
@@ -116,6 +200,13 @@ export interface RagReferenceDto {
   heading?: string;
   evidenceKind?: string;
   supportStatus?: "SOURCE_VERIFIED" | "INFERRED" | "INDEX_VALID" | string;
+  origin?: "DOCUMENT" | "INDEXED_WEB" | "OFFICIAL_EXTERNAL";
+  sourceType?: "NORMALIZED_CHUNK" | "STATUTE" | "CASE" | "GOVERNMENT" | "ACADEMIC" | "OFFICIAL" | string;
+  publisher?: string;
+  canonicalUrl?: string;
+  publishedDate?: string;
+  effectiveDate?: string;
+  retrievedAt?: string;
   startOffset?: number;
   endOffset?: number;
   truncated?: boolean;
@@ -134,6 +225,37 @@ export interface RagReferenceDto {
     blockIds?: string[];
   }>;
   metadata?: Record<string, unknown>;
+}
+
+export type RagAnswerOutcomeType = "ANSWERED" | "EVIDENCE_ONLY" | "ABSTAINED";
+export type RagAnswerOutcomeStage = "NONE" | "RETRIEVAL" | "PACKING" | "VALIDATION" | "GENERATION";
+export type RagAnswerOutcomeReasonCode =
+  | "NONE"
+  | "NO_RETRIEVAL_RESULTS"
+  | "NO_PACKED_EVIDENCE"
+  | "EMPTY_DRAFT"
+  | "MISSING_CITATION"
+  | "OUT_OF_RANGE_CITATION"
+  | "MISSING_UNIT_CITATION"
+  | "MISSING_COMPARISON_SOURCE_CITATION"
+  | "INSUFFICIENT_SOURCE_COVERAGE"
+  | "NO_USABLE_SOURCE_SPAN";
+
+export interface RagAnswerOutcomeDto {
+  type: RagAnswerOutcomeType;
+  stage: RagAnswerOutcomeStage;
+  reasonCode: RagAnswerOutcomeReasonCode;
+  retrievedResultCount: number;
+  acceptedResultCount: number;
+  packedEvidenceCount: number;
+  usedEvidenceIndexes: number[];
+  citationValidationStatus: string;
+  policyValidationStatus: string;
+  validationUnitCount: number;
+  citedValidationUnitCount: number;
+  partial?: boolean;
+  originalValidationUnitCount?: number;
+  omittedValidationUnitCount?: number;
 }
 
 export interface ChatRagRequestDto {
@@ -159,6 +281,13 @@ export interface ChatRagRequestDto {
     includeDebugChunks?: boolean;
   };
   answerMode?: RagAnswerMode;
+  sourceScope?: RagSourceScope;
+  externalSourceOptions?: {
+    jurisdiction?: string;
+    asOfDate?: string;
+    language?: string;
+  };
+  indexedWebSources?: IndexedWebSourceRefDto[];
 }
 
 export interface TokenUsageDto {


### PR DESCRIPTION
## Why

외부 URL RAG 수집·색인 참고자료 기능의 클라이언트 노출 및 사용성을 대폭 개선합니다.

## What

- `+` (자료 추가) 버튼을 질문 입력창 하단 모델 선택 버튼 바로 앞으로 배치하고 `Add Context` 팝오버 메뉴 연결
- 참고자료 수집/선택 관리를 우측 Drawer에서 화면 중앙 레이어 팝업 Modal(Dialog) 형태로 전환
- RAG 컨트롤 pill 순서 정리 (`+ | gemini-2.5-flash | 문서 직접 근거만 | 첨부문서만 | (임베딩 : gemini-embedding-2)`)
- canonical `embeddingDeploymentId` 일치 및 fallback 제거, 에러 코드 한글화 및 권한/상태 세분화 처리
- `RagChatPage` 및 `FileDetailDialog` 공통 참고자료 연동 및 대화/선택 초기화 처리

## Related Issues

- N/A (새로운 기능 사용성 개선 요청으로 별도 Issue 없이 진행)

## Validation

- Command: `npm run typecheck`
- Result: PASS (0 errors)
- Command: `npm test -- --run`
- Result: PASS (7 files, 23 tests 100% pass)
- Command: `npm run build`
- Result: PASS (Vite production build success)

## Risk / Rollback

- Risk: RAG 요청 시 선택된 웹 참고자료(`indexedWebSources`) 및 deployment ID 검증 강화로 인한 잘못된 수집 요청 차단
- Rollback: `git revert` 및 이전 `2.x` 커밋으로 롤백 가능

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 단위 테스트, 타입체크, 빌드 검증 수행

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included