### PR TITLE
RAG 답변 프레젠테이션과 웹 소스 정책 보존 개선

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 2026-08-03
+
+### Changed
+
+- RAG 채팅과 첨부 상세 Q&A에 `자동 구성 | 텍스트 중심 | 시각 자료 우선` 선택을 추가하고, 질문에서
+  명시한 표·차트 형식 요청은 서버 grounding 정책을 유지한 채 우선 적용한다.
+- canonical 답변의 GFM 표와 행별 근거 링크를 표시하고, 서버가 검증된 숫자 표에서 투영한 bounded
+  차트만 렌더링한다. 각 표 우측 상단에 마우스를 올리면 나타나는 버튼으로 인용 번호를 포함한 표
+  내용을 탭 구분 형식으로 복사할 수 있다. 인용된 PDF page의 `SOURCE_IMAGE`는 canonical
+  fingerprint가 일치하고 서버가 발급한 동일
+  출처 경로일 때만 표시한다. 모델이 만든 외부 링크·이미지·HTML/SVG는 활성화하지 않는다.
+
+### Fixed
+
+- SITE 웹 자료의 옵션 수정 화면을 서버가 반환한 저장 `crawlPolicy`로 초기화한다. 기존처럼
+  capabilities 기본값으로 덮어써 다음 재수집의 깊이·페이지 수와 경로 필터가 의도치 않게 바뀌는
+  문제를 수정했다.
+
+### Verification
+
+- `npm test -- --run src/react/pages/ai/components/RagEvidenceSourcePicker.test.tsx` 통과
+- `npm test -- --run src/react/pages/ai/components/RagMarkdownRenderer.test.tsx src/react/pages/ai/components/RagAnswerPresentationSelector.test.tsx src/react/pages/ai/components/RagAnswerBlocks.test.tsx` 통과
+- `npm run typecheck` 통과
+- 전체 Vitest 43건과 production build 통과
+- `npm audit --omit=dev`는 기존 `react-router` 및 `epubjs`/`xmldom` 계열 4건 때문에 실패하며,
+  breaking downgrade/major upgrade가 필요한 별도 의존성 정비 항목으로 남긴다.
+
 ## 2026-07-27
 
 ### Changed

--- a/dist/index.html
+++ b/dist/index.html
@@ -11,12 +11,15 @@
       href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
     <title>Data Studio</title>
-    <script type="module" crossorigin src="/assets/index-CnfRVkvj.js"></script>
-    <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-B1FJdls4.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-sN8qgNb1.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-mui-BoSQDpyP.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-ag-grid-CLgOg88W.js">
-    <link rel="modulepreload" crossorigin href="/assets/store-B7Dzq3n5.js">
+    <script type="module" crossorigin src="/assets/index-vaEGQYc4.js"></script>
+    <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-QTnfLwEv.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-Cp9NpW9-.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-ag-grid-B9SDGjeJ.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-mui-2UhacO39.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-uppy-DI4iQNcf.js">
+    <link rel="stylesheet" crossorigin href="/assets/vendor-ClQbWekD.css">
+    <link rel="stylesheet" crossorigin href="/assets/vendor-uppy-CXg8fkUx.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-LKlVcGSw.css">
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
                 "react-router-dom": "^7.18.1",
                 "rehype-katex": "^7.0.1",
                 "rehype-sanitize": "^6.0.0",
+                "remark-gfm": "^4.0.1",
                 "remark-math": "^6.0.0",
                 "sockjs-client": "^1.6.1",
                 "yup": "^1.7.1",
@@ -6210,6 +6211,16 @@
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
+        "node_modules/markdown-table": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/marks-pane": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/marks-pane/-/marks-pane-1.0.9.tgz",
@@ -6223,6 +6234,34 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+            "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "escape-string-regexp": "^5.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/mdast-util-from-markdown": {
@@ -6243,6 +6282,107 @@
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0",
                 "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+            "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+            "license": "MIT",
+            "dependencies": {
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-gfm-autolink-literal": "^2.0.0",
+                "mdast-util-gfm-footnote": "^2.0.0",
+                "mdast-util-gfm-strikethrough": "^2.0.0",
+                "mdast-util-gfm-table": "^2.0.0",
+                "mdast-util-gfm-task-list-item": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-autolink-literal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+            "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "ccount": "^2.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-find-and-replace": "^3.0.0",
+                "micromark-util-character": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-footnote": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.1.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-strikethrough": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+            "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-table": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+            "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "markdown-table": "^3.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-task-list-item": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+            "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -6471,6 +6611,127 @@
                 "micromark-util-subtokenize": "^2.0.0",
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-gfm": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+            "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+            "license": "MIT",
+            "dependencies": {
+                "micromark-extension-gfm-autolink-literal": "^2.0.0",
+                "micromark-extension-gfm-footnote": "^2.0.0",
+                "micromark-extension-gfm-strikethrough": "^2.0.0",
+                "micromark-extension-gfm-table": "^2.0.0",
+                "micromark-extension-gfm-tagfilter": "^2.0.0",
+                "micromark-extension-gfm-task-list-item": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-autolink-literal": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+            "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-footnote": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-strikethrough": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+            "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-table": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+            "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-tagfilter": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+            "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-task-list-item": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+            "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/micromark-extension-math": {
@@ -7796,6 +8057,24 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/remark-gfm": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+            "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-gfm": "^3.0.0",
+                "micromark-extension-gfm": "^3.0.0",
+                "remark-parse": "^11.0.0",
+                "remark-stringify": "^11.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/remark-math": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
@@ -7839,6 +8118,21 @@
                 "mdast-util-to-hast": "^13.0.0",
                 "unified": "^11.0.0",
                 "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-stringify": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+            "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "react-router-dom": "^7.18.1",
         "rehype-katex": "^7.0.1",
         "rehype-sanitize": "^6.0.0",
+        "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "sockjs-client": "^1.6.1",
         "yup": "^1.7.1",

--- a/src/react/pages/ai/RagChatPage.tsx
+++ b/src/react/pages/ai/RagChatPage.tsx
@@ -24,6 +24,7 @@ import { ChatComposer } from "@/react/pages/ai/components/ChatComposer";
 import { ChatMessageList } from "@/react/pages/ai/components/ChatMessageList";
 import { AiProviderSelect } from "@/react/components/ai/AiProviderSelect";
 import { RagAnswerModeSelector } from "@/react/pages/ai/components/RagAnswerModeSelector";
+import { RagAnswerPresentationSelector } from "@/react/pages/ai/components/RagAnswerPresentationSelector";
 import { RagSourceScopeSelector } from "@/react/pages/ai/components/RagSourceScopeSelector";
 import { RagEvidenceSourceDrawer } from "@/react/pages/ai/components/RagEvidenceSourceDrawer";
 import { RagEvidenceSourceSummary } from "@/react/pages/ai/components/RagEvidenceSourceSummary";
@@ -38,6 +39,10 @@ import type {
   ProviderInfo,
   RagAnswerMode,
   RagAnswerPolicyCapabilitiesDto,
+  RagAnswerPresentationCapabilitiesDto,
+  RagAnswerPresentationPreference,
+  RagExternalRetrievalCapabilitiesDto,
+  RagExternalRetrievalMode,
   RagSourcePolicyCapabilitiesDto,
   RagSourceScope,
   TokenUsageDto,
@@ -88,8 +93,16 @@ export function RagChatPage() {
   const [systemPrompt, setSystemPrompt] = useState("");
   const [answerPolicy, setAnswerPolicy] = useState<RagAnswerPolicyCapabilitiesDto | null>(null);
   const [answerMode, setAnswerMode] = useState<RagAnswerMode | null>(null);
+  const [answerPresentation, setAnswerPresentation] =
+    useState<RagAnswerPresentationCapabilitiesDto | null>(null);
+  const [presentationPreference, setPresentationPreference] =
+    useState<RagAnswerPresentationPreference | null>(null);
   const [sourcePolicy, setSourcePolicy] = useState<RagSourcePolicyCapabilitiesDto | null>(null);
   const [sourceScope, setSourceScope] = useState<RagSourceScope | null>(null);
+  const [externalRetrieval, setExternalRetrieval] =
+    useState<RagExternalRetrievalCapabilitiesDto | null>(null);
+  const [externalRetrievalMode, setExternalRetrievalMode] =
+    useState<RagExternalRetrievalMode>("OFF");
   const [indexedWebCapabilities, setIndexedWebCapabilities] =
     useState<IndexedWebCapabilitiesDto | null>(null);
   const [indexedWebCapabilitiesLoading, setIndexedWebCapabilitiesLoading] = useState(true);
@@ -170,8 +183,12 @@ export function RagChatPage() {
       .then((capabilities) => {
         setAnswerPolicy(capabilities.answerPolicy);
         setAnswerMode(capabilities.answerPolicy.defaultMode);
+        setAnswerPresentation(capabilities.answerPresentation);
+        setPresentationPreference(capabilities.answerPresentation?.defaultPreference ?? "AUTO");
         setSourcePolicy(capabilities.sourcePolicy);
         setSourceScope(capabilities.sourcePolicy.defaultScope);
+        setExternalRetrieval(capabilities.externalRetrieval ?? null);
+        setExternalRetrievalMode(capabilities.externalRetrieval?.defaultMode ?? "OFF");
         setIndexedWebCapabilities(capabilities.indexedWeb);
         setIndexedWebCapabilitiesError(null);
       })
@@ -248,8 +265,8 @@ export function RagChatPage() {
     setSending(true);
     setError(null);
     setStreamStatus(
-      sourceScope === "DOCUMENT_AND_OFFICIAL_EXTERNAL"
-        ? "문서와 공식 외부 자료를 검색하고 있습니다."
+      externalRetrievalMode === "AUTO"
+        ? "문서 근거를 확인하고 필요하면 공식 외부 자료를 검색합니다."
         : "문서 근거를 검색하고 있습니다."
     );
     setInput("");
@@ -279,7 +296,9 @@ export function RagChatPage() {
         },
         debug,
         answerMode: answerMode ?? undefined,
+        presentation: presentationPreference ? { preference: presentationPreference } : undefined,
         sourceScope: sourceScope ?? undefined,
+        externalRetrievalMode,
         indexedWebSources: indexedWebSources.length > 0 ? toIndexedWebSourcePayload(indexedWebSources) : undefined,
       };
       if (selectedOption) {
@@ -300,12 +319,15 @@ export function RagChatPage() {
             setStreamStatus(`근거 ${count}건 검색 완료 · 답변을 생성하고 있습니다.`);
           } else if (streamPayload.stage === "generation_started") {
             setStreamStatus("근거를 바탕으로 답변을 생성하고 검증하고 있습니다.");
-          } else if (streamPayload.stage === "external_search") {
-            setStreamStatus("공식 외부 자료를 검색하고 출처를 확인하고 있습니다.");
+          } else if (
+            streamPayload.stage === "external_search" ||
+            streamPayload.stage === "external_search_complete"
+          ) {
+            setStreamStatus("필요한 공식 외부 자료 검색과 출처 확인을 완료했습니다.");
           } else {
             setStreamStatus(
-              sourceScope === "DOCUMENT_AND_OFFICIAL_EXTERNAL"
-                ? "문서와 공식 외부 자료를 검색하고 있습니다."
+              externalRetrievalMode === "AUTO"
+                ? "문서 근거를 확인하고 필요하면 공식 외부 자료를 검색합니다."
                 : "문서 근거를 검색하고 있습니다."
             );
           }
@@ -420,6 +442,15 @@ export function RagChatPage() {
     if (nextScope === sourceScope) return;
     handleNewConversation();
     setSourceScope(nextScope);
+    setExternalRetrievalMode(
+      nextScope === "DOCUMENT_AND_OFFICIAL_EXTERNAL" ? "AUTO" : "OFF"
+    );
+  }
+
+  function handlePresentationChange(nextPreference: RagAnswerPresentationPreference) {
+    if (nextPreference === presentationPreference) return;
+    handleNewConversation();
+    setPresentationPreference(nextPreference);
   }
 
   function handleIndexedWebSourcesChange(nextSources: IndexedWebSourceRefDto[]) {
@@ -562,8 +593,15 @@ export function RagChatPage() {
               disabled={sending}
               onChange={handleAnswerModeChange}
             />
+            <RagAnswerPresentationSelector
+              capabilities={answerPresentation}
+              value={presentationPreference}
+              disabled={sending}
+              onChange={handlePresentationChange}
+            />
             <RagSourceScopeSelector
               capabilities={sourcePolicy}
+              externalRetrievalCapabilities={externalRetrieval}
               value={sourceScope}
               disabled={sending}
               onChange={handleSourceScopeChange}
@@ -749,17 +787,22 @@ export function RagChatPage() {
                     setError(null);
                   }}
                 />
+                <RagAnswerPresentationSelector
+                  capabilities={answerPresentation}
+                  value={presentationPreference}
+                  disabled={sending}
+                  hideHelperText
+                  variant="compact-pill"
+                  onChange={handlePresentationChange}
+                />
                 <RagSourceScopeSelector
                   capabilities={sourcePolicy}
+                  externalRetrievalCapabilities={externalRetrieval}
                   value={sourceScope}
                   disabled={sending}
                   hideHelperText
                   variant="compact-pill"
-                  onChange={(scope) => {
-                    if (scope === sourceScope) return;
-                    setSourceScope(scope);
-                    setError(null);
-                  }}
+                  onChange={handleSourceScopeChange}
                 />
                 {selectedOption ? (
                   <Tooltip title="이 대화에 사용되는 RAG 임베딩 모델입니다">

--- a/src/react/pages/ai/components/AssistantMessageBubble.tsx
+++ b/src/react/pages/ai/components/AssistantMessageBubble.tsx
@@ -5,6 +5,7 @@ import type { ChatMessage, ChatResponseMetadataDto } from "@/react/pages/ai/comp
 import type { RagReferenceDto } from "@/types/studio/ai";
 import { deriveRagOutcome } from "@/react/pages/ai/components/ragOutcome";
 import { RagMarkdownRenderer } from "@/react/pages/ai/components/RagMarkdownRenderer";
+import { RagAnswerBlocks } from "@/react/pages/ai/components/RagAnswerBlocks";
 
 const numberFormatter = new Intl.NumberFormat("ko-KR");
 
@@ -364,6 +365,8 @@ export function AssistantMessageBubble({
   const ragReferences = getRagReferences(message.metadata);
   const answerPolicy = message.metadata?.answerPolicy;
   const sourcePolicy = message.metadata?.sourcePolicy;
+  const externalRetrieval = message.metadata?.externalRetrieval;
+  const answerPresentation = message.metadata?.answerPresentation;
   const outcomeView = deriveRagOutcome(message.metadata, sending);
   const citationsReady = outcomeView.citationsReady;
   const referencesVisible =
@@ -450,8 +453,43 @@ export function AssistantMessageBubble({
                 icon={<PublicOutlined sx={{ fontSize: 13 }} />}
                 label={
                   sourcePolicy.effectiveScope === "DOCUMENT_AND_OFFICIAL_EXTERNAL"
-                    ? "공식 외부 자료 참고"
+                    ? "외부 자료 검색 허용"
                     : "첨부 문서만"
+                }
+                sx={{ height: 18, fontSize: 10, fontWeight: 600 }}
+              />
+            </Tooltip>
+          ) : null}
+          {externalRetrieval?.effectiveMode === "AUTO" ? (
+            <Tooltip
+              title={
+                externalRetrieval.clamped
+                  ? `외부 조회 모드가 서버 정책에 의해 조정되었습니다. (${externalRetrieval.reasonCode})`
+                  : externalRetrieval.searched
+                    ? `외부 자료를 조회했습니다. (${externalRetrieval.decisionReasonCode})`
+                    : `내부 근거가 충분하여 외부 조회를 생략했습니다. (${externalRetrieval.decisionReasonCode})`
+              }
+            >
+              <Chip
+                size="small"
+                variant="outlined"
+                icon={<PublicOutlined sx={{ fontSize: 13 }} />}
+                label={externalRetrieval.searched ? "외부 검색 사용" : "외부 검색 생략"}
+                sx={{ height: 18, fontSize: 10, fontWeight: 600 }}
+              />
+            </Tooltip>
+          ) : null}
+          {answerPresentation?.effectivePreference ? (
+            <Tooltip title="서버가 실제 적용한 답변 구성 방식입니다.">
+              <Chip
+                size="small"
+                variant="outlined"
+                label={
+                  answerPresentation.effectivePreference === "VISUAL_PREFERRED"
+                    ? "시각 자료 우선"
+                    : answerPresentation.effectivePreference === "TEXT_FOCUSED"
+                      ? "텍스트 중심"
+                      : "자동 구성"
                 }
                 sx={{ height: 18, fontSize: 10, fontWeight: 600 }}
               />
@@ -478,6 +516,20 @@ export function AssistantMessageBubble({
           <Typography component="div" sx={{ fontSize: 14.5, lineHeight: 1.8 }}>
             응답 생성 중...
           </Typography>
+        ) : null}
+        {!sending ? (
+          <RagAnswerBlocks
+            document={message.metadata?.answerBlocks}
+            canonicalContent={message.metadata?.canonicalContent}
+            onCitationClick={
+              citationsReady
+                ? (indices, event) => {
+                    setSourceAnchorEl(event.currentTarget);
+                    setSelectedCitationIndices(indices);
+                  }
+                : undefined
+            }
+          />
         ) : null}
         {renderTokenUsage(message.metadata)}
         {renderRetrievalDebug(message.metadata)}

--- a/src/react/pages/ai/components/RagAnswerBlocks.test.tsx
+++ b/src/react/pages/ai/components/RagAnswerBlocks.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { createHash } from "node:crypto";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RagAnswerBlocks } from "./RagAnswerBlocks";
+
+describe("RagAnswerBlocks", () => {
+  it("renders only blocks bound to the canonical answer and preserves citation clicks", async () => {
+    const onCitationClick = vi.fn();
+    const canonicalContent = "검증된 canonical 답변";
+    render(
+      <RagAnswerBlocks
+        document={{
+          schemaVersion: "rag-answer-blocks-v1",
+          canonicalContentFingerprint: createHash("sha256").update(canonicalContent).digest("hex"),
+          blocks: [{
+            blockId: "chart-1",
+            type: "CHART",
+            chartType: "BAR",
+            title: "사건 수",
+            unit: "",
+            points: [
+              { label: "2024", value: 12, citationIndexes: [1] },
+              { label: "2025", value: 18, citationIndexes: [2] },
+            ],
+          }],
+        }}
+        canonicalContent={canonicalContent}
+        onCitationClick={onCitationClick}
+      />
+    );
+
+    expect(await screen.findByTestId("rag-answer-chart")).toBeTruthy();
+    expect(screen.getByText("사건 수")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "근거 2" }));
+    expect(onCitationClick).toHaveBeenCalledWith([2], expect.anything());
+  });
+
+  it("hides stale blocks whose fingerprint does not match canonical content", () => {
+    const { container } = render(
+      <RagAnswerBlocks
+        canonicalContent="new answer"
+        document={{
+          schemaVersion: "rag-answer-blocks-v1",
+          canonicalContentFingerprint: createHash("sha256").update("old answer").digest("hex"),
+          blocks: [{
+            blockId: "chart-stale",
+            type: "CHART",
+            chartType: "BAR",
+            title: "stale",
+            unit: "",
+            points: [{ label: "A", value: 1, citationIndexes: [1] }],
+          }],
+        }}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders only authorized same-origin source-image paths and links their citations", async () => {
+    const onCitationClick = vi.fn();
+    const canonicalContent = "PDF 근거가 포함된 답변 [3]";
+    render(
+      <RagAnswerBlocks
+        canonicalContent={canonicalContent}
+        onCitationClick={onCitationClick}
+        document={{
+          schemaVersion: "rag-answer-blocks-v1",
+          canonicalContentFingerprint: createHash("sha256").update(canonicalContent).digest("hex"),
+          blocks: [{
+            blockId: "source-image-1",
+            type: "SOURCE_IMAGE",
+            mediaType: "image/png",
+            src: "/api/ai/chat/rag/source-images/abcdefghijklmnopqrstuvwxyz012345",
+            alt: "검증된 PDF 근거 페이지",
+            page: 7,
+            citationIndexes: [3],
+          }],
+        }}
+      />
+    );
+
+    const image = await screen.findByRole("img", { name: "검증된 PDF 근거 페이지" });
+    expect(image.getAttribute("src")).toBe(
+      "/api/ai/chat/rag/source-images/abcdefghijklmnopqrstuvwxyz012345");
+    expect(image.getAttribute("referrerpolicy")).toBe("no-referrer");
+    expect(screen.getByText("원문 PDF 7페이지")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "근거 3" }));
+    expect(onCitationClick).toHaveBeenCalledWith([3], expect.anything());
+  });
+
+  it("rejects external and non-http source-image values", async () => {
+    const canonicalContent = "검증된 답변";
+    const fingerprint = createHash("sha256").update(canonicalContent).digest("hex");
+    const { container } = render(
+      <RagAnswerBlocks
+        canonicalContent={canonicalContent}
+        document={{
+          schemaVersion: "rag-answer-blocks-v1",
+          canonicalContentFingerprint: fingerprint,
+          blocks: [
+            {
+              blockId: "external",
+              type: "SOURCE_IMAGE",
+              mediaType: "image/png",
+              src: "https://attacker.example/image.png",
+              alt: "external",
+              page: 1,
+              citationIndexes: [1],
+            },
+            {
+              blockId: "script",
+              type: "SOURCE_IMAGE",
+              mediaType: "image/png",
+              src: "javascript:alert(1)",
+              alt: "script",
+              page: 1,
+              citationIndexes: [1],
+            },
+          ],
+        }}
+      />
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("ignores unknown schemas", () => {
+    const { container } = render(
+      <RagAnswerBlocks document={{ schemaVersion: "unknown", blocks: [] }} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/react/pages/ai/components/RagAnswerBlocks.tsx
+++ b/src/react/pages/ai/components/RagAnswerBlocks.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useState, type MouseEvent } from "react";
+import { alpha, Box, Button, Stack, Typography } from "@mui/material";
+import type {
+  RagAnswerBlocksDto,
+  RagAnswerChartBlockDto,
+  RagAnswerSourceImageBlockDto,
+} from "@/types/studio/ai";
+
+interface Props {
+  document?: RagAnswerBlocksDto;
+  canonicalContent?: string;
+  onCitationClick?: (indices: number[], event: MouseEvent<HTMLElement>) => void;
+}
+
+async function sha256(value: string) {
+  if (!globalThis.crypto?.subtle) return null;
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function validChart(block: unknown): block is RagAnswerChartBlockDto {
+  if (!block || typeof block !== "object") return false;
+  const candidate = block as RagAnswerChartBlockDto;
+  return candidate.type === "CHART"
+    && candidate.chartType === "BAR"
+    && typeof candidate.title === "string"
+    && Array.isArray(candidate.points)
+    && candidate.points.length > 0
+    && candidate.points.length <= 100
+    && candidate.points.every((point) =>
+      point
+      && typeof point.label === "string"
+      && point.label.length <= 2_000
+      && Number.isFinite(point.value)
+      && Array.isArray(point.citationIndexes));
+}
+
+const SOURCE_IMAGE_PATH = /^\/api\/ai\/chat\/rag\/source-images\/[A-Za-z0-9_-]{20,4096}$/;
+
+function validSourceImage(block: unknown): block is RagAnswerSourceImageBlockDto {
+  if (!block || typeof block !== "object") return false;
+  const candidate = block as RagAnswerSourceImageBlockDto;
+  return candidate.type === "SOURCE_IMAGE"
+    && candidate.mediaType === "image/png"
+    && typeof candidate.src === "string"
+    && SOURCE_IMAGE_PATH.test(candidate.src)
+    && typeof candidate.alt === "string"
+    && candidate.alt.length > 0
+    && candidate.alt.length <= 200
+    && Number.isInteger(candidate.page)
+    && candidate.page > 0
+    && Array.isArray(candidate.citationIndexes)
+    && candidate.citationIndexes.length <= 64
+    && candidate.citationIndexes.every((value) => Number.isInteger(value) && value > 0);
+}
+
+function BoundedBarChart({
+  block,
+  onCitationClick,
+}: {
+  block: RagAnswerChartBlockDto;
+  onCitationClick?: Props["onCitationClick"];
+}) {
+  const absoluteMaximum = Math.max(...block.points.map((point) => Math.abs(point.value)), 1);
+
+  return (
+    <Box
+      data-testid="rag-answer-chart"
+      sx={{
+        mt: 1.5,
+        p: 1.5,
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 1.5,
+        bgcolor: (theme) => alpha(theme.palette.primary.main, 0.025),
+      }}
+    >
+      <Typography variant="subtitle2" fontWeight={800} sx={{ mb: 1.25 }}>
+        {block.title}
+      </Typography>
+      <Stack spacing={1}>
+        {block.points.map((point, index) => {
+          const width = Math.max(2, Math.min(100, Math.abs(point.value) / absoluteMaximum * 100));
+          const citations = point.citationIndexes.filter((value) => Number.isInteger(value) && value > 0);
+          return (
+            <Box key={`${block.blockId}-${point.label}-${index}`}>
+              <Stack direction="row" justifyContent="space-between" spacing={1} alignItems="baseline">
+                <Typography variant="caption" sx={{ fontWeight: 650, overflowWrap: "anywhere" }}>
+                  {point.label}
+                </Typography>
+                <Stack direction="row" spacing={0.5} alignItems="center">
+                  <Typography variant="caption" sx={{ fontVariantNumeric: "tabular-nums" }}>
+                    {point.value.toLocaleString()}{block.unit}
+                  </Typography>
+                  {citations.length > 0 ? (
+                    <Button
+                      size="small"
+                      aria-label={`근거 ${citations.join(", ")}`}
+                      onClick={(event) => onCitationClick?.(citations, event)}
+                      sx={{ minWidth: 0, px: 0.5, py: 0, fontSize: 10, fontWeight: 800 }}
+                    >
+                      [{citations.join(", ")}]
+                    </Button>
+                  ) : null}
+                </Stack>
+              </Stack>
+              <Box sx={{ mt: 0.4, height: 8, borderRadius: 4, bgcolor: "action.hover", overflow: "hidden" }}>
+                <Box
+                  sx={{
+                    width: `${width}%`,
+                    height: "100%",
+                    borderRadius: 4,
+                    bgcolor: point.value < 0 ? "error.main" : "primary.main",
+                  }}
+                />
+              </Box>
+            </Box>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}
+
+function SourceImageBlock({
+  block,
+  onCitationClick,
+}: {
+  block: RagAnswerSourceImageBlockDto;
+  onCitationClick?: Props["onCitationClick"];
+}) {
+  const [failed, setFailed] = useState(false);
+  if (failed) return null;
+
+  return (
+    <Box
+      data-testid="rag-source-image"
+      sx={{
+        mt: 1.5,
+        overflow: "hidden",
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 1.5,
+        bgcolor: "background.paper",
+      }}
+    >
+      <Box
+        component="img"
+        src={block.src}
+        alt={block.alt}
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        onError={() => setFailed(true)}
+        sx={{ display: "block", width: "100%", height: "auto", maxHeight: 720, objectFit: "contain" }}
+      />
+      <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1} sx={{ p: 1 }}>
+        <Typography variant="caption" color="text.secondary">
+          원문 PDF {block.page}페이지
+        </Typography>
+        {block.citationIndexes.length > 0 ? (
+          <Button
+            size="small"
+            aria-label={`근거 ${block.citationIndexes.join(", ")}`}
+            onClick={(event) => onCitationClick?.(block.citationIndexes, event)}
+            sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: 10, fontWeight: 800 }}
+          >
+            [{block.citationIndexes.join(", ")}]
+          </Button>
+        ) : null}
+      </Stack>
+    </Box>
+  );
+}
+
+export function RagAnswerBlocks({ document, canonicalContent, onCitationClick }: Props) {
+  const [fingerprintValid, setFingerprintValid] = useState(false);
+  useEffect(() => {
+    let active = true;
+    setFingerprintValid(false);
+    const expected = document?.canonicalContentFingerprint;
+    if (!expected || typeof canonicalContent !== "string") return () => { active = false; };
+    void sha256(canonicalContent).then((actual) => {
+      if (active) setFingerprintValid(actual === expected.toLowerCase());
+    });
+    return () => { active = false; };
+  }, [canonicalContent, document?.canonicalContentFingerprint]);
+
+  if (document?.schemaVersion !== "rag-answer-blocks-v1" || !Array.isArray(document.blocks)) {
+    return null;
+  }
+  if (!fingerprintValid) return null;
+  const charts = document.blocks.filter(validChart);
+  const sourceImages = document.blocks.filter(validSourceImage);
+  if (charts.length === 0 && sourceImages.length === 0) return null;
+
+  return (
+    <Stack spacing={1}>
+      {charts.map((chart) => (
+        <BoundedBarChart key={chart.blockId} block={chart} onCitationClick={onCitationClick} />
+      ))}
+      {sourceImages.map((sourceImage) => (
+        <SourceImageBlock
+          key={sourceImage.blockId}
+          block={sourceImage}
+          onCitationClick={onCitationClick}
+        />
+      ))}
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/components/RagAnswerPresentationSelector.test.tsx
+++ b/src/react/pages/ai/components/RagAnswerPresentationSelector.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RagAnswerPresentationSelector } from "./RagAnswerPresentationSelector";
+
+const capabilities = {
+  enabled: true,
+  defaultPreference: "AUTO" as const,
+  clientSelectionEnabled: true,
+  policyVersion: "rag-answer-presentation-v1:test",
+  availablePreferences: ["AUTO", "TEXT_FOCUSED", "VISUAL_PREFERRED"] as const,
+  allowedBlockTypes: ["MARKDOWN", "TABLE"],
+};
+
+describe("RagAnswerPresentationSelector", () => {
+  it("shows the server options and reports the selected preference", () => {
+    const onChange = vi.fn();
+    render(
+      <RagAnswerPresentationSelector
+        capabilities={{ ...capabilities, availablePreferences: [...capabilities.availablePreferences] }}
+        value="AUTO"
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "시각 자료 우선" }));
+    expect(onChange).toHaveBeenCalledWith("VISUAL_PREFERRED");
+    expect(screen.getByText(/검색 범위와 근거 규칙은 바뀌지 않습니다/)).toBeTruthy();
+  });
+});

--- a/src/react/pages/ai/components/RagAnswerPresentationSelector.tsx
+++ b/src/react/pages/ai/components/RagAnswerPresentationSelector.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { Box, Button, Menu, MenuItem, Stack, TextField, Typography } from "@mui/material";
+import { CheckOutlined, ExpandMoreOutlined } from "@mui/icons-material";
+import type {
+  RagAnswerPresentationCapabilitiesDto,
+  RagAnswerPresentationPreference,
+} from "@/types/studio/ai";
+
+interface Props {
+  capabilities: RagAnswerPresentationCapabilitiesDto | null;
+  value: RagAnswerPresentationPreference | null;
+  onChange: (preference: RagAnswerPresentationPreference) => void;
+  disabled?: boolean;
+  hideHelperText?: boolean;
+  variant?: "standard" | "compact-pill";
+}
+
+const labels: Record<RagAnswerPresentationPreference, string> = {
+  AUTO: "자동 구성",
+  TEXT_FOCUSED: "텍스트 중심",
+  VISUAL_PREFERRED: "시각 자료 우선",
+};
+
+const descriptions: Record<RagAnswerPresentationPreference, string> = {
+  AUTO: "질문과 근거에 맞춰 문단, 목록 또는 표를 선택합니다.",
+  TEXT_FOCUSED: "간결한 문단과 목록을 우선합니다.",
+  VISUAL_PREFERRED: "근거가 충분하면 표처럼 비교하기 쉬운 구성을 우선합니다.",
+};
+
+export function RagAnswerPresentationSelector({
+  capabilities,
+  value,
+  onChange,
+  disabled,
+  hideHelperText,
+  variant = "standard",
+}: Props) {
+  const preferences = capabilities?.availablePreferences ?? [];
+  const selected = capabilities && !capabilities.clientSelectionEnabled
+    ? capabilities.defaultPreference
+    : value ?? capabilities?.defaultPreference ?? "";
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  if (variant === "compact-pill") {
+    return (
+      <>
+        <Button
+          size="small"
+          disabled={disabled || !capabilities?.enabled || !capabilities.clientSelectionEnabled}
+          onClick={(event) => setAnchorEl(event.currentTarget)}
+          endIcon={<ExpandMoreOutlined sx={{ fontSize: 16, color: "text.secondary" }} />}
+          sx={{
+            textTransform: "none",
+            fontWeight: 500,
+            fontSize: 12.5,
+            color: "text.secondary",
+            px: 1,
+            py: 0.3,
+            borderRadius: "16px",
+            "&:hover": { bgcolor: "action.hover", color: "text.primary" },
+          }}
+        >
+          {selected ? labels[selected as RagAnswerPresentationPreference] : "답변 구성"}
+        </Button>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
+          <Box sx={{ px: 2, py: 1, borderBottom: "1px solid", borderColor: "divider" }}>
+            <Typography variant="caption" color="text.secondary" fontWeight={700}>
+              답변 구성 방식
+            </Typography>
+          </Box>
+          {preferences.map((preference) => {
+            const isSelected = preference === selected;
+            return (
+              <MenuItem
+                key={preference}
+                selected={isSelected}
+                onClick={() => {
+                  onChange(preference);
+                  setAnchorEl(null);
+                }}
+                sx={{ py: 1.2, px: 2, minWidth: 300 }}
+              >
+                <Stack spacing={0.25} sx={{ width: "100%" }}>
+                  <Stack direction="row" justifyContent="space-between" alignItems="center">
+                    <Typography variant="body2" fontWeight={isSelected ? 700 : 500}>
+                      {labels[preference]}
+                    </Typography>
+                    {isSelected ? <CheckOutlined fontSize="small" color="primary" /> : null}
+                  </Stack>
+                  <Typography variant="caption" color="text.secondary">
+                    {descriptions[preference]}
+                  </Typography>
+                </Stack>
+              </MenuItem>
+            );
+          })}
+        </Menu>
+      </>
+    );
+  }
+
+  return (
+    <Stack spacing={0.5}>
+      <TextField
+        select
+        label="답변 구성 방식"
+        size="small"
+        value={selected}
+        disabled={disabled || !capabilities?.enabled || !capabilities.clientSelectionEnabled}
+        onChange={(event) => onChange(event.target.value as RagAnswerPresentationPreference)}
+        helperText={selected ? descriptions[selected as RagAnswerPresentationPreference] : "서버 기능을 확인하고 있습니다."}
+        fullWidth
+      >
+        {preferences.map((preference) => (
+          <MenuItem key={preference} value={preference}>{labels[preference]}</MenuItem>
+        ))}
+      </TextField>
+      {!hideHelperText ? (
+        <Typography variant="caption" color="text.secondary">
+          질문에서 “표로 정리해줘”처럼 형식을 명시하면 그 요청을 우선합니다. 검색 범위와 근거 규칙은 바뀌지 않습니다.
+        </Typography>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/react/pages/ai/components/RagEvidenceSourcePicker.test.tsx
+++ b/src/react/pages/ai/components/RagEvidenceSourcePicker.test.tsx
@@ -118,6 +118,65 @@ describe("RagEvidenceSourcePicker", () => {
     expect(screen.getByText(/하위 페이지 포함/i)).toBeDefined();
   });
 
+  it("initializes the SITE policy editor from the saved source policy", async () => {
+    listWebKnowledgeSources.mockResolvedValue([
+      {
+        sourceId: "wsrc-site-policy",
+        workspaceId: 2,
+        url: "https://example.org/docs/",
+        host: "example.org",
+        displayName: "저장 정책 자료",
+        embeddingDeploymentId: "embedding-default",
+        status: "COMPLETED",
+        collectionMode: "SITE",
+        currentCorpusRevisionId: "wcorpus-policy",
+        crawlPolicy: {
+          scope: "SAME_ORIGIN",
+          discoveryMode: "LINKS_ONLY",
+          maxDepth: 1,
+          maxPages: 10,
+          maxConcurrency: 2,
+          minDelayPerOriginMillis: 500,
+          dropAllQuery: true,
+          includePathGlobs: ["/docs/**", "/guide/**"],
+          excludePathGlobs: ["/archive/**"],
+          allowedQueryKeys: [],
+          policyVersion: "web-crawl-policy-v1",
+        },
+        createdAt: "2026-08-03T00:00:00Z",
+        updatedAt: "2026-08-03T00:00:00Z",
+      },
+    ]);
+
+    render(
+      <RagEvidenceSourcePicker
+        workspaceId={2}
+        embeddingDeploymentId="embedding-default"
+        capabilities={{
+          enabled: true,
+          siteCrawlEnabled: true,
+          maxSelectedSources: 10,
+          supportedSchemes: ["https"],
+          maxUrlLength: 2048,
+          defaultMaxDepth: 2,
+          defaultMaxPages: 50,
+        }}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    );
+
+    await screen.findByText("저장 정책 자료");
+    fireEvent.click(screen.getByRole("button", { name: "옵션 수정" }));
+
+    expect((await screen.findByLabelText("최대 깊이") as HTMLInputElement).value).toBe("1");
+    expect((screen.getByLabelText("최대 페이지 수") as HTMLInputElement).value).toBe("10");
+    const includeInputs = screen.getAllByLabelText(/포함 패턴/);
+    const excludeInputs = screen.getAllByLabelText(/제외 패턴/);
+    expect((includeInputs.at(-1) as HTMLInputElement).value).toBe("/docs/**, /guide/**");
+    expect((excludeInputs.at(-1) as HTMLInputElement).value).toBe("/archive/**");
+  });
+
   it("triggers preview and opens preview modal on SITE preview click", async () => {
     listWebKnowledgeSources.mockResolvedValue([]);
     previewWebKnowledgeSource.mockResolvedValue({

--- a/src/react/pages/ai/components/RagEvidenceSourcePicker.tsx
+++ b/src/react/pages/ai/components/RagEvidenceSourcePicker.tsx
@@ -347,13 +347,13 @@ export function RagEvidenceSourcePicker({
     setDetailTab("runs");
     setPolicyEditNotice(null);
 
-    // Populate policy edit state for existing source
-    setEditScope("PATH_PREFIX");
-    setEditDiscoveryMode("SITEMAP_AND_LINKS");
-    setEditMaxDepth(capabilities?.defaultMaxDepth ?? 2);
-    setEditMaxPages(capabilities?.defaultMaxPages ?? 50);
-    setEditIncludeGlobs("");
-    setEditExcludeGlobs("");
+    const savedPolicy = source.crawlPolicy;
+    setEditScope(savedPolicy?.scope ?? "PATH_PREFIX");
+    setEditDiscoveryMode(savedPolicy?.discoveryMode ?? "SITEMAP_AND_LINKS");
+    setEditMaxDepth(savedPolicy?.maxDepth ?? capabilities?.defaultMaxDepth ?? 2);
+    setEditMaxPages(savedPolicy?.maxPages ?? capabilities?.defaultMaxPages ?? 50);
+    setEditIncludeGlobs((savedPolicy?.includePathGlobs ?? []).join(", "));
+    setEditExcludeGlobs((savedPolicy?.excludePathGlobs ?? []).join(", "));
 
     if (!workspaceId) return;
     try {

--- a/src/react/pages/ai/components/RagMarkdownRenderer.test.tsx
+++ b/src/react/pages/ai/components/RagMarkdownRenderer.test.tsx
@@ -65,6 +65,69 @@ describe("RagMarkdownRenderer", () => {
       />
     );
 
-    expect(container.querySelector("a")?.getAttribute("href")).toBeNull();
+    expect(container.querySelector("a")).toBeNull();
+    expect(within(container).getByText("위험 링크")).toBeTruthy();
+  });
+
+  it("renders a GFM table, copies it as tab-separated text, and keeps citations interactive", async () => {
+    const onCitationClick = vi.fn();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(
+      <RagMarkdownRenderer
+        content={"| 학자 | 관련 내용 |\n| --- | --- |\n| 니컬러스 P. 머니 | 진균학자 [1] |\n| 로베르트 레마크 | 백선증 연구 [2] |"}
+        references={[
+          { index: 1, title: "진균의 역사" },
+          { index: 2, title: "진균의 역사" },
+        ]}
+        onCitationClick={onCitationClick}
+      />
+    );
+
+    const table = screen.getByRole("table");
+    expect(table).toBeTruthy();
+    expect(within(table).getAllByRole("row")).toHaveLength(3);
+    fireEvent.click(within(table).getByRole("button", { name: "근거 2" }));
+    expect(onCitationClick).toHaveBeenCalledWith([2], expect.anything());
+
+    fireEvent.click(screen.getByRole("button", { name: "표 복사" }));
+    expect(writeText).toHaveBeenCalledWith(
+      "학자\t관련 내용\n니컬러스 P. 머니\t진균학자 [1]\n로베르트 레마크\t백선증 연구 [2]"
+    );
+    expect(await screen.findByRole("button", { name: "표 복사 완료" })).toBeTruthy();
+  });
+
+  it("does not activate model-authored external links or images", () => {
+    const { container } = render(
+      <RagMarkdownRenderer
+        content={"[외부 링크](https://example.com)\n\n![차트](https://example.com/chart.png)"}
+        references={[]}
+      />
+    );
+
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+    expect(within(container).getByText("외부 링크")).toBeTruthy();
+    expect(within(container).getByText("[이미지: 차트]")).toBeTruthy();
+  });
+
+  it("does not promote a model-authored citation target with a non-citation label", () => {
+    const { container } = render(
+      <RagMarkdownRenderer
+        content={"[중요 근거](#rag-citation-1)"}
+        references={[{ index: 1, title: "문서" }]}
+      />
+    );
+
+    expect(within(container).queryByRole("button", { name: "근거 1" })).toBeNull();
+    expect(within(container).getByText("중요 근거")).toBeTruthy();
+  });
+
+  it("falls back to plain text when the rich markdown budget is exceeded", () => {
+    render(<RagMarkdownRenderer content={"a".repeat(32_001)} references={[]} />);
+    expect(screen.getByTestId("rag-markdown-plain-fallback")).toBeTruthy();
   });
 });

--- a/src/react/pages/ai/components/RagMarkdownRenderer.tsx
+++ b/src/react/pages/ai/components/RagMarkdownRenderer.tsx
@@ -1,14 +1,17 @@
-import type { MouseEvent, ReactNode } from "react";
-import { alpha, Box, Tooltip, Typography } from "@mui/material";
+import { useEffect, useRef, useState, type MouseEvent, type ReactNode } from "react";
+import { CheckOutlined, ContentCopyOutlined } from "@mui/icons-material";
+import { alpha, Box, IconButton, Tooltip, Typography } from "@mui/material";
 import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import rehypeSanitize from "rehype-sanitize";
+import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import "katex/dist/katex.min.css";
 
 const CITATION_PATTERN = /\[(\d+(?:\s*,\s*\d+)*)\]/g;
 const CITATION_TARGET = "#rag-citation-";
 const FENCE_PATTERN = /^\s{0,3}(`{3,}|~{3,})/;
+const MAX_RICH_MARKDOWN_CHARS = 32_000;
 
 export interface RagMarkdownReference {
   index?: number;
@@ -99,6 +102,9 @@ function CitationLink({
 }) {
   const matchingReferences = references.filter((reference) => indices.includes(reference.index ?? -1));
   const label = `[${indices.join(", ")}]`;
+  if (matchingReferences.length !== indices.length) {
+    return <>{label}</>;
+  }
   const badge = (
     <Box
       component="button"
@@ -179,6 +185,107 @@ function safeUrlTransform(url: string) {
   return url.startsWith(CITATION_TARGET) ? url : defaultUrlTransform(url);
 }
 
+type TableCopyStatus = "idle" | "copied" | "failed";
+
+function tableAsTsv(table: HTMLTableElement) {
+  return Array.from(table.rows)
+    .map((row) => Array.from(row.cells)
+      .map((cell) => (cell.textContent ?? "").replace(/\s+/g, " ").trim())
+      .join("\t"))
+    .join("\n");
+}
+
+function CopyableTable({ children }: { children: ReactNode }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [copyStatus, setCopyStatus] = useState<TableCopyStatus>("idle");
+
+  useEffect(() => {
+    if (copyStatus === "idle") return undefined;
+    const timer = window.setTimeout(() => setCopyStatus("idle"), 1_600);
+    return () => window.clearTimeout(timer);
+  }, [copyStatus]);
+
+  const copyTable = async () => {
+    const table = containerRef.current?.querySelector("table");
+    const text = table ? tableAsTsv(table) : "";
+    if (!text || !navigator.clipboard?.writeText) {
+      setCopyStatus("failed");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyStatus("copied");
+    } catch {
+      setCopyStatus("failed");
+    }
+  };
+
+  const tooltip = copyStatus === "copied"
+    ? "표 복사 완료"
+    : copyStatus === "failed"
+      ? "표를 복사할 수 없습니다"
+      : "표 복사";
+
+  return (
+    <Box
+      ref={containerRef}
+      className="rag-table-container"
+      sx={{ position: "relative", maxWidth: "100%" }}
+    >
+      <Box className="rag-table-scroll" sx={{ maxWidth: "100%", overflowX: "auto" }}>
+        <table>{children}</table>
+      </Box>
+      <Box
+        className="rag-table-copy-zone"
+        sx={{
+          position: "absolute",
+          top: 0,
+          right: 0,
+          width: 44,
+          height: 44,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          "& .rag-table-copy-button": {
+            opacity: 0,
+            pointerEvents: "none",
+          },
+          "&:hover .rag-table-copy-button, &:focus-within .rag-table-copy-button": {
+            opacity: 1,
+            pointerEvents: "auto",
+          },
+        }}
+      >
+        <Tooltip title={tooltip} placement="top" arrow>
+          <IconButton
+            className="rag-table-copy-button"
+            type="button"
+            size="small"
+            aria-label={tooltip}
+            onClick={() => void copyTable()}
+            color={copyStatus === "failed" ? "error" : "default"}
+            sx={{
+              width: 28,
+              height: 28,
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: 1,
+              bgcolor: (theme) => alpha(theme.palette.background.paper, 0.94),
+              boxShadow: 1,
+              transition: "opacity 120ms ease, background-color 120ms ease",
+              "&:hover, &:focus-visible": { bgcolor: "background.paper" },
+            }}
+          >
+            {copyStatus === "copied"
+              ? <CheckOutlined color="success" sx={{ fontSize: 16 }} />
+              : <ContentCopyOutlined sx={{ fontSize: 15 }} />}
+          </IconButton>
+        </Tooltip>
+      </Box>
+    </Box>
+  );
+}
+
 export function RagMarkdownRenderer({ content, references, onCitationClick }: Props) {
   const allowedCitationIndices = new Set(
     references
@@ -188,7 +295,13 @@ export function RagMarkdownRenderer({ content, references, onCitationClick }: Pr
   const components: Components = {
     a: ({ href, children }) => {
       const indices = citationIndices(href);
-      if (indices.length > 0) {
+      const renderedLabel = Array.isArray(children)
+        ? children.join("")
+        : String(children ?? "");
+      const expectedLabel = indices.join(", ");
+      if (indices.length > 0
+          && renderedLabel.replace(/\s+/g, " ").trim() === expectedLabel
+          && indices.every((index) => allowedCitationIndices.has(index))) {
         return (
           <CitationLink
             indices={indices}
@@ -197,13 +310,25 @@ export function RagMarkdownRenderer({ content, references, onCitationClick }: Pr
           />
         );
       }
-      return (
-        <a href={href} target="_blank" rel="noreferrer noopener">
-          {children as ReactNode}
-        </a>
-      );
+      // Model-authored links are not trusted navigation. Source links are
+      // rendered by the bounded reference UI after the server authorizes them.
+      return <>{children as ReactNode}</>;
     },
+    img: ({ alt }) => <>{alt ? `[이미지: ${alt}]` : null}</>,
+    table: ({ children }) => <CopyableTable>{children}</CopyableTable>,
   };
+
+  if (content.length > MAX_RICH_MARKDOWN_CHARS) {
+    return (
+      <Typography
+        data-testid="rag-markdown-plain-fallback"
+        component="div"
+        sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: 14.5, lineHeight: 1.75 }}
+      >
+        {content}
+      </Typography>
+    );
+  }
 
   return (
     <Box
@@ -254,11 +379,32 @@ export function RagMarkdownRenderer({ content, references, onCitationClick }: Pr
         },
         "& pre code": { p: 0, bgcolor: "transparent" },
         "& a": { color: "primary.main", textDecorationColor: "currentColor" },
+        "& .rag-table-container": { my: 1.25 },
+        "& table": {
+          width: "100%",
+          minWidth: 480,
+          borderCollapse: "collapse",
+          fontSize: "0.94em",
+        },
+        "& th, & td": {
+          px: 1.25,
+          py: 0.8,
+          border: "1px solid",
+          borderColor: "divider",
+          textAlign: "left",
+          verticalAlign: "top",
+        },
+        "& th": {
+          bgcolor: (theme) => alpha(theme.palette.primary.main, 0.07),
+          fontWeight: 800,
+          whiteSpace: "nowrap",
+        },
+        "& th:last-of-type": { pr: 5 },
       }}
     >
       <ReactMarkdown
         skipHtml
-        remarkPlugins={[remarkMath]}
+        remarkPlugins={[remarkMath, remarkGfm]}
         rehypePlugins={[rehypeSanitize, rehypeKatex]}
         urlTransform={safeUrlTransform}
         components={components}

--- a/src/react/pages/ai/components/RagSourceScopeSelector.test.tsx
+++ b/src/react/pages/ai/components/RagSourceScopeSelector.test.tsx
@@ -46,4 +46,31 @@ describe("RagSourceScopeSelector", () => {
       screen.getByText(/서버에 공식 외부 자료 공급자가 설정되지 않아 첨부 문서만 사용할 수 있습니다/)
     ).toBeTruthy();
   });
+
+  it("describes AUTO as an explicit conditional external lookup", () => {
+    render(
+      <RagSourceScopeSelector
+        capabilities={{
+          defaultScope: "DOCUMENT_ONLY",
+          maximumScope: "DOCUMENT_AND_OFFICIAL_EXTERNAL",
+          clientSelectionEnabled: true,
+          externalProviderAvailable: true,
+          policyVersion: "source-test",
+          availableScopes: ["DOCUMENT_ONLY", "DOCUMENT_AND_OFFICIAL_EXTERNAL"],
+        }}
+        externalRetrievalCapabilities={{
+          defaultMode: "OFF",
+          maximumMode: "AUTO",
+          clientSelectionEnabled: true,
+          policyVersion: "external-test",
+          availableModes: ["OFF", "AUTO"],
+        }}
+        value="DOCUMENT_AND_OFFICIAL_EXTERNAL"
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/필요 시 외부 자료 자동 검색/)).toBeTruthy();
+    expect(screen.getByText(/내부 근거 부족 시에만 검증된 공식 외부 자료를 검색/)).toBeTruthy();
+  });
 });

--- a/src/react/pages/ai/components/RagSourceScopeSelector.tsx
+++ b/src/react/pages/ai/components/RagSourceScopeSelector.tsx
@@ -3,11 +3,13 @@ import { Alert, Box, Button, Menu, MenuItem, Stack, TextField, Typography } from
 import { CheckOutlined, ExpandMoreOutlined, PublicOutlined } from "@mui/icons-material";
 import type {
   RagSourcePolicyCapabilitiesDto,
+  RagExternalRetrievalCapabilitiesDto,
   RagSourceScope,
 } from "@/types/studio/ai";
 
 interface Props {
   capabilities: RagSourcePolicyCapabilitiesDto | null;
+  externalRetrievalCapabilities?: RagExternalRetrievalCapabilitiesDto | null;
   value: RagSourceScope | null;
   onChange: (scope: RagSourceScope) => void;
   disabled?: boolean;
@@ -17,24 +19,30 @@ interface Props {
 
 const labels: Record<RagSourceScope, string> = {
   DOCUMENT_ONLY: "첨부 문서만",
-  DOCUMENT_AND_OFFICIAL_EXTERNAL: "공식 외부 자료도 참고",
+  DOCUMENT_AND_OFFICIAL_EXTERNAL: "필요 시 외부 자료 자동 검색",
 };
 
 const descriptions: Record<RagSourceScope, string> = {
   DOCUMENT_ONLY: "첨부 문서에서 확인된 근거만 검색합니다.",
   DOCUMENT_AND_OFFICIAL_EXTERNAL:
-    "문서 근거와 검증된 공식 외부 자료를 분리하여 검색하고 비교합니다.",
+    "현재성·비교 요청 또는 내부 근거 부족 시에만 검증된 공식 외부 자료를 검색합니다.",
 };
 
 export function RagSourceScopeSelector({
   capabilities,
+  externalRetrievalCapabilities,
   value,
   onChange,
   disabled,
   hideHelperText,
   variant = "standard",
 }: Props) {
-  const scopes = capabilities?.availableScopes ?? [];
+  const autoAvailable = externalRetrievalCapabilities === undefined
+    ? true
+    : externalRetrievalCapabilities?.availableModes.includes("AUTO") ?? false;
+  const scopes = (capabilities?.availableScopes ?? []).filter(
+    (scope) => scope !== "DOCUMENT_AND_OFFICIAL_EXTERNAL" || autoAvailable
+  );
   const selected =
     capabilities && !capabilities.clientSelectionEnabled
       ? capabilities.defaultScope
@@ -43,6 +51,8 @@ export function RagSourceScopeSelector({
   const unavailableReason =
     capabilities && !capabilities.externalProviderAvailable
       ? "서버에 공식 외부 자료 공급자가 설정되지 않아 첨부 문서만 사용할 수 있습니다."
+      : capabilities?.externalProviderAvailable && !autoAvailable
+        ? "서버 정책에서 필요 시 외부 자료 자동 검색을 허용하지 않습니다."
       : null;
 
   if (variant === "compact-pill") {

--- a/src/react/pages/files/FileDetailDialog.tsx
+++ b/src/react/pages/files/FileDetailDialog.tsx
@@ -69,6 +69,10 @@ import type {
   ChatRagRequestDto,
   RagAnswerMode,
   RagAnswerPolicyCapabilitiesDto,
+  RagAnswerPresentationCapabilitiesDto,
+  RagAnswerPresentationPreference,
+  RagExternalRetrievalCapabilitiesDto,
+  RagExternalRetrievalMode,
   RagSourcePolicyCapabilitiesDto,
   RagSourceScope,
   IndexedWebCapabilitiesDto,
@@ -104,6 +108,7 @@ import {
 import { AiProviderSelect } from "@/react/components/ai/AiProviderSelect";
 import { AssistantMessageBubble } from "../ai/components/AssistantMessageBubble";
 import { RagAnswerModeSelector } from "../ai/components/RagAnswerModeSelector";
+import { RagAnswerPresentationSelector } from "../ai/components/RagAnswerPresentationSelector";
 import { RagSourceScopeSelector } from "../ai/components/RagSourceScopeSelector";
 import { RagEvidenceSourceDrawer } from "../ai/components/RagEvidenceSourceDrawer";
 import { RagEvidenceSourceSummary } from "../ai/components/RagEvidenceSourceSummary";
@@ -720,8 +725,16 @@ export function FileDetailDialog({ open, attachmentId, onClose, workspaceId }: P
   const [qaError, setQaError] = useState<string | null>(null);
   const [qaAnswerPolicy, setQaAnswerPolicy] = useState<RagAnswerPolicyCapabilitiesDto | null>(null);
   const [qaAnswerMode, setQaAnswerMode] = useState<RagAnswerMode>("STRICT_GROUNDED");
+  const [qaAnswerPresentation, setQaAnswerPresentation] =
+    useState<RagAnswerPresentationCapabilitiesDto | null>(null);
+  const [qaPresentationPreference, setQaPresentationPreference] =
+    useState<RagAnswerPresentationPreference>("AUTO");
   const [qaSourcePolicy, setQaSourcePolicy] = useState<RagSourcePolicyCapabilitiesDto | null>(null);
   const [qaSourceScope, setQaSourceScope] = useState<RagSourceScope>("DOCUMENT_ONLY");
+  const [qaExternalRetrieval, setQaExternalRetrieval] =
+    useState<RagExternalRetrievalCapabilitiesDto | null>(null);
+  const [qaExternalRetrievalMode, setQaExternalRetrievalMode] =
+    useState<RagExternalRetrievalMode>("OFF");
   const [qaIndexedWebCapabilities, setQaIndexedWebCapabilities] =
     useState<IndexedWebCapabilitiesDto | null>(null);
   const [qaIndexedWebCapabilitiesLoading, setQaIndexedWebCapabilitiesLoading] = useState(false);
@@ -810,8 +823,12 @@ export function FileDetailDialog({ open, attachmentId, onClose, workspaceId }: P
       setQaIndexedWebCapabilitiesLoading(true);
       const capabilities = await reactAiApi.fetchRagCapabilities();
       setQaAnswerPolicy(capabilities.answerPolicy);
+      setQaAnswerPresentation(capabilities.answerPresentation);
+      setQaPresentationPreference(capabilities.answerPresentation?.defaultPreference ?? "AUTO");
       setQaSourcePolicy(capabilities.sourcePolicy);
       setQaSourceScope(capabilities.sourcePolicy.defaultScope);
+      setQaExternalRetrieval(capabilities.externalRetrieval ?? null);
+      setQaExternalRetrievalMode(capabilities.externalRetrieval?.defaultMode ?? "OFF");
       setQaIndexedWebCapabilities(capabilities.indexedWeb);
       setQaIndexedWebCapabilitiesError(null);
     } catch (err) {
@@ -2825,7 +2842,9 @@ export function FileDetailDialog({ open, attachmentId, onClose, workspaceId }: P
         objectId: String(file.attachmentId),
         topK: 5,
         answerMode: qaAnswerMode,
+        presentation: { preference: qaPresentationPreference },
         sourceScope: qaSourceScope,
+        externalRetrievalMode: qaExternalRetrievalMode,
         indexedWebSources: qaIndexedWebSources.length > 0 ? toIndexedWebSourcePayload(qaIndexedWebSources) : undefined,
       };
 
@@ -4602,12 +4621,8 @@ export function FileDetailDialog({ open, attachmentId, onClose, workspaceId }: P
                           key={msg.id}
                           message={msg}
                           onCopy={(content) => void navigator.clipboard.writeText(content)}
-                          onEdit={(id, content) => {
+                          onEdit={(_id, content) => {
                             setQaInput(content);
-                            setQaMessages((prev) => {
-                              const idx = prev.findIndex((m) => m.id === id);
-                              return idx >= 0 ? prev.slice(0, idx) : prev;
-                            });
                           }}
                         />
                       );
@@ -4785,8 +4800,22 @@ export function FileDetailDialog({ open, attachmentId, onClose, workspaceId }: P
                           setQaError(null);
                         }}
                       />
+                      <RagAnswerPresentationSelector
+                        capabilities={qaAnswerPresentation}
+                        value={qaPresentationPreference}
+                        disabled={qaSending}
+                        hideHelperText
+                        variant="compact-pill"
+                        onChange={(preference) => {
+                          if (preference === qaPresentationPreference) return;
+                          setQaPresentationPreference(preference);
+                          setQaMessages([]);
+                          setQaError(null);
+                        }}
+                      />
                       <RagSourceScopeSelector
                         capabilities={qaSourcePolicy}
+                        externalRetrievalCapabilities={qaExternalRetrieval}
                         value={qaSourceScope}
                         disabled={qaSending}
                         hideHelperText
@@ -4794,6 +4823,10 @@ export function FileDetailDialog({ open, attachmentId, onClose, workspaceId }: P
                         onChange={(scope) => {
                           if (scope === qaSourceScope) return;
                           setQaSourceScope(scope);
+                          setQaExternalRetrievalMode(
+                            scope === "DOCUMENT_AND_OFFICIAL_EXTERNAL" ? "AUTO" : "OFF"
+                          );
+                          setQaMessages([]);
                           setQaError(null);
                         }}
                       />

--- a/src/types/studio/ai.ts
+++ b/src/types/studio/ai.ts
@@ -68,10 +68,62 @@ export interface ChatResponseMetadataDto {
   canonicalContent?: string;
   answerPolicy?: ResolvedRagAnswerPolicyDto;
   sourcePolicy?: ResolvedRagSourcePolicyDto;
+  externalRetrieval?: ResolvedRagExternalRetrievalDto;
   externalSourceReview?: ExternalSourceReviewDto;
   answerPolicyValidationStatus?: string;
   ragAnswerOutcome?: RagAnswerOutcomeDto;
+  answerPresentation?: ResolvedRagAnswerPresentationDto;
+  answerBlocks?: RagAnswerBlocksDto;
   [key: string]: unknown;
+}
+
+export interface ResolvedRagAnswerPresentationDto {
+  requestedPreference?: RagAnswerPresentationPreference | null;
+  effectivePreference: RagAnswerPresentationPreference;
+  source: "SERVER_DEFAULT" | "REQUEST";
+  clamped: boolean;
+  reasonCode: string;
+  policyVersion: string;
+  generationStrategy: "MARKDOWN" | string;
+  allowedBlockTypes: string[];
+  selectedBlockTypes: string[];
+}
+
+export interface RagAnswerBlocksDto {
+  schemaVersion: string;
+  canonicalContentFingerprint?: string;
+  blocks: RagAnswerBlockDto[];
+}
+
+export type RagAnswerBlockDto =
+  | RagAnswerTableBlockDto
+  | RagAnswerChartBlockDto
+  | RagAnswerSourceImageBlockDto;
+
+export interface RagAnswerTableBlockDto {
+  blockId: string;
+  type: "TABLE";
+  columns: string[];
+  rows: Array<{ cells: string[]; citationIndexes: number[] }>;
+}
+
+export interface RagAnswerChartBlockDto {
+  blockId: string;
+  type: "CHART";
+  chartType: "BAR";
+  title: string;
+  unit: string;
+  points: Array<{ label: string; value: number; citationIndexes: number[] }>;
+}
+
+export interface RagAnswerSourceImageBlockDto {
+  blockId: string;
+  type: "SOURCE_IMAGE";
+  mediaType: "image/png";
+  src: string;
+  alt: string;
+  page: number;
+  citationIndexes: number[];
 }
 
 export type RagAnswerMode = "STRICT_GROUNDED" | "GROUNDED_INFERENCE";
@@ -118,10 +170,55 @@ export interface RagSourcePolicyCapabilitiesDto {
   availableScopes: RagSourceScope[];
 }
 
+export type RagExternalRetrievalMode = "OFF" | "AUTO";
+
+export interface ResolvedRagExternalRetrievalDto {
+  requestedMode?: RagExternalRetrievalMode | null;
+  effectiveMode: RagExternalRetrievalMode;
+  source: "SERVER_DEFAULT" | "REQUEST";
+  clamped: boolean;
+  reasonCode: string;
+  policyVersion: string;
+  searched: boolean;
+  decisionReasonCode: string;
+  internalEvidenceCount: number;
+  status: string;
+  retrievalReasonCode: string;
+  evidenceCount: number;
+}
+
+export interface RagExternalRetrievalCapabilitiesDto {
+  defaultMode: RagExternalRetrievalMode;
+  maximumMode: RagExternalRetrievalMode;
+  clientSelectionEnabled: boolean;
+  policyVersion: string;
+  availableModes: RagExternalRetrievalMode[];
+}
+
+export type RagAnswerPresentationPreference =
+  | "AUTO"
+  | "TEXT_FOCUSED"
+  | "VISUAL_PREFERRED";
+
+export interface RagAnswerPresentationRequestDto {
+  preference: RagAnswerPresentationPreference;
+}
+
+export interface RagAnswerPresentationCapabilitiesDto {
+  enabled: boolean;
+  defaultPreference: RagAnswerPresentationPreference;
+  clientSelectionEnabled: boolean;
+  policyVersion: string;
+  availablePreferences: RagAnswerPresentationPreference[];
+  allowedBlockTypes: string[];
+}
+
 export interface RagChatCapabilitiesDto {
   answerPolicy: RagAnswerPolicyCapabilitiesDto;
   sourcePolicy: RagSourcePolicyCapabilitiesDto;
   indexedWeb: IndexedWebCapabilitiesDto;
+  answerPresentation: RagAnswerPresentationCapabilitiesDto;
+  externalRetrieval?: RagExternalRetrievalCapabilitiesDto;
 }
 
 export interface IndexedWebCapabilitiesDto {
@@ -193,6 +290,7 @@ export interface WebKnowledgeSourceDto {
   retrievedAt?: string | null;
   contentPreview?: string | null;
   errorCode?: string | null;
+  crawlPolicy?: WebKnowledgeSitePreviewEffectivePolicy | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -402,12 +500,14 @@ export interface ChatRagRequestDto {
   };
   answerMode?: RagAnswerMode;
   sourceScope?: RagSourceScope;
+  externalRetrievalMode?: RagExternalRetrievalMode;
   externalSourceOptions?: {
     jurisdiction?: string;
     asOfDate?: string;
     language?: string;
   };
   indexedWebSources?: IndexedWebSourceRefDto[];
+  presentation?: RagAnswerPresentationRequestDto;
 }
 
 export interface TokenUsageDto {


### PR DESCRIPTION
## Why

- 서버의 `answerPresentation` 및 구조화 답변 계약을 RAG 채팅과 첨부 상세 Q&A에서 활용합니다.
- SITE 웹 자료 수정 시 저장된 `crawlPolicy`가 capabilities 기본값으로 덮어써지는 문제를 방지합니다.

## What

- RAG 채팅과 첨부 상세 Q&A에 `자동 구성 | 텍스트 중심 | 시각 자료 우선` 선택을 추가했습니다.
- canonical 답변의 GFM 표와 표 복사 기능을 추가했습니다.
- 서버가 검증한 bounded 차트와 canonical fingerprint가 일치하는 `SOURCE_IMAGE`만 표시합니다.
- 웹 소스 수정 화면을 저장된 `crawlPolicy`로 초기화하도록 변경했습니다.
- 관련 API 타입, 단위 테스트, `CHANGELOG.md`, production build 결과를 갱신했습니다.

## Related Issues

- Closes #114

## Validation

- Command: `npm test -- --run`
- Result: 10 files, 44 tests passed
- Command: `npm run typecheck`
- Result: passed
- Command: `npm run build`
- Result: passed. 기존 대형 chunk 경고는 유지됩니다.
- Command: `git diff --check`
- Result: passed

## Risk / Rollback

- Risk: 서버의 구조화 답변 payload 또는 fingerprint 계약과 프런트 타입이 불일치하면 시각 자료가 표시되지 않을 수 있습니다. 이 경우 canonical 텍스트 답변은 계속 표시됩니다.
- Rollback: commit `c4e395e`를 revert하여 기존 텍스트 중심 표시와 웹 소스 초기화 동작으로 되돌릴 수 있습니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 해당 없음
- Main author validation: 전체 Vitest, typecheck, production build, staged diff 검증을 수행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included
